### PR TITLE
Restore AI examples with proper Java messages

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/AreaWordsService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/AreaWordsService.java
@@ -7,6 +7,8 @@ import org.springframework.ai.content.Media;
 import org.springframework.stereotype.Service;
 import org.springframework.util.MimeTypeUtils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.github.mucsi96.learnlanguage.model.WordResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -17,21 +19,43 @@ public class AreaWordsService {
   record AreaWords(List<WordResponse> wordList) {
   }
 
+  private final ObjectMapper objectMapper;
   private final WordIdService wordIdService;
+
+  private String buildSystemPrompt() {
+    String basePrompt = """
+        You are a linguistic expert.
+        You task is to extract the wordlist data from provided page image.
+        !IMPORTANT! In response please provide all extracted words in JSON array with objects containing following properties: "word", "forms", "examples".
+        The word property holds a string. it's the basic form of the word without any forms.
+        The forms is a string array representing the different forms. In case of a noun it the plural form.
+        In case of verb it's the 3 forms of conjugation (Eg. Du gehst, Er/Sie/Es geht, Er/Sie/Es ist gegangen). Please enhance it to make those full words. Not just endings.
+        The examples property is a string array enlisting the examples provided in the document.""";
+
+    AreaWords example = new AreaWords(List.of(
+        WordResponse.builder()
+            .word("das Haus")
+            .forms(List.of("die Häuser"))
+            .examples(List.of("Das Haus ist groß."))
+            .build(),
+        WordResponse.builder()
+            .word("gehen")
+            .forms(List.of("gehst", "geht", "ist gegangen"))
+            .examples(List.of("Ich gehe jetzt.", "Er ist nach Hause gegangen."))
+            .build()));
+
+    try {
+      String exampleJson = objectMapper.writeValueAsString(example);
+      return basePrompt + "\nExample of the expected JSON response:\n" + exampleJson;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to serialize example to JSON", e);
+    }
+  }
 
   public List<WordResponse> getAreaWords(byte[] imageData, ChatClient chatClient) {
     var result = chatClient
         .prompt()
-        .system(
-            """
-                You are a linguistic expert.
-                You task is to extract the wordlist data from provided page image.
-                !IMPORTANT! In response please provide all extracted words in JSON array with objects containing following properties: "word", "forms", "examples".
-                The word property holds a string. it's the basic form of the word without any forms.
-                The forms is a string array representing the different forms. In case of a noun it the plural form.
-                In case of verb it's the 3 forms of conjugation (Eg. Du gehst, Er/Sie/Es geht, Er/Sie/Es ist gegangen). Please enhance it to make those full words. Not just endings.
-                The examples property is a string array enlisting the examples provided in the document.
-                """)
+        .system(buildSystemPrompt())
         .user(u -> u
             .text("Here is the image of the page")
             .media(Media.builder()


### PR DESCRIPTION
Restore the JSON examples in AI prompts that were removed during the Spring AI migration. Instead of inline strings, use proper Java models and Jackson ObjectMapper to serialize examples, ensuring schema correctness.

Services updated:
- TranslationService: language-specific translation examples
- WordTypeService: word type classification example
- GenderDetectionService: gender detection example
- AreaWordsService: word list extraction examples