### PR TITLE
Replace GPT with Gemini 3 Pro model

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/AreaWordsService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/AreaWordsService.java
@@ -1,16 +1,18 @@
 package io.github.mucsi96.learnlanguage.service;
 
-import java.util.Base64;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
 
-import com.openai.client.OpenAIClient;
-import com.openai.models.ChatModel;
-import com.openai.models.chat.completions.ChatCompletionContentPart;
-import com.openai.models.chat.completions.ChatCompletionContentPartImage;
-import com.openai.models.chat.completions.ChatCompletionContentPartText;
-import com.openai.models.chat.completions.ChatCompletionCreateParams;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.genai.Client;
+import com.google.genai.types.Content;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.Part;
+import com.google.genai.types.Schema;
+import com.google.genai.types.Type;
 
 import io.github.mucsi96.learnlanguage.model.WordResponse;
 import lombok.RequiredArgsConstructor;
@@ -19,27 +21,47 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AreaWordsService {
 
+  private static final String GEMINI_MODEL = "gemini-3-pro-preview-11-2025";
+
   static record AreaWords(List<WordResponse> wordList) {
   }
 
-  private final OpenAIClient openAIClient;
+  private final Client googleAiClient;
   private final WordIdService wordIdService;
 
   public List<WordResponse> getAreaWords(byte[] imageData) {
-    String imageBase64Url = "data:image/png;base64," + Base64.getEncoder().encodeToString(imageData);
-    var imageContentPart = ChatCompletionContentPart.ofImageUrl(ChatCompletionContentPartImage.builder()
-        .imageUrl(ChatCompletionContentPartImage.ImageUrl.builder()
-            .url(imageBase64Url)
-            .build())
-        .build());
-    var questionContentPart = ChatCompletionContentPart.ofText(ChatCompletionContentPartText.builder()
-        .text("Here is the image of the page")
-        .build());
+    Schema wordSchema = Schema.builder()
+        .type(Type.Known.OBJECT)
+        .properties(ImmutableMap.of(
+            "word", Schema.builder().type(Type.Known.STRING).build(),
+            "forms", Schema.builder()
+                .type(Type.Known.ARRAY)
+                .items(Schema.builder().type(Type.Known.STRING).build())
+                .build(),
+            "examples", Schema.builder()
+                .type(Type.Known.ARRAY)
+                .items(Schema.builder().type(Type.Known.STRING).build())
+                .build()))
+        .required("word", "forms", "examples")
+        .build();
 
-    var createParams = ChatCompletionCreateParams.builder()
-        .model(ChatModel.GPT_4_1)
-        .addSystemMessage(
-            """
+    Schema responseSchema = Schema.builder()
+        .type(Type.Known.OBJECT)
+        .properties(ImmutableMap.of(
+            "wordList", Schema.builder()
+                .type(Type.Known.ARRAY)
+                .items(wordSchema)
+                .build()))
+        .required("wordList")
+        .build();
+
+    GenerateContentConfig config = GenerateContentConfig.builder()
+        .responseMimeType("application/json")
+        .candidateCount(1)
+        .responseSchema(responseSchema)
+        .systemInstruction(Content.builder()
+            .role("user")
+            .parts(Part.text("""
                 You are a linguistic expert.
                 You task is to extract the wordlist data from provided page image.
                 !IMPORTANT! In response please provide all extracted words in JSON array with objects containing following properties: "word", "forms", "examples".
@@ -62,18 +84,28 @@ public class AreaWordsService {
                         }
                     ]
                 }
-                """)
-        .addUserMessageOfArrayOfContentParts(List.of(questionContentPart, imageContentPart))
-        .responseFormat(AreaWords.class)
+                """))
+            .build())
         .build();
 
-    var result = openAIClient.chat().completions().create(createParams).choices().stream()
-            .flatMap(choice -> choice.message().content().stream()).findFirst()
-            .orElseThrow(() -> new RuntimeException("No content returned from OpenAI API"));
+    GenerateContentResponse response = googleAiClient.models.generateContent(
+        GEMINI_MODEL,
+        Content.fromParts(
+            Part.text("Here is the image of the page"),
+            Part.fromBytes(imageData, "image/png")),
+        config);
 
