### PR TITLE
Remove DiffSummary and simplify model fallback logic

### DIFF
--- a/client/src/app/environment/environment.config.ts
+++ b/client/src/app/environment/environment.config.ts
@@ -3,6 +3,8 @@ import { InjectionToken } from '@angular/core';
 export interface ChatModelInfo {
   modelName: string;
   primary: boolean;
+  inputPricePerMillionTokens: number;
+  outputPricePerMillionTokens: number;
 }
 
 export interface EnvironmentConfig {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/EnvironmentController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/EnvironmentController.java
@@ -34,12 +34,20 @@ public class EnvironmentController {
         clientId,
         environment.matchesProfiles("test"),
         Arrays.stream(ChatModel.values())
-            .map(model -> new ChatModelInfo(model.getModelName(), model.isPrimary()))
+            .map(model -> new ChatModelInfo(
+                model.getModelName(),
+                model.isPrimary(),
+                model.getInputPricePerMillionTokens(),
+                model.getOutputPricePerMillionTokens()))
             .toList(),
         Arrays.stream(ImageGenerationModel.values()).map(ImageGenerationModel::getModelName).toList());
   }
 
-  public record ChatModelInfo(String modelName, boolean primary) {
+  public record ChatModelInfo(
+      String modelName,
+      boolean primary,
+      double inputPricePerMillionTokens,
+      double outputPricePerMillionTokens) {
   }
 
   public record ConfigResponse(

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ModelResponseLogController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ModelResponseLogController.java
@@ -29,7 +29,6 @@ public class ModelResponseLogController {
                 .operationType(request.getOperationType())
                 .input(request.getInput())
                 .responses(request.getResponses())
-                .diffSummary(request.getDiffSummary())
                 .createdAt(LocalDateTime.now())
                 .build();
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/entity/ModelResponseLog.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/entity/ModelResponseLog.java
@@ -40,9 +40,6 @@ public class ModelResponseLog {
     @Type(JsonBinaryType.class)
     private List<ModelResponse> responses;
 
-    @Column(name = "diff_summary", columnDefinition = "text")
-    private String diffSummary;
-
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ChatModel.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ChatModel.java
@@ -9,14 +9,16 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum ChatModel {
-  GPT_4O("gpt-4o", false),
-  GPT_4_1("gpt-4.1", false),
-  GPT_5("gpt-5", false),
-  CLAUDE_SONNET_4_5("claude-sonnet-4-5", false),
-  GEMINI_3_PRO_PREVIEW("gemini-3-pro-preview", true);
+  GPT_4O("gpt-4o", false, 3.00, 10.00),
+  GPT_4_1("gpt-4.1", false, 2.00, 8.00),
+  GPT_5("gpt-5", false, 1.25, 10.00),
+  CLAUDE_SONNET_4_5("claude-sonnet-4-5", false, 3.00, 15.00),
+  GEMINI_3_PRO_PREVIEW("gemini-3-pro-preview", true, 1.25, 10.00);
 
   private final String modelName;
   private final boolean primary;
+  private final double inputPricePerMillionTokens;
+  private final double outputPricePerMillionTokens;
 
   @JsonValue
   public String getModelName() {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ModelResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ModelResponse.java
@@ -12,4 +12,6 @@ import lombok.NoArgsConstructor;
 public class ModelResponse {
     private String modelName;
     private String output;
+    private Double priceUsd;
+    private Long executionTimeMs;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ModelResponseLogRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ModelResponseLogRequest.java
@@ -15,5 +15,4 @@ public class ModelResponseLogRequest {
     private String operationType;
     private String input;
     private List<ModelResponse> responses;
-    private String diffSummary;
 }

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -46,7 +46,6 @@ CREATE TABLE IF NOT EXISTS learn_language.model_response_logs (
     operation_type character varying(255) NOT NULL,
     input text NOT NULL,
     responses jsonb NOT NULL,
-    diff_summary text,
     created_at timestamp(6) without time zone NOT NULL,
     CONSTRAINT model_response_logs_pkey PRIMARY KEY (id)
 );


### PR DESCRIPTION
- Remove diff_summary field from model_response_logs table and entities
- Remove fallback logic that used other models when primary failed
- Add pricing information to ChatModel enum (per million tokens)
- Expose pricing info to frontend via EnvironmentController
- Add priceUsd and executionTimeMs fields to ModelResponse
- Track execution time per model call in MultiModelService
- Estimate cost based on token count approximation (4 chars/token)
- Throw error when primary model fails instead of falling back