### PR TITLE
Auto-rate duplicate chat model logs

### DIFF
--- a/client/src/app/model-usage-logs/model-usage-logs.service.ts
+++ b/client/src/app/model-usage-logs/model-usage-logs.service.ts
@@ -45,8 +45,19 @@ export class ModelUsageLogsService {
   });
 
   async updateRating(id: number, rating: number | null): Promise<void> {
+    const currentLog = this.logs.value()?.find((log) => log.id === id);
+    const responseContent = currentLog?.responseContent;
+
     this.logs.update((currentLogs) =>
-      currentLogs?.map((log) => (log.id === id ? { ...log, rating } : log))
+      currentLogs?.map((log) => {
+        if (log.id === id) {
+          return { ...log, rating };
+        }
+        if (responseContent && log.responseContent === responseContent) {
+          return { ...log, rating };
+        }
+        return log;
+      })
     );
 
     await fetchJson(this.http, `/api/model-usage-logs/${id}/rating`, {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ModelUsageLogController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ModelUsageLogController.java
@@ -39,7 +39,19 @@ public class ModelUsageLogController {
         return repository.findById(id)
             .map(log -> {
                 log.setRating(request.rating());
-                return ResponseEntity.ok(repository.save(log));
+                repository.save(log);
+
+                if (log.getResponseContent() != null) {
+                    List<ModelUsageLog> duplicates = repository.findByResponseContent(log.getResponseContent());
+                    for (ModelUsageLog duplicate : duplicates) {
+                        if (!duplicate.getId().equals(id)) {
+                            duplicate.setRating(request.rating());
+                            repository.save(duplicate);
+                        }
+                    }
+                }
+
+                return ResponseEntity.ok(log);
             })
             .orElse(ResponseEntity.notFound().build());
     }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/ModelUsageLogRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/ModelUsageLogRepository.java
@@ -14,6 +14,7 @@ public interface ModelUsageLogRepository extends JpaRepository<ModelUsageLog, Lo
     List<ModelUsageLog> findAllByOrderByCreatedAtDesc();
     List<ModelUsageLog> findByModelTypeOrderByCreatedAtDesc(ModelType modelType);
     List<ModelUsageLog> findByOperationTypeOrderByCreatedAtDesc(String operationType);
+    List<ModelUsageLog> findByResponseContent(String responseContent);
 
     @Query("""
         SELECT m.modelName, COUNT(m), COUNT(m.rating),

--- a/test/tests/model-usage-page.spec.ts
+++ b/test/tests/model-usage-page.spec.ts
@@ -281,7 +281,7 @@ test('auto-rates duplicate logs with same response content', async ({ page }) =>
 
   await page.goto('http://localhost:8180/model-usage');
 
-  await page.getByRole('button', { name: 'Rate 4 stars' }).first().click();
+  await page.getByRole('button', { name: 'Rate 4 stars' }).last().click();
 
   await page.getByRole('tab', { name: 'Model Summary' }).click();
 


### PR DESCRIPTION
When a chat model log is rated, automatically apply the same rating to all other logs that have identical responseContent. This helps users rate similar AI responses more efficiently.