### PR TITLE
Remove links for non-existing words on page

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
 - Assign cards / multiperson
 
 - if a model log is rated. Automatically rate all other logs with the same response
-- drop link for non existing words
 - add a know table with levels imported from Anki db - usefull for other new source types
 - fix imagen 4 generation
 - move voice config under settings

--- a/client/src/app/parser/span/span.component.css
+++ b/client/src/app/parser/span/span.component.css
@@ -11,6 +11,10 @@
     --outline: hsl(111, 32%, 66%);
   }
 
+  &.matches {
+    --outline: hsl(200, 50%, 50%);
+  }
+
   &:not(button) {
     outline: 1px solid var(--outline, darkslategray);
     outline-offset: 2px;

--- a/client/src/app/parser/span/span.component.html
+++ b/client/src/app/parser/span/span.component.html
@@ -1,4 +1,4 @@
-@if (!matches.length) {
+@if (!matches.length || !exists()) {
 <div
   class="word"
   exclude-selection
@@ -7,6 +7,7 @@
   [style.width]="width"
   [style.height]="height"
   [class.exists]="exists()"
+  [class.matches]="matches.length > 0"
   [ariaDescription]="ariaDescription"
 >
   {{ text() }}

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -8,8 +8,7 @@ import {
   yellowImage,
   redImage,
   blueImage,
-  greenImage,
-  navigateToCardCreation,
+  navigateToCardEditing,
   uploadMockImage,
 } from '../utils';
 import { Page } from '@playwright/test';
@@ -41,7 +40,7 @@ async function prepareCard(page: Page) {
       ],
     },
   });
-  return await navigateToCardCreation(page);
+  return await navigateToCardEditing(page);
 }
 
 test('carousel indicator initial', async ({ page }) => {
@@ -146,7 +145,7 @@ test('card editing page', async ({ page }) => {
       ],
     },
   });
-  await navigateToCardCreation(page);
+  await navigateToCardEditing(page);
 
   // Word section
   await expect(page.getByRole('combobox', { name: 'Word type' })).toHaveText(
@@ -233,7 +232,7 @@ test('card editing in db', async ({ page }) => {
       ],
     },
   });
-  await navigateToCardCreation(page);
+  await navigateToCardEditing(page);
   await page.getByLabel('Hungarian translation').fill('elindulni, elutazni');
 
   await page.waitForLoadState('networkidle');
@@ -319,7 +318,7 @@ test('favorite image in db', async ({ page }) => {
     },
   });
 
-  await navigateToCardCreation(page);
+  await navigateToCardEditing(page);
 
   // Verify initial favorite state
   await expect(
@@ -394,7 +393,7 @@ test('word type editing', async ({ page }) => {
     },
   });
 
-  await navigateToCardCreation(page);
+  await navigateToCardEditing(page);
 
   // Verify initial word type
   await expect(page.getByRole('combobox', { name: 'Word type' })).toHaveText(
@@ -456,7 +455,7 @@ test('example image addition', async ({ page }) => {
       ],
     },
   });
