### PR TITLE
Add multi-region selection and grouped AI extraction

### DIFF
--- a/client/src/app/parser/page/page.component.css
+++ b/client/src/app/parser/page/page.component.css
@@ -34,3 +34,21 @@
   transform: translate(-50%, -50%);
   z-index: 10;
 }
+
+.grouped-word {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  background: white;
+  padding: 1rem;
+  border: 2px solid #3f51b5;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  max-width: 400px;
+  z-index: 5;
+}
+
+.grouped-word + .grouped-word {
+  top: auto;
+  margin-top: 1rem;
+}

--- a/client/src/app/parser/page/page.component.html
+++ b/client/src/app/parser/page/page.component.html
@@ -31,6 +31,26 @@
     aria-label="Next page"
     ><mat-icon>arrow_forward_ios</mat-icon></a
   >
+  <mat-button-toggle-group
+    [value]="selectionMode()"
+    (change)="toggleSelectionMode()"
+  >
+    <mat-button-toggle value="immediate">Immediate</mat-button-toggle>
+    <mat-button-toggle value="grouped">Grouped</mat-button-toggle>
+  </mat-button-toggle-group>
+  @if (selectionMode() === 'grouped') {
+    <mat-chip-set>
+      <mat-chip>{{ regionGroup().length }} regions</mat-chip>
+    </mat-chip-set>
+    @if (regionGroup().length > 0) {
+      <button mat-raised-button color="primary" (click)="processRegionGroup()">
+        Process Group
+      </button>
+      <button mat-button (click)="clearRegionGroup()">
+        Clear Group
+      </button>
+    }
+  }
 </div>
 } @if (pageLoading()) {
 <mat-spinner class="page-loading" />
@@ -41,7 +61,7 @@
   (selectionBox)="onSelection($event)"
   [style.height]="heightStyle"
 >
-  @if (selectionRegionsLoading()) {
+  @if (selectionRegionsLoading() || groupedWordsLoading()) {
   <mat-spinner class="area-loading"></mat-spinner>
   } @for (span of spans(); track $index) {
   <app-span
@@ -56,6 +76,19 @@
     [exists]="span.exists"
     [selectionRegions]="selectionRegions()"
   ></app-span>
+  }
+  @if (groupedWordsResource()?.value(); as groupedWords) {
+    @for (word of groupedWords.words; track word.id) {
+      <div class="grouped-word">
+        <strong>{{ word.word }}</strong>
+        @if (word.forms.length > 0) {
+          <div>Forms: {{ word.forms.join(', ') }}</div>
+        }
+        @if (word.examples.length > 0) {
+          <div>Examples: {{ word.examples.join(', ') }}</div>
+        }
+      </div>
+    }
   }
 </section>
 

--- a/client/src/app/parser/page/page.component.ts
+++ b/client/src/app/parser/page/page.component.ts
@@ -20,6 +20,8 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatFormFieldModule, MatLabel } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { ScrollPositionService } from '../../scroll-position.service';
 import { BulkCardCreationFabComponent } from '../../bulk-card-creation-fab/bulk-card-creation-fab.component';
 
@@ -37,6 +39,8 @@ import { BulkCardCreationFabComponent } from '../../bulk-card-creation-fab/bulk-
     MatFormFieldModule,
     MatLabel,
     MatInputModule,
+    MatChipsModule,
+    MatButtonToggleModule,
     BulkCardCreationFabComponent
   ],
   templateUrl: './page.component.html',
@@ -65,6 +69,12 @@ export class PageComponent implements AfterViewInit, OnDestroy {
   readonly pageLoading = this.pageService.page.isLoading;
   readonly selectionRegionsLoading = computed(() =>
     this.pageService.selectionRegions().some((w) => w.isLoading())
+  );
+  readonly selectionMode = this.pageService.selectionMode;
+  readonly regionGroup = this.pageService.regionGroup;
+  readonly groupedWordsResource = this.pageService.groupedWordsResource;
+  readonly groupedWordsLoading = computed(() =>
+    this.groupedWordsResource()?.isLoading() ?? false
   );
   private resizeObserver: ResizeObserver | undefined;
   private readonly scrollPositionService = inject(ScrollPositionService);
@@ -132,5 +142,17 @@ export class PageComponent implements AfterViewInit, OnDestroy {
     const width = pageWidth * event.width / parentWidth;
     const height = pageWidth * event.height / parentWidth;
     this.pageService.addSelectedRectangle({ x, y, width, height });
+  }
+
+  toggleSelectionMode() {
+    this.pageService.toggleSelectionMode();
+  }
+
+  processRegionGroup() {
+    this.pageService.processRegionGroup();
+  }
+
+  clearRegionGroup() {
+    this.pageService.clearRegionGroup();
   }
 }

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -103,6 +103,18 @@ export type WordList = {
   height: number;
 };
 
+export type Region = {
+  pageNumber: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type RegionGroup = {
+  regions: Region[];
+};
+
 export type Translation = {
   translation?: string;
   examples?: (string | undefined)[];

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/MultiRegionRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/MultiRegionRequest.java
@@ -1,0 +1,16 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MultiRegionRequest {
+    private List<RegionRequest> regions;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/RegionRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/RegionRequest.java
@@ -1,0 +1,18 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegionRequest {
+    private int pageNumber;
+    private double x;
+    private double y;
+    private double width;
+    private double height;
+}


### PR DESCRIPTION
Implemented a new grouped selection mode that allows users to select multiple
regions across different pages or columns and combine them into a single AI
extraction call. This addresses the limitation where text split across page
columns or pages couldn't be processed together.

Backend changes:
- Created RegionRequest and MultiRegionRequest models for multi-region support
- Added POST /api/source/{sourceId}/words/multi-region endpoint
- Implemented DocumentProcessorService.getCombinedRegions() to stitch multiple
  regions from different pages into a single image

Frontend changes:
- Added selection mode toggle (Immediate vs Grouped) in page navigation
- Updated PageService with regionGroup signal and grouped extraction logic
- Added UI controls to show region count and process/clear grouped selections
- Updated types to support Region and RegionGroup structures
- Modified page component to display grouped extraction results

Users can now:
1. Toggle to "Grouped" mode
2. Select multiple regions across pages
3. Click "Process Group" to extract words from combined regions in one AI call
4. See all extracted words displayed together