### PR TITLE
Add Claude Sonnet 4.5 model support

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -136,6 +136,10 @@
       <groupId>org.springframework.ai</groupId>
       <artifactId>spring-ai-starter-model-elevenlabs</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.ai</groupId>
+      <artifactId>spring-ai-starter-model-anthropic</artifactId>
+    </dependency>
   </dependencies>
   <dependencyManagement>
     <dependencies>

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/config/AIConfiguration.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/config/AIConfiguration.java
@@ -1,9 +1,15 @@
 package io.github.mucsi96.learnlanguage.config;
 
+import org.springframework.ai.anthropic.AnthropicChatModel;
+import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.elevenlabs.api.ElevenLabsVoicesApi;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
 import com.google.genai.Client;
 import com.google.genai.types.HttpOptions;
 import com.openai.client.OpenAIClient;
@@ -54,5 +60,18 @@ public class AIConfiguration {
     return ElevenLabsVoicesApi.builder()
         .apiKey(elevenLabsApiKey)
         .build();
+  }
+
+  @Bean
+  @Primary
+  @Qualifier("openAiChatClient")
+  ChatClient.Builder openAiChatClientBuilder(OpenAiChatModel openAiChatModel) {
+    return ChatClient.builder(openAiChatModel);
+  }
+
+  @Bean
+  @Qualifier("anthropicChatClient")
+  ChatClient.Builder anthropicChatClientBuilder(AnthropicChatModel anthropicChatModel) {
+    return ChatClient.builder(anthropicChatModel);
   }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/TranslationController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/TranslationController.java
@@ -4,8 +4,10 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.github.mucsi96.learnlanguage.model.ChatModel;
 import io.github.mucsi96.learnlanguage.model.TranslationResponse;
 import io.github.mucsi96.learnlanguage.model.WordResponse;
 import io.github.mucsi96.learnlanguage.service.TranslationService;
@@ -19,7 +21,10 @@ public class TranslationController {
 
     @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
     @PostMapping("/translate/{languageCode}")
-    public TranslationResponse translate(@RequestBody WordResponse word, @PathVariable String languageCode) {
-        return translationService.translate(word, languageCode);
+    public TranslationResponse translate(
+            @RequestBody WordResponse word,
+            @PathVariable String languageCode,
+            @RequestParam(defaultValue = "gpt-5") ChatModel model) {
+        return translationService.translate(word, languageCode, model);
     }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ChatModel.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ChatModel.java
@@ -1,0 +1,32 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ChatModel {
+    GPT_5("gpt-5", "openai"),
+    CLAUDE_SONNET_4_5("claude-sonnet-4-5", "anthropic");
+
+    private final String modelName;
+    private final String provider;
+
+    @JsonValue
+    public String getModelName() {
+        return modelName;
+    }
+
+    @JsonCreator
+    public static ChatModel fromString(String modelName) {
+        for (ChatModel model : values()) {
+            if (model.modelName.equals(modelName)) {
+                return model;
+            }
+        }
+        throw new IllegalArgumentException("Unknown chat model: " + modelName);
+    }
+}

--- a/server/src/main/resources/application-test.yml
+++ b/server/src/main/resources/application-test.yml
@@ -15,6 +15,9 @@ spring:
     openai:
       api-key: ${OPENAI_API_KEY}
       base-url: ${OPENAI_BASE_URL}
+    anthropic:
+      api-key: ${ANTHROPIC_API_KEY}
+      base-url: ${ANTHROPIC_BASE_URL}
     elevenlabs:
       base-url: ${ELEVEN_LABS_BASE_URL}
       api-key: ${ELEVEN_LABS_API_KEY}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -30,6 +30,8 @@ spring:
   ai:
     openai:
       api-key: ${openai-api-key}
+    anthropic:
+      api-key: ${anthropic-api-key}
     elevenlabs:
       api-key: ${eleven-labs-api-key}
       tts:


### PR DESCRIPTION
Add Spring AI Anthropic integration to enable Claude Sonnet 4.5 as an alternative model for translations. This includes:
- Spring AI Anthropic dependency in pom.xml
- Anthropic API key configuration in application.yml files
- Named ChatClient beans for both OpenAI and Anthropic providers
- ChatModel enum for model selection (GPT-5, Claude Sonnet 4.5)
- Updated TranslationService with model parameter support
- Updated TranslationController with optional model query parameter

The translation endpoint now accepts a model parameter, defaulting to GPT-5 for backwards compatibility.