### PR TITLE
Disable ratings for image and voice models

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
 - Assign cards / multiperson
 
 - if a model log is rated. Automatically rate all other logs with the same response
-- disable rating for image and voice models usage
 - for eleven labs model v3 please use tags [spoken in German]
 - display image model name on image
 - drop link for non existing words

--- a/client/src/app/model-usage-logs/model-usage-logs.component.html
+++ b/client/src/app/model-usage-logs/model-usage-logs.component.html
@@ -153,18 +153,20 @@
           <ng-container matColumnDef="rating">
             <th mat-header-cell *matHeaderCellDef>Rating</th>
             <td mat-cell *matCellDef="let log">
-              <div class="rating-stars">
-                @for (star of ratingStars; track star) {
-                  <button mat-icon-button
-                          class="star-button"
-                          (click)="setRating(log, star, $event)"
-                          [attr.aria-label]="'Rate ' + star + ' stars'">
-                    <mat-icon [class]="getStarClass(log, star)">
-                      {{ log.rating && star <= log.rating ? 'star' : 'star_border' }}
-                    </mat-icon>
-                  </button>
-                }
-              </div>
+              @if (log.modelType === 'CHAT') {
+                <div class="rating-stars">
+                  @for (star of ratingStars; track star) {
+                    <button mat-icon-button
+                            class="star-button"
+                            (click)="setRating(log, star, $event)"
+                            [attr.aria-label]="'Rate ' + star + ' stars'">
+                      <mat-icon [class]="getStarClass(log, star)">
+                        {{ log.rating && star <= log.rating ? 'star' : 'star_border' }}
+                      </mat-icon>
+                    </button>
+                  }
+                </div>
+              }
             </td>
           </ng-container>
 

--- a/client/src/app/model-usage-logs/model-usage-logs.component.html
+++ b/client/src/app/model-usage-logs/model-usage-logs.component.html
@@ -153,7 +153,7 @@
           <ng-container matColumnDef="rating">
             <th mat-header-cell *matHeaderCellDef>Rating</th>
             <td mat-cell *matCellDef="let log">
-              @if (log.modelType === 'CHAT') {
+              @if (isRatable(log)) {
                 <div class="rating-stars">
                   @for (star of ratingStars; track star) {
                     <button mat-icon-button

--- a/client/src/app/model-usage-logs/model-usage-logs.component.ts
+++ b/client/src/app/model-usage-logs/model-usage-logs.component.ts
@@ -97,6 +97,7 @@ export class ModelUsageLogsComponent {
 
   async setRating(log: ModelUsageLog, rating: number, event: Event): Promise<void> {
     event.stopPropagation();
+    if (log.modelType !== 'CHAT') return;
     const newRating = log.rating === rating ? null : rating;
     await this.service.updateRating(log.id, newRating);
   }

--- a/client/src/app/model-usage-logs/model-usage-logs.component.ts
+++ b/client/src/app/model-usage-logs/model-usage-logs.component.ts
@@ -95,9 +95,13 @@ export class ModelUsageLogsComponent {
     return log.modelType === 'CHAT' && !!log.responseContent;
   }
 
+  isRatable(log: ModelUsageLog): boolean {
+    return log.modelType === 'CHAT';
+  }
+
   async setRating(log: ModelUsageLog, rating: number, event: Event): Promise<void> {
     event.stopPropagation();
-    if (log.modelType !== 'CHAT') return;
+    if (!this.isRatable(log)) return;
     const newRating = log.rating === rating ? null : rating;
     await this.service.updateRating(log.id, newRating);
   }

--- a/test/tests/model-usage-page.spec.ts
+++ b/test/tests/model-usage-page.spec.ts
@@ -276,6 +276,36 @@ test('allows clearing rating by clicking the same star', async ({ page }) => {
   ]);
 });
 
+test('does not show rating for image models', async ({ page }) => {
+  await createModelUsageLog({
+    modelName: 'gpt-image-1',
+    modelType: 'IMAGE',
+    operationType: 'image_generation',
+    imageCount: 1,
+    costUsd: 0.04,
+    processingTimeMs: 5000,
+  });
+
+  await page.goto('http://localhost:8180/model-usage');
+
+  await expect(page.getByRole('button', { name: /Rate \d stars/ })).toHaveCount(0);
+});
+
+test('does not show rating for audio models', async ({ page }) => {
+  await createModelUsageLog({
+    modelName: 'eleven_v3',
+    modelType: 'AUDIO',
+    operationType: 'audio_generation',
+    inputCharacters: 250,
+    costUsd: 0.005,
+    processingTimeMs: 3000,
+  });
+
+  await page.goto('http://localhost:8180/model-usage');
+
+  await expect(page.getByRole('button', { name: /Rate \d stars/ })).toHaveCount(0);
+});
+
 test('displays model summary tab', async ({ page }) => {
   await createModelUsageLog({
     modelName: 'gpt-4o',


### PR DESCRIPTION
Only chat models are now rateable. Rating stars are hidden for IMAGE and AUDIO model types in the usage logs view.