### PR TITLE
Fix invisible rating star icons on usage page

### DIFF
--- a/client/src/app/model-usage-logs/model-usage-logs.component.css
+++ b/client/src/app/model-usage-logs/model-usage-logs.component.css
@@ -221,14 +221,15 @@ p {
   font-size: 18px;
   width: 18px;
   height: 18px;
+  opacity: 1;
 }
 
-.star-filled {
+.star-button .mat-icon.star-empty {
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.star-button .mat-icon.star-filled {
   color: #ffc107;
-}
-
-.star-empty {
-  color: var(--mat-sys-outline);
 }
 
 /* Summary table */
@@ -246,6 +247,7 @@ p {
   font-size: 18px;
   width: 18px;
   height: 18px;
+  color: #ffc107;
 }
 
 .no-rating {

--- a/client/src/app/model-usage-logs/model-usage-logs.service.ts
+++ b/client/src/app/model-usage-logs/model-usage-logs.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, inject, resource } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { fetchJson } from '../utils/fetchJson';
-import { firstValueFrom } from 'rxjs';
 
 export interface ModelUsageLog {
   id: number;
@@ -50,9 +49,10 @@ export class ModelUsageLogsService {
       currentLogs?.map((log) => (log.id === id ? { ...log, rating } : log))
     );
 
-    await firstValueFrom(
-      this.http.patch(`/api/model-usage-logs/${id}/rating`, { rating })
-    );
+    await fetchJson(this.http, `/api/model-usage-logs/${id}/rating`, {
+      method: 'patch',
+      body: { rating },
+    });
   }
 
   refetch() {

--- a/client/src/app/model-usage-logs/model-usage-logs.service.ts
+++ b/client/src/app/model-usage-logs/model-usage-logs.service.ts
@@ -46,11 +46,13 @@ export class ModelUsageLogsService {
   });
 
   async updateRating(id: number, rating: number | null): Promise<void> {
+    this.logs.update((currentLogs) =>
+      currentLogs?.map((log) => (log.id === id ? { ...log, rating } : log))
+    );
+
     await firstValueFrom(
       this.http.patch(`/api/model-usage-logs/${id}/rating`, { rating })
     );
-    this.logs.reload();
-    this.summary.reload();
   }
 
   refetch() {

--- a/client/src/app/model-usage-logs/model-usage-logs.service.ts
+++ b/client/src/app/model-usage-logs/model-usage-logs.service.ts
@@ -53,6 +53,8 @@ export class ModelUsageLogsService {
       method: 'patch',
       body: { rating },
     });
+
+    this.summary.reload();
   }
 
   refetch() {

--- a/test/tests/model-usage-page.spec.ts
+++ b/test/tests/model-usage-page.spec.ts
@@ -226,6 +226,39 @@ test('allows rating usage logs', async ({ page }) => {
   ]);
 });
 
+test('allows clearing rating by clicking the same star', async ({ page }) => {
+  await createModelUsageLog({
+    modelName: 'gpt-4o',
+    modelType: 'CHAT',
+    operationType: 'translation',
+    inputTokens: 100,
+    outputTokens: 50,
+    costUsd: 0.002,
+    processingTimeMs: 1000,
+    rating: 4,
+  });
+
+  await page.goto('http://localhost:8180/model-usage');
+
+  await page.getByRole('button', { name: 'Rate 4 stars' }).click();
+
+  await page.getByRole('tab', { name: 'Model Summary' }).click();
+
+  const summaryData = await getTableData<ModelSummaryRow>(
+    page.getByRole('tabpanel', { name: 'Model Summary' }).getByRole('table')
+  );
+
+  expect(summaryData).toEqual([
+    {
+      Model: 'gpt-4o',
+      'Total Calls': '1',
+      'Rated Calls': '0',
+      'Avg Rating': '-',
+      'Total Cost': '$0.0020',
+    },
+  ]);
+});
+
 test('displays model summary tab', async ({ page }) => {
   await createModelUsageLog({
     modelName: 'gpt-4o',


### PR DESCRIPTION
Stars were invisible because the color was too similar to the background. Added explicit visible colors for both empty and filled star states.