### PR TITLE
Add automated dependency updates for backups

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "dependencyDashboard": true,
+  "groupName": "all dependencies",
+  "groupSlug": "all",
+  "packageRules": [
+    {
+      "groupName": "all dependencies",
+      "groupSlug": "all",
+      "matchPackagePatterns": ["*"]
+    }
+  ],
+  "labels": ["dependencies"]
+}

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -1,0 +1,25 @@
+name: Update dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '7 0 * * 1'
+
+concurrency:
+  group: any
+  cancel-in-progress: true
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write # Requires also "Allow GitHub Actions to create and approve pull requests" to be enabled in the repository settings
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+      - env:
+          LOG_LEVEL: debug
+        run: npx renovate --token ${{ secrets.GITHUB_TOKEN }} --platform github --autodiscover


### PR DESCRIPTION
Configure Renovate bot to automatically manage dependency updates for both npm and Maven ecosystems. All updates are grouped into a single PR with the "dependencies" label for easier review and management.

Inspired by the configuration from postgres-azure-backup repository.