### PR TITLE
Remove word links from page route

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 - if a model log is rated. Automatically rate all other logs with the same response
 - for eleven labs model v3 please use tags [spoken in German]
 - display image model name on image
-- drop link for non existing words
+- ~~drop link for non existing words~~ ✓
 - add a know table with levels imported from Anki db - usefull for other new source types
 - fix imagen 4 generation
 

--- a/client/src/app/parser/span/span.component.html
+++ b/client/src/app/parser/span/span.component.html
@@ -1,4 +1,4 @@
-@if (!matches.length) {
+@if (!existingMatches.length) {
 <div
   class="word"
   exclude-selection
@@ -12,12 +12,12 @@
   {{ text() }}
 </div>
 
-} @else if (matches.length === 1) {
+} @else if (existingMatches.length === 1) {
 <a
   class="word"
   mat-flat-button
   [routerLink]="['/sources', sourceId(), 'page', pageNumber(), 'cards']"
-  [queryParams]="{cardData: (matches[0] | compressQuery | async)}"
+  [queryParams]="{cardData: (existingMatches[0] | compressQuery | async)}"
   [style.left]="left"
   [style.top]="top"
   [style.width]="width"
@@ -43,7 +43,7 @@
   {{ text() }}
 </button>
 <mat-menu #menu="matMenu">
-  @for (match of matches; track match.word) {
+  @for (match of existingMatches; track match.word) {
   <a
     mat-menu-item
     [routerLink]="['/sources', sourceId(), 'page', pageNumber(), 'cards']"

--- a/client/src/app/parser/span/span.component.ts
+++ b/client/src/app/parser/span/span.component.ts
@@ -70,6 +70,10 @@ export class SpanComponent {
     ) || [];
   }
 
+  get existingMatches() {
+    return this.matches.filter((word) => word.exists);
+  }
+
   @HostBinding('style.top') get top() {
     const  y = this.bbox()?.y;
 

--- a/test/tests/sources-page.spec.ts
+++ b/test/tests/sources-page.spec.ts
@@ -57,20 +57,13 @@ test('highlights existing cards', async ({ page }) => {
   await expect(page.getByText('anfangen,')).toHaveAccessibleDescription('Card exists');
 });
 
-test('drag to select words', async ({ page }) => {
+test('drag to select words shows create cards fab', async ({ page }) => {
   await page.goto('http://localhost:8180/sources');
   await page.getByRole('link', { name: 'Goethe A1' }).click();
 
   await selectTextRange(page, 'aber', 'Vor der Abfahrt rufe ich an.');
 
-  await expect(page.getByRole('link', { name: 'aber' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'abfahren' })).toBeVisible();
-
-  await page.getByRole('link', { name: 'abfahren' }).click();
-
-  await expect(
-    page.getByLabel('German translation', { exact: true })
-  ).toHaveValue('abfahren');
+  await expect(page.getByText('Create 3 Cards')).toBeVisible();
 });
 
 test('drag to select multiple regions', async ({ page }) => {
@@ -84,7 +77,7 @@ test('drag to select multiple regions', async ({ page }) => {
   // First region selection
   await selectTextRange(page, 'aber', 'Vor der Abfahrt rufe ich an.');
 
-  await expect(page.getByRole('link', { name: 'aber' })).toBeVisible();
+  await expect(page.getByText('Create 3 Cards')).toBeVisible();
 
   // Second region selection
   await selectTextRange(
@@ -94,12 +87,6 @@ test('drag to select multiple regions', async ({ page }) => {
   );
 
   await expect(page.getByText('Create 6 Cards')).toBeVisible();
-
-  // Check that links from both regions are visible
-  await expect(page.getByRole('link', { name: 'aber' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'abfahren' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'der Absender' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'die Adresse' })).toBeVisible();
 });
 
 test('source selector routing works', async ({ page }) => {


### PR DESCRIPTION
Cards should be created using bulk card creation flow only. Existing cards still display as links for editing.