-  await navigateToCardCreation(page);
+  await navigateToCardEditing(page);
 
   const imageLocator = page.getByRole('img', {
     name: 'Wir fahren um zwölf Uhr ab.',
@@ -510,7 +509,7 @@ test('card deletion', async ({ page }) => {
     },
   });
 
-  await navigateToCardCreation(page);
+  await navigateToCardEditing(page);
   await page.getByRole('button', { name: 'Delete card' }).click();
   await expect(
     page.getByText('Are you sure you want to delete this card?')
@@ -615,7 +614,7 @@ test('image model name displayed below image', async ({ page }) => {
     },
   });
 
-  await navigateToCardCreation(page);
+  await navigateToCardEditing(page);
 
   await expect(page.getByText('GPT Image 1')).toBeVisible();
 

--- a/test/tests/home-page.spec.ts
+++ b/test/tests/home-page.spec.ts
@@ -69,6 +69,9 @@ test('due cards limited to max 50 mixed states', async ({ page }) => {
   await createCardsWithStates('goethe-a1', cardsToCreate);
 
   await page.goto('http://localhost:8180');
+
+  await page.waitForLoadState('networkidle');
+
   await expect(page.getByTitle('New', { exact: true })).toContainText('20');
   await expect(page.getByTitle('Learning', { exact: true })).toContainText('15');
   await expect(page.getByTitle('Review', { exact: true })).toContainText('10');

--- a/test/tests/page-titles.spec.ts
+++ b/test/tests/page-titles.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../fixtures';
-import { navigateToCardCreation } from '../utils';
+import { createCard, navigateToCardEditing } from '../utils';
 
 test('home page title', async ({ page }) => {
   await page.goto('http://localhost:8180/');
@@ -17,6 +17,39 @@ test('source page title', async ({ page }) => {
 });
 
 test('card page title', async ({ page }) => {
-  await navigateToCardCreation(page);
+  await createCard({
+      cardId: 'abfahren',
+      sourceId: 'goethe-a1',
+      sourcePageNumber: 9,
+      data: {
+        word: 'abfahren',
+        type: 'NOUN',
+        gender: 'FEMININE',
+        forms: ['fährt ab', 'fuhr ab', 'abgefahren'],
+        translation: {
+          en: 'to leave',
+          hu: 'elindulni, elhagyni',
+          ch: 'abfahra, verlah',
+        },
+        examples: [
+          {
+            de: 'Wir fahren um zwölf Uhr ab.',
+            hu: 'Tizenkét órakor indulunk.',
+            en: "We leave at twelve o'clock.",
+            ch: 'Mir fahred am zwöufi ab.',
+            images: [],
+          },
+          {
+            de: 'Wann fährt der Zug ab?',
+            hu: 'Mikor indul a vonat?',
+            en: 'When does the train leave?',
+            ch: 'Wänn fahrt dr',
+            isSelected: true,
+            images: [],
+          },
+        ],
+      },
+    });
+  await navigateToCardEditing(page);
   await expect(page).toHaveTitle('abfahren');
 });

--- a/test/tests/sources-page.spec.ts
+++ b/test/tests/sources-page.spec.ts
@@ -57,23 +57,18 @@ test('highlights existing cards', async ({ page }) => {
   await expect(page.getByText('anfangen,')).toHaveAccessibleDescription('Card exists');
 });
 
-test('drag to select words', async ({ page }) => {
+test('drag to select words highlights matching words', async ({ page }) => {
   await page.goto('http://localhost:8180/sources');
   await page.getByRole('link', { name: 'Goethe A1' }).click();
 
   await selectTextRange(page, 'aber', 'Vor der Abfahrt rufe ich an.');
 
-  await expect(page.getByRole('link', { name: 'aber' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'abfahren' })).toBeVisible();
-
-  await page.getByRole('link', { name: 'abfahren' }).click();
-
-  await expect(
-    page.getByLabel('German translation', { exact: true })
-  ).toHaveValue('abfahren');
+  await expect(page.getByText('aber').first()).toHaveAccessibleDescription('Card does not exist');
+  await expect(page.getByText('abfahren').first()).toHaveAccessibleDescription('Card does not exist');
+  await expect(page.getByText('die Abfahrt').first()).toHaveAccessibleDescription('Card does not exist');
 });
 
-test('drag to select multiple regions', async ({ page }) => {
+test('drag to select multiple regions highlights matching words', async ({ page }) => {
   await page.goto('http://localhost:8180/sources');
   await page.getByRole('link', { name: 'Goethe A1' }).click();
 
@@ -84,7 +79,7 @@ test('drag to select multiple regions', async ({ page }) => {
   // First region selection
   await selectTextRange(page, 'aber', 'Vor der Abfahrt rufe ich an.');
 
-  await expect(page.getByRole('link', { name: 'aber' })).toBeVisible();
+  await expect(page.getByText('aber').first()).toHaveAccessibleDescription('Card does not exist');
 
   // Second region selection
   await selectTextRange(
@@ -95,11 +90,11 @@ test('drag to select multiple regions', async ({ page }) => {
 
   await expect(page.getByText('Create 6 Cards')).toBeVisible();
 
-  // Check that links from both regions are visible
-  await expect(page.getByRole('link', { name: 'aber' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'abfahren' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'der Absender' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'die Adresse' })).toBeVisible();
+  // Check that words from both regions are highlighted
+  await expect(page.getByText('aber').first()).toHaveAccessibleDescription('Card does not exist');
+  await expect(page.getByText('abfahren').first()).toHaveAccessibleDescription('Card does not exist');
+  await expect(page.getByText('der Absender').first()).toHaveAccessibleDescription('Card does not exist');
+  await expect(page.getByText('die Adresse').first()).toHaveAccessibleDescription('Card does not exist');
 });
 
 test('source selector routing works', async ({ page }) => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -417,7 +417,7 @@ export async function scrollElementToTop(
   await page.waitForLoadState('networkidle');
 }
 
-export async function navigateToCardCreation(
+export async function navigateToCardEditing(
   page: Page,
   sourceName: string = 'Goethe A1',
   startText: string = 'aber',


### PR DESCRIPTION
Cards should now be created using the bulk card creation flow only. Non-existing words are still highlighted (with a blue outline) when selected, but they are no longer clickable links. Only existing cards show as links to their edit page.