### PR TITLE
Fix image generation with latest Gemini SDK

### DIFF
--- a/mock_google_ai_server/src/index.ts
+++ b/mock_google_ai_server/src/index.ts
@@ -22,7 +22,7 @@ app.post('/reset', (req, res) => {
   res.status(200).json({ status: 'ok', message: 'Image counter reset to 0' });
 });
 
-app.post('/v1beta/models/imagen-4.0-ultra:predict', (req, res) => {
+app.post('/v1beta/models/imagen-4.0-ultra-generate-001:predict', (req, res) => {
   try {
     const prompt = req.body.instances[0].prompt;
     console.log({ prompt });

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/config/ModelPricingConfig.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/config/ModelPricingConfig.java
@@ -43,7 +43,7 @@ public class ModelPricingConfig {
         "gpt-image-1", new ImageModelPricing(new BigDecimal("0.25")),
         "gpt-image-1.5", new ImageModelPricing(new BigDecimal("0.20")),
         // Google image models
-        "imagen-4.0-ultra", new ImageModelPricing(new BigDecimal("0.06")),
+        "imagen-4.0-ultra-generate-001", new ImageModelPricing(new BigDecimal("0.06")),
         "gemini-3-pro-image-preview", new ImageModelPricing(new BigDecimal("0.134"))
     );
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationModel.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationModel.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 public enum ImageGenerationModel {
     GPT_IMAGE_1("gpt-image-1", "GPT Image 1"),
     GPT_IMAGE_1_5("gpt-image-1.5", "GPT Image 1.5"),
-    IMAGEN_4_ULTRA("imagen-4.0-ultra", "Imagen 4 Ultra"),
+    IMAGEN_4_ULTRA("imagen-4.0-ultra-generate-001", "Imagen 4 Ultra"),
     GEMINI_3_PRO_IMAGE_PREVIEW("gemini-3-pro-image-preview", "Gemini 3 Pro");
 
     private final String modelName;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/GoogleImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/GoogleImageService.java
@@ -44,7 +44,7 @@ public class GoogleImageService {
       Image generatedImage = generatedImagesResponse.images().get(0);
 
       long processingTime = System.currentTimeMillis() - startTime;
-      usageLoggingService.logImageUsage("imagen-4.0-ultra-generate-001", "image_generation", 1, processingTime);
+      usageLoggingService.logImageUsage(IMAGEN_MODEL, "image_generation", 1, processingTime);
 
       return generatedImage.imageBytes().orElseThrow(
           () -> new RuntimeException("No image bytes in generated image"));
@@ -78,7 +78,7 @@ public class GoogleImageService {
       for (Part part : response.candidates().get().get(0).content().get().parts().get()) {
         if (part.inlineData().isPresent()) {
           long processingTime = System.currentTimeMillis() - startTime;
-          usageLoggingService.logImageUsage("gemini-3-pro-image-preview", "image_generation", 1, processingTime);
+          usageLoggingService.logImageUsage(GEMINI_3_PRO_IMAGE_PREVIEW_MODEL, "image_generation", 1, processingTime);
           return part.inlineData().get().data().get();
         }
       }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/GoogleImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/GoogleImageService.java
@@ -18,7 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class GoogleImageService {
 
-  private static final String IMAGEN_MODEL = "imagen-4.0-ultra";
+  private static final String IMAGEN_MODEL = "imagen-4.0-ultra-generate-001";
   private static final String GEMINI_3_PRO_IMAGE_PREVIEW_MODEL = "gemini-3-pro-image-preview";
 
   private final Client googleAiClient;
@@ -37,17 +37,17 @@ public class GoogleImageService {
           prompt + ". Avoid using text.",
           generateImagesConfig);
 
-      if (generatedImagesResponse.generatedImages().isEmpty() ||
-          generatedImagesResponse.generatedImages().get().isEmpty()) {
+      if (generatedImagesResponse.images().isEmpty()) {
         throw new RuntimeException("No image generated from Google Imagen API");
       }
 
-      Image generatedImage = generatedImagesResponse.generatedImages().get().get(0).image().get();
+      Image generatedImage = generatedImagesResponse.images().get(0);
 
       long processingTime = System.currentTimeMillis() - startTime;
-      usageLoggingService.logImageUsage("imagen-4.0-ultra", "image_generation", 1, processingTime);
+      usageLoggingService.logImageUsage("imagen-4.0-ultra-generate-001", "image_generation", 1, processingTime);
 
-      return generatedImage.imageBytes().get();
+      return generatedImage.imageBytes().orElseThrow(
+          () -> new RuntimeException("No image bytes in generated image"));
 
     } catch (Exception e) {
       log.error("Failed to generate image with Google Imagen", e);


### PR DESCRIPTION
- Update model name from imagen-4.0-ultra to imagen-4.0-ultra-generate-001
- Use new images() convenience method instead of deprecated generatedImages()
- Update mock server endpoint to match new model name
- Update pricing config and model enum with new model ID