### PR TITLE
Add AI-powered vocabulary card validation feature

### DIFF
--- a/client/src/app/card-creation-strategies/vocabulary-card-creation.strategy.ts
+++ b/client/src/app/card-creation-strategies/vocabulary-card-creation.strategy.ts
@@ -145,7 +145,8 @@ export class VocabularyCardCreationStrategy implements CardCreationStrategy {
           ]),
           isSelected: index === 0, // First example is selected by default
           images: exampleImages[index] || []
-        }))
+        })),
+        pdfText: word.pdfText
       };
 
     } catch (error) {

--- a/client/src/app/parser/edit-card/edit-card.component.html
+++ b/client/src/app/parser/edit-card/edit-card.component.html
@@ -27,6 +27,14 @@
           Mark as reviewed
         </button>
       }
+      <button
+        type="button"
+        mat-flat-button
+        (click)="validateCard()"
+        [disabled]="isValidating()"
+      >
+        {{ isValidating() ? 'Validating...' : 'AI Validate' }}
+      </button>
       <button type="button" mat-flat-button (click)="saveCard()">
         Update
       </button>

--- a/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.css
+++ b/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.css
@@ -139,3 +139,48 @@
   align-items: center;
   justify-content: center;
 }
+
+.validation-info {
+  background-color: rgba(33, 150, 243, 0.1);
+  border-left: 4px solid #2196f3;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  border-radius: 4px;
+}
+
+.validation-info h3 {
+  margin: 0 0 0.75rem 0;
+  color: #2196f3;
+  font-size: 1rem;
+}
+
+.validation-item {
+  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 4px;
+}
+
+.validation-item:last-child {
+  margin-bottom: 0;
+}
+
+.validation-mismatch {
+  background-color: rgba(255, 152, 0, 0.1);
+  border-left: 3px solid #ff9800;
+}
+
+.current-value {
+  color: #ff9800;
+  font-style: italic;
+  margin-left: 0.5rem;
+}
+
+.suggested-forms {
+  margin: 0.5rem 0 0 0;
+  padding-left: 1.5rem;
+}
+
+.suggested-forms li {
+  margin-bottom: 0.25rem;
+}

--- a/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.html
+++ b/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.html
@@ -1,3 +1,31 @@
+@if (card()?.data.validation; as validation) {
+<div class="validation-info">
+  <h3>AI Validation Results</h3>
+  @if (validation.extractedText) {
+  <div class="validation-item">
+    <strong>Extracted from PDF:</strong> {{ validation.extractedText }}
+  </div>
+  }
+  @if (validation.suggestedGender && wordType() === 'NOUN') {
+  <div class="validation-item" [class.validation-mismatch]="validation.suggestedGender !== gender()">
+    <strong>Suggested Gender:</strong> {{ validation.suggestedGender }}
+    @if (validation.suggestedGender !== gender()) {
+    <span class="current-value">(Current: {{ gender() || 'not set' }})</span>
+    }
+  </div>
+  }
+  @if (validation.suggestedForms && validation.suggestedForms.length > 0) {
+  <div class="validation-item">
+    <strong>Suggested Forms:</strong>
+    <ul class="suggested-forms">
+      @for (form of validation.suggestedForms; track $index) {
+      <li>{{ form }}</li>
+      }
+    </ul>
+  </div>
+  }
+</div>
+}
 <div class="word">
   <mat-form-field class="field">
     <mat-label>Type</mat-label>

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -30,11 +30,18 @@ export type Word = {
   forms: string[];
   examples: string[];
   exists?: boolean;
+  pdfText?: string;
 };
 
 export type ExampleImage = {
   id: string;
   isFavorite?: boolean;
+};
+
+export type ValidationData = {
+  suggestedGender?: string;
+  suggestedForms?: string[];
+  extractedText?: string;
 };
 
 export type CardData = {
@@ -49,6 +56,8 @@ export type CardData = {
   })[];
   audio?: AudioData[];
   audioVoice?: string;
+  pdfText?: string;
+  validation?: ValidationData;
 };
 
 export type Card = {

--- a/client/src/app/study/learn-vocabulary-card/learn-vocabulary-card.component.css
+++ b/client/src/app/study/learn-vocabulary-card/learn-vocabulary-card.component.css
@@ -92,6 +92,25 @@ h2 {
   line-height: 1.4;
 }
 
+.validation-hints {
+  visibility: hidden;
+}
+
+:host-context(.revealed) .validation-hints {
+  visibility: visible;
+}
+
+.validation-hint {
+  text-align: center;
+  margin-bottom: 0.5rem;
+}
+
+.validation-hint small {
+  color: var(--mat-sys-primary);
+  font-size: 0.9rem;
+  opacity: 0.8;
+}
+
 .example {
   padding: 1rem;
   padding-top: 2rem;

--- a/client/src/app/study/learn-vocabulary-card/learn-vocabulary-card.component.html
+++ b/client/src/app/study/learn-vocabulary-card/learn-vocabulary-card.component.html
@@ -40,6 +40,22 @@
       <p class="centered-text">{{ forms()?.join(", ") }}</p>
     </div>
     }
+
+    @if (card()?.value()?.data?.validation; as validation) {
+    <div class="validation-hints">
+      @if (validation.suggestedForms && validation.suggestedForms.length > 0) {
+      <div class="validation-hint">
+        <small>📚 PDF: {{ validation.suggestedForms.join(", ") }}</small>
+      </div>
+      }
+      @if (validation.extractedText) {
+      <div class="validation-hint">
+        <small>📖 Original: {{ validation.extractedText }}</small>
+      </div>
+      }
+    </div>
+    }
+
     <div class="example">
       <p class="centered-text">{{ example() }}</p>
     </div>

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardData.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardData.java
@@ -26,4 +26,10 @@ public class CardData {
 
     @JsonInclude(Include.NON_NULL)
     private List<AudioData> audio;
+
+    @JsonInclude(Include.NON_NULL)
+    private String pdfText;
+
+    @JsonInclude(Include.NON_NULL)
+    private ValidationData validation;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ValidationData.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ValidationData.java
@@ -1,0 +1,18 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ValidationData {
+    private String suggestedGender;
+    private List<String> suggestedForms;
+    private String extractedText;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/WordResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/WordResponse.java
@@ -17,4 +17,5 @@ public class WordResponse {
     private String word;
     private List<String> forms;
     private List<String> examples;
+    private String pdfText;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/AreaWordsService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/AreaWordsService.java
@@ -73,6 +73,7 @@ public class AreaWordsService {
 
     return result.wordList.stream().map(word -> {
       word.setId(wordIdService.generateWordId(word.getWord()));
+      word.setPdfText(word.getWord());
       return word;
     }).toList();
   }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardValidationService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardValidationService.java
@@ -1,0 +1,111 @@
+package io.github.mucsi96.learnlanguage.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.openai.client.OpenAIClient;
+import com.openai.models.ChatModel;
+import com.openai.models.chat.completions.ChatCompletionCreateParams;
+
+import io.github.mucsi96.learnlanguage.model.ValidationData;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CardValidationService {
+
+  static record ValidationResult(String gender, List<String> forms, String extractedWord) {
+  }
+
+  private final OpenAIClient openAIClient;
+
+  public ValidationData validateCard(String pdfText, String wordType) {
+    var systemPrompt = buildSystemPrompt(wordType);
+
+    var createParams = ChatCompletionCreateParams.builder()
+        .model(ChatModel.GPT_4_1)
+        .addSystemMessage(systemPrompt)
+        .addUserMessage("The text from PDF is: %s".formatted(pdfText))
+        .responseFormat(ValidationResult.class)
+        .build();
+
+    var result = openAIClient.chat().completions().create(createParams).choices().stream()
+        .flatMap(choice -> choice.message().content().stream()).findFirst()
+        .orElseThrow(() -> new RuntimeException("No content returned from OpenAI API"));
+
+    return ValidationData.builder()
+        .suggestedGender(result.gender())
+        .suggestedForms(result.forms())
+        .extractedText(result.extractedWord())
+        .build();
+  }
+
+  private String buildSystemPrompt(String wordType) {
+    if ("NOUN".equals(wordType)) {
+      return """
+          You are a German language expert.
+          Your task is to analyze the given text from a PDF and extract grammatical information about a German noun.
+
+          Extract:
+          1. The article (der, die, das) - return the grammatical gender: MASCULINE, FEMININE, or NEUTER
+          2. The plural form (if present in the text)
+          3. The base noun without article
+
+          Return the results in JSON format:
+          {
+              "gender": "MASCULINE|FEMININE|NEUTER",
+              "forms": ["plural form"],
+              "extractedWord": "the noun without article"
+          }
+
+          If no plural form is present in the text, return an empty array for forms.
+          If no article is present, use null for gender.
+
+          Example input: "der Tisch, die Tische"
+          Example output:
+          {
+              "gender": "MASCULINE",
+              "forms": ["die Tische"],
+              "extractedWord": "Tisch"
+          }
+          """;
+    } else if ("VERB".equals(wordType)) {
+      return """
+          You are a German language expert.
+          Your task is to analyze the given text from a PDF and extract grammatical information about a German verb.
+
+          Extract:
+          1. The base verb (infinitive form)
+          2. All conjugated forms present in the text (Präsens, Präteritum, Perfekt, etc.)
+
+          Return the results in JSON format:
+          {
+              "gender": null,
+              "forms": ["conjugated form 1", "conjugated form 2", ...],
+              "extractedWord": "infinitive form"
+          }
+
+          Example input: "gehen, ging, gegangen"
+          Example output:
+          {
+              "gender": null,
+              "forms": ["ging", "gegangen"],
+              "extractedWord": "gehen"
+          }
+          """;
+    } else {
+      return """
+          You are a German language expert.
+          Your task is to analyze the given text from a PDF and extract the word.
+
+          Return the results in JSON format:
+          {
+              "gender": null,
+              "forms": [],
+              "extractedWord": "the word from the text"
+          }
+          """;
+    }
+  }
+}


### PR DESCRIPTION
Implement smart AI-based validation for vocabulary cards to compare extracted
PDF text with card data. This helps identify discrepancies in articles, plural
forms, and verb conjugations.

Backend changes:
- Add CardValidationService to extract grammatical info from PDF text using GPT-4.1
- Add ValidationData model to store AI suggestions (gender, forms, extracted text)
- Update CardData model to include pdfText and validation fields
- Add POST /api/card/{cardId}/validate endpoint in CardController
- Capture original PDF text in WordResponse during extraction
- Populate pdfText field when words are extracted from PDF

Frontend changes:
- Add validation trigger in edit-card component with "AI Validate" button
- Display validation results in edit-vocabulary-card with visual indicators
- Show mismatches between suggested and current values with highlighting
- Add validation hints in learn-vocabulary-card during study/review
- Update CardData and Word types to include pdfText and validation fields
- Include pdfText in card creation workflow

The validation feature helps ensure accuracy by:
- Extracting articles, plural forms, or verb forms from the original PDF text
- Comparing AI suggestions with current card data
- Highlighting discrepancies during card editing and review
- Providing contextual information during study sessions