-    return result.wordList.stream().map(word -> {
-      word.setId(wordIdService.generateWordId(word.getWord()));
-      return word;
-    }).toList();
+    String responseText = response.text();
+
+    try {
+      var objectMapper = new ObjectMapper();
+      var result = objectMapper.readValue(responseText, AreaWords.class);
+      return result.wordList.stream().map(word -> {
+        word.setId(wordIdService.generateWordId(word.getWord()));
+        return word;
+      }).toList();
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to deserialize response from Gemini API: " + responseText, e);
+    }
   }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/GenderDetectionService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/GenderDetectionService.java
@@ -2,9 +2,15 @@ package io.github.mucsi96.learnlanguage.service;
 
 import org.springframework.stereotype.Service;
 
-import com.openai.client.OpenAIClient;
-import com.openai.models.ChatModel;
-import com.openai.models.chat.completions.ChatCompletionCreateParams;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.genai.Client;
+import com.google.genai.types.Content;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.Part;
+import com.google.genai.types.Schema;
+import com.google.genai.types.Type;
 
 import lombok.RequiredArgsConstructor;
 
@@ -12,16 +18,28 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class GenderDetectionService {
 
+  private static final String GEMINI_MODEL = "gemini-3-pro-preview-11-2025";
+
   static record GenderResult(String gender) {
   }
 
-  private final OpenAIClient openAIClient;
+  private final Client googleAiClient;
 
   public String detectGender(String noun) {
-    var createParams = ChatCompletionCreateParams.builder()
-        .model(ChatModel.GPT_4_1)
-        .addSystemMessage(
-            """
+    Schema responseSchema = Schema.builder()
+        .type(Type.Known.OBJECT)
+        .properties(ImmutableMap.of(
+            "gender", Schema.builder().type(Type.Known.STRING).build()))
+        .required("gender")
+        .build();
+
+    GenerateContentConfig config = GenerateContentConfig.builder()
+        .responseMimeType("application/json")
+        .candidateCount(1)
+        .responseSchema(responseSchema)
+        .systemInstruction(Content.builder()
+            .role("user")
+            .parts(Part.text("""
                 You are a German language expert.
                 Your task is to determine the gender of the given German noun.
                 Return the grammatical gender in capitalized form: MASCULINE, FEMININE, or NEUTER.
@@ -30,15 +48,23 @@ public class GenderDetectionService {
                 {
                     "gender": "MASCULINE"
                 }
-                """)
-        .addUserMessage("The noun is: %s.".formatted(noun))
-        .responseFormat(GenderResult.class)
+                """))
+            .build())
         .build();
 
-    var result = openAIClient.chat().completions().create(createParams).choices().stream()
-        .flatMap(choice -> choice.message().content().stream()).findFirst()
-        .orElseThrow(() -> new RuntimeException("No content returned from OpenAI API"));
+    GenerateContentResponse response = googleAiClient.models.generateContent(
+        GEMINI_MODEL,
+        "The noun is: %s.".formatted(noun),
+        config);
 
-    return result.gender();
+    String responseText = response.text();
+
+    try {
+      var objectMapper = new ObjectMapper();
+      var result = objectMapper.readValue(responseText, GenderResult.class);
+      return result.gender();
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to deserialize response from Gemini API: " + responseText, e);
+    }
   }
 }


### PR DESCRIPTION
Replace OpenAI GPT-4.1 with Google Gemini 3 Pro (gemini-3-pro-preview-11-2025) as the primary thinking model across all language learning services.

Changes:
- TranslationService: Migrate from OpenAI to Gemini 3 Pro with structured JSON schema for translations
- GenderDetectionService: Replace GPT-4.1 with Gemini 3 Pro for German noun gender detection
- WordTypeService: Switch to Gemini 3 Pro for linguistic word categorization
- AreaWordsService: Update to use Gemini 3 Pro with multimodal image processing using Part.fromBytes()

Technical implementation:
- Use google-genai Java SDK (v1.28.0) already in dependencies
- Implement structured output using Schema.builder() with response schemas
- Configure GenerateContentConfig with responseMimeType("application/json")
- Handle multimodal inputs with Part.fromBytes() for image data
- Maintain consistent error handling with JSON deserialization

Note: OpenAI services retained for specialized tasks (OpenAIAudioService for TTS, OpenAIImageService for image generation) as these are not thinking/reasoning models.

Model: gemini-3-pro-preview-11-2025
API: Google GenAI SDK
Configuration: Uses existing google.ai.apiKey from application.yml