### PR TITLE
Configure Azure Key Vault secrets loading for production profile

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/config/AzureKeyVaultEnvironmentPostProcessor.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/config/AzureKeyVaultEnvironmentPostProcessor.java
@@ -15,11 +15,12 @@ import com.azure.security.keyvault.secrets.SecretClientBuilder;
 import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
 
 @Order(Ordered.HIGHEST_PRECEDENCE)
-public class LocalEnvironmentPostProcessor implements EnvironmentPostProcessor {
+public class AzureKeyVaultEnvironmentPostProcessor implements EnvironmentPostProcessor {
 
   @Override
   public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
-    if (!"local".equals(environment.getProperty("spring.profiles.active"))) {
+    String activeProfile = environment.getProperty("spring.profiles.active");
+    if ("test".equals(activeProfile)) {
       return;
     }
 

--- a/server/src/main/resources/META-INF/spring.factories
+++ b/server/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,1 @@
-org.springframework.boot.env.EnvironmentPostProcessor=io.github.mucsi96.learnlanguage.config.LocalEnvironmentPostProcessor
+org.springframework.boot.env.EnvironmentPostProcessor=io.github.mucsi96.learnlanguage.config.AzureKeyVaultEnvironmentPostProcessor

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -1,0 +1,5 @@
+spring:
+  jpa:
+    properties:
+      hibernate:
+        show-sql: false


### PR DESCRIPTION
- Rename LocalEnvironmentPostProcessor to AzureKeyVaultEnvironmentPostProcessor
- Update logic to load secrets from Azure Key Vault for both local and prod profiles
- Exclude test profile to continue using environment variables for testing
- Add application-prod.yml configuration file
- Update spring.factories to reference new class name

This ensures all secrets are pulled from Azure Key Vault at startup for production,
eliminating the need to store secrets in Kubernetes resources.