### PR TITLE
Display image model name below generated images

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,6 @@
 
 - if a model log is rated. Automatically rate all other logs with the same response
 - for eleven labs model v3 please use tags [spoken in German]
-- display image model name on image
 - drop link for non existing words
 - add a know table with levels imported from Anki db - usefull for other new source types
 - fix imagen 4 generation

--- a/client/src/app/bulk-card-creation.service.ts
+++ b/client/src/app/bulk-card-creation.service.ts
@@ -195,7 +195,7 @@ export class BulkCardCreationService {
         cardId: info.cardId,
         exampleIndex: info.exampleIndex,
         englishTranslation: info.englishTranslation,
-        model
+        model: model.id
       }))
     );
 

--- a/client/src/app/environment/environment.config.ts
+++ b/client/src/app/environment/environment.config.ts
@@ -5,6 +5,11 @@ export interface ChatModelInfo {
   primary: boolean;
 }
 
+export interface ImageModel {
+  id: string;
+  displayName: string;
+}
+
 export interface AudioModel {
   id: string;
   displayName: string;
@@ -29,7 +34,7 @@ export interface EnvironmentConfig {
   apiClientId: string;
   mockAuth: boolean;
   chatModels: ChatModelInfo[];
-  imageModels: string[];
+  imageModels: ImageModel[];
   audioModels: AudioModel[];
   voices: Voice[];
   supportedLanguages: SupportedLanguage[];

--- a/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.css
+++ b/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.css
@@ -117,6 +117,14 @@
   }
 }
 
+.model-name {
+  display: block;
+  text-align: center;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.7);
+  margin-top: 4px;
+}
+
 .carousel-controls {
   display: grid;
   grid-template-columns: repeat(3, 1fr);

--- a/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.html
+++ b/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.html
@@ -137,7 +137,9 @@
       } @else {
       <mat-icon>image_not_supported</mat-icon>
       }
-
+      @if (imageResource?.value()?.model) {
+      <span class="model-name">{{ getModelDisplayName(imageResource.value()?.model) }}</span>
+      }
       <div class="carousel-controls">
         <button
           mat-icon-button

--- a/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.ts
@@ -176,8 +176,8 @@ export class EditVocabularyCardComponent {
     this.exampleImages.update((images) => {
       images[exampleIdx] = [
         ...images[exampleIdx],
-        ...imageModels.map((modelName) =>
-          this.createExampleImageResource(exampleIdx, modelName)
+        ...imageModels.map((model) =>
+          this.createExampleImageResource(exampleIdx, model.id)
         ),
       ];
       return images;
@@ -339,5 +339,11 @@ export class EditVocabularyCardComponent {
       this.http,
       `/api/image/${imageId}?width=600&height=600`
     );
+  }
+
+  getModelDisplayName(modelId: string | undefined): string {
+    if (!modelId) return '';
+    const model = this.environmentConfig.imageModels.find(m => m.id === modelId);
+    return model?.displayName ?? modelId;
   }
 }

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -35,6 +35,7 @@ export type Word = {
 export type ExampleImage = {
   id: string;
   isFavorite?: boolean;
+  model?: string;
 };
 
 export type CardData = {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/EnvironmentController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/EnvironmentController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import io.github.mucsi96.learnlanguage.model.AudioModelResponse;
 import io.github.mucsi96.learnlanguage.model.ChatModel;
 import io.github.mucsi96.learnlanguage.model.ImageGenerationModel;
+import io.github.mucsi96.learnlanguage.model.ImageModelResponse;
 import io.github.mucsi96.learnlanguage.model.VoiceResponse;
 import io.github.mucsi96.learnlanguage.service.AudioService;
 import io.github.mucsi96.learnlanguage.service.ElevenLabsAudioService;
@@ -47,7 +48,9 @@ public class EnvironmentController {
         Arrays.stream(ChatModel.values())
             .map(model -> new ChatModelInfo(model.getModelName(), model.isPrimary()))
             .toList(),
-        Arrays.stream(ImageGenerationModel.values()).map(ImageGenerationModel::getModelName).toList(),
+        Arrays.stream(ImageGenerationModel.values())
+            .map(model -> new ImageModelResponse(model.getModelName(), model.getDisplayName()))
+            .toList(),
         audioService.getAvailableModels(),
         elevenLabsAudioService.getVoices(),
         SUPPORTED_LANGUAGES);
@@ -65,7 +68,7 @@ public class EnvironmentController {
       String apiClientId,
       boolean mockAuth,
       List<ChatModelInfo> chatModels,
-      List<String> imageModels,
+      List<ImageModelResponse> imageModels,
       List<AudioModelResponse> audioModels,
       List<VoiceResponse> voices,
       List<SupportedLanguage> supportedLanguages) {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationModel.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationModel.java
@@ -9,16 +9,21 @@ import lombok.RequiredArgsConstructor;
 //          https://ai.google.dev/gemini-api/docs/pricing
 @RequiredArgsConstructor
 public enum ImageGenerationModel {
-    GPT_IMAGE_1("gpt-image-1"),
-    GPT_IMAGE_1_5("gpt-image-1.5"),
-    IMAGEN_4_ULTRA("imagen-4.0-ultra"),
-    GEMINI_3_PRO_IMAGE_PREVIEW("gemini-3-pro-image-preview");
+    GPT_IMAGE_1("gpt-image-1", "GPT Image 1"),
+    GPT_IMAGE_1_5("gpt-image-1.5", "GPT Image 1.5"),
+    IMAGEN_4_ULTRA("imagen-4.0-ultra", "Imagen 4 Ultra"),
+    GEMINI_3_PRO_IMAGE_PREVIEW("gemini-3-pro-image-preview", "Gemini 3 Pro");
 
     private final String modelName;
+    private final String displayName;
 
     @JsonValue
     public String getModelName() {
         return modelName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
     }
 
     @JsonCreator

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageModelResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageModelResponse.java
@@ -1,0 +1,15 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageModelResponse {
+    private String id;
+    private String displayName;
+}

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -571,3 +571,42 @@ test('card edits stored locally until save', async ({ page }) => {
     expect(cardData.translation.hu).toBe('megtanulni'); // Updated value
   });
 });
+
+test('image model name displayed below image', async ({ page }) => {
+  const image1 = uploadMockImage(yellowImage);
+  const image2 = uploadMockImage(redImage);
+  await createCard({
+    cardId: 'abfahren',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'abfahren',
+      type: 'VERB',
+      forms: ['fährt ab', 'fuhr ab', 'abgefahren'],
+      translation: {
+        en: 'to leave',
+        hu: 'elindulni, elhagyni',
+        ch: 'abfahra, verlah',
+      },
+      examples: [
+        {
+          de: 'Wir fahren um zwölf Uhr ab.',
+          hu: 'Tizenkét órakor indulunk.',
+          en: "We leave at twelve o'clock.",
+          ch: 'Mir fahred am zwöufi ab.',
+          images: [
+            { id: image1, model: 'gpt-image-1' },
+            { id: image2, model: 'imagen-4.0-ultra' },
+          ],
+        },
+      ],
+    },
+  });
+
+  await navigateToCardCreation(page);
+
+  await expect(page.getByText('GPT Image 1')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Next image' }).first().click();
+  await expect(page.getByText('Imagen 4 Ultra')).toBeVisible();
+});


### PR DESCRIPTION
Add display names to image generation models and show them below each generated image in the edit vocabulary card component. Updated backend to return ImageModelResponse with id and displayName instead of plain strings.