### PR TITLE
Configure primary chat model per operation type

### DIFF
--- a/client/src/app/chat-model-settings/chat-model-settings.component.css
+++ b/client/src/app/chat-model-settings/chat-model-settings.component.css
@@ -90,20 +90,19 @@ mat-card-header {
   text-overflow: ellipsis;
 }
 
-.primary-tag {
-  display: inline-block;
-  font-size: 10px;
-  padding: 2px 6px;
-  border-radius: 4px;
-  text-transform: uppercase;
-  font-weight: 500;
-  background-color: var(--mat-sys-primary-container);
-  color: var(--mat-sys-on-primary-container);
-  margin-top: 4px;
-}
-
 .toggle-cell {
   vertical-align: middle;
+}
+
+.cell-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.primary-radio {
+  transform: scale(0.85);
 }
 
 .empty-state {

--- a/client/src/app/chat-model-settings/chat-model-settings.component.html
+++ b/client/src/app/chat-model-settings/chat-model-settings.component.html
@@ -57,17 +57,23 @@
                       }
                       <span class="model-name">{{ model.modelName }}</span>
                     </div>
-                    @if (model.primary) {
-                      <span class="primary-tag">primary</span>
-                    }
                   </td>
                   @for (operation of operationTypes; track operation.code) {
                     <td class="toggle-cell">
-                      <mat-slide-toggle
-                        [checked]="settingsMatrix()[model.modelName][operation.code]"
-                        (change)="toggleSetting(model.modelName, operation.code)"
-                        [aria-label]="model.modelName + ' for ' + operation.displayName"
-                      ></mat-slide-toggle>
+                      <div class="cell-controls">
+                        <mat-slide-toggle
+                          [checked]="settingsMatrix()[model.modelName][operation.code]"
+                          (change)="toggleSetting(model.modelName, operation.code)"
+                          [aria-label]="model.modelName + ' for ' + operation.displayName"
+                        ></mat-slide-toggle>
+                        <mat-radio-button
+                          [checked]="isPrimaryModel(model.modelName, operation.code)"
+                          [disabled]="!settingsMatrix()[model.modelName][operation.code]"
+                          (change)="setPrimaryModel(model.modelName, operation.code)"
+                          [aria-label]="'Set ' + model.modelName + ' as primary for ' + operation.displayName"
+                          class="primary-radio"
+                        ></mat-radio-button>
+                      </div>
                     </td>
                   }
                 </tr>

--- a/client/src/app/chat-model-settings/chat-model-settings.component.html
+++ b/client/src/app/chat-model-settings/chat-model-settings.component.html
@@ -67,6 +67,7 @@
                           [aria-label]="model.modelName + ' for ' + operation.displayName"
                         ></mat-slide-toggle>
                         <mat-radio-button
+                          [name]="'primary-' + operation.code"
                           [checked]="isPrimaryModel(model.modelName, operation.code)"
                           [disabled]="!settingsMatrix()[model.modelName][operation.code]"
                           (change)="setPrimaryModel(model.modelName, operation.code)"

--- a/client/src/app/chat-model-settings/chat-model-settings.component.ts
+++ b/client/src/app/chat-model-settings/chat-model-settings.component.ts
@@ -5,6 +5,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatRadioModule } from '@angular/material/radio';
 import { ChatModelSettingsService } from './chat-model-settings.service';
 
 @Component({
@@ -17,6 +18,7 @@ import { ChatModelSettingsService } from './chat-model-settings.service';
     MatIconModule,
     MatSlideToggleModule,
     MatTooltipModule,
+    MatRadioModule,
   ],
   templateUrl: './chat-model-settings.component.html',
   styleUrl: './chat-model-settings.component.css',
@@ -27,6 +29,7 @@ export class ChatModelSettingsComponent {
   readonly chatModels = this.service.chatModels;
   readonly operationTypes = this.service.operationTypes;
   readonly settingsMatrix = this.service.settingsMatrix;
+  readonly primaryModelByOperation = this.service.primaryModelByOperation;
 
   getOperationDisplayName(code: string): string {
     return this.service.getOperationDisplayName(code);
@@ -36,8 +39,16 @@ export class ChatModelSettingsComponent {
     return this.service.isModelEnabled(modelName, operationType);
   }
 
+  isPrimaryModel(modelName: string, operationType: string): boolean {
+    return this.service.isPrimaryModel(modelName, operationType);
+  }
+
   async toggleSetting(modelName: string, operationType: string): Promise<void> {
     await this.service.toggleSetting(modelName, operationType);
+  }
+
+  async setPrimaryModel(modelName: string, operationType: string): Promise<void> {
+    await this.service.setPrimaryModel(modelName, operationType);
   }
 
   async enableAllForOperation(operationType: string): Promise<void> {

--- a/client/src/app/environment/environment.config.ts
+++ b/client/src/app/environment/environment.config.ts
@@ -4,7 +4,6 @@ export type ModelProvider = 'openai' | 'anthropic' | 'google';
 
 export interface ChatModelInfo {
   modelName: string;
-  primary: boolean;
   provider: ModelProvider;
 }
 
@@ -47,6 +46,7 @@ export interface EnvironmentConfig {
   voices: Voice[];
   supportedLanguages: SupportedLanguage[];
   enabledModelsByOperation: Record<string, string[]>;
+  primaryModelByOperation: Record<string, string>;
   operationTypes: OperationTypeInfo[];
 }
 

--- a/client/src/app/multi-model.service.ts
+++ b/client/src/app/multi-model.service.ts
@@ -16,13 +16,13 @@ export class MultiModelService {
     operationType: string,
     apiCall: (model: string) => Promise<T>
   ): Promise<T> {
-    const enabledModelNames = this.environmentConfig.enabledModelsByOperation[operationType];
+    const enabledModelNames = this.environmentConfig.enabledModelsByOperation[operationType] ?? [];
     const modelsToUse = this.environmentConfig.chatModels.filter(m =>
       enabledModelNames.includes(m.modelName)
     );
-    const primaryModelName = modelsToUse.find(m => m.primary)?.modelName;
+    const primaryModelName = this.environmentConfig.primaryModelByOperation[operationType];
 
-    if (!primaryModelName) {
+    if (!primaryModelName || !enabledModelNames.includes(primaryModelName)) {
       throw new Error(`No primary model enabled for operation type: ${operationType}`);
     }
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/EnvironmentController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/EnvironmentController.java
@@ -45,6 +45,7 @@ public class EnvironmentController {
   @GetMapping("/environment")
   public ConfigResponse getConfig() {
     Map<String, List<String>> enabledModelsByOperation = chatModelSettingService.getEnabledModelsByOperation();
+    Map<String, String> primaryModelByOperation = chatModelSettingService.getPrimaryModelByOperation();
 
     List<OperationTypeInfo> operationTypes = Arrays.stream(ChatOperationType.values())
         .map(op -> new OperationTypeInfo(op.getCode(), op.getDisplayName()))
@@ -56,7 +57,7 @@ public class EnvironmentController {
         clientId,
         environment.matchesProfiles("test"),
         Arrays.stream(ChatModel.values())
-            .map(model -> new ChatModelInfo(model.getModelName(), model.isPrimary(), model.getProvider().getCode()))
+            .map(model -> new ChatModelInfo(model.getModelName(), model.getProvider().getCode()))
             .toList(),
         Arrays.stream(ImageGenerationModel.values())
             .map(model -> new ImageModelResponse(model.getModelName(), model.getDisplayName()))
@@ -65,10 +66,11 @@ public class EnvironmentController {
         elevenLabsAudioService.getVoices(),
         SUPPORTED_LANGUAGES,
         enabledModelsByOperation,
+        primaryModelByOperation,
         operationTypes);
   }
 
-  public record ChatModelInfo(String modelName, boolean primary, String provider) {
+  public record ChatModelInfo(String modelName, String provider) {
   }
 
   public record SupportedLanguage(String code, String displayName) {
@@ -88,6 +90,7 @@ public class EnvironmentController {
       List<VoiceResponse> voices,
       List<SupportedLanguage> supportedLanguages,
       Map<String, List<String>> enabledModelsByOperation,
+      Map<String, String> primaryModelByOperation,
       List<OperationTypeInfo> operationTypes) {
   }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/entity/ChatModelSetting.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/entity/ChatModelSetting.java
@@ -32,4 +32,8 @@ public class ChatModelSetting {
     @Column(name = "is_enabled", nullable = false)
     @Builder.Default
     private Boolean isEnabled = true;
+
+    @Column(name = "is_primary", nullable = false)
+    @Builder.Default
+    private Boolean isPrimary = false;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ChatModel.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ChatModel.java
@@ -9,22 +9,21 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum ChatModel {
-  GPT_4O("gpt-4o", false, ModelProvider.OPENAI),
-  GPT_4O_MINI("gpt-4o-mini", false, ModelProvider.OPENAI),
-  GPT_4_1("gpt-4.1", false, ModelProvider.OPENAI),
-  GPT_4_1_MINI("gpt-4.1-mini", false, ModelProvider.OPENAI),
-  GPT_4_1_NANO("gpt-4.1-nano", false, ModelProvider.OPENAI),
-  GPT_5("gpt-5", false, ModelProvider.OPENAI),
-  GPT_5_2("gpt-5.2", false, ModelProvider.OPENAI),
-  GPT_5_MINI("gpt-5-mini", false, ModelProvider.OPENAI),
-  GPT_5_NANO("gpt-5-nano", false, ModelProvider.OPENAI),
-  CLAUDE_SONNET_4_5("claude-sonnet-4-5", false, ModelProvider.ANTHROPIC),
-  CLAUDE_HAIKU_4_5("claude-haiku-4-5", false, ModelProvider.ANTHROPIC),
-  GEMINI_3_PRO_PREVIEW("gemini-3-pro-preview", true, ModelProvider.GOOGLE),
-  GEMINI_3_FLASH_PREVIEW("gemini-3-flash-preview", false, ModelProvider.GOOGLE);
+  GPT_4O("gpt-4o", ModelProvider.OPENAI),
+  GPT_4O_MINI("gpt-4o-mini", ModelProvider.OPENAI),
+  GPT_4_1("gpt-4.1", ModelProvider.OPENAI),
+  GPT_4_1_MINI("gpt-4.1-mini", ModelProvider.OPENAI),
+  GPT_4_1_NANO("gpt-4.1-nano", ModelProvider.OPENAI),
+  GPT_5("gpt-5", ModelProvider.OPENAI),
+  GPT_5_2("gpt-5.2", ModelProvider.OPENAI),
+  GPT_5_MINI("gpt-5-mini", ModelProvider.OPENAI),
+  GPT_5_NANO("gpt-5-nano", ModelProvider.OPENAI),
+  CLAUDE_SONNET_4_5("claude-sonnet-4-5", ModelProvider.ANTHROPIC),
+  CLAUDE_HAIKU_4_5("claude-haiku-4-5", ModelProvider.ANTHROPIC),
+  GEMINI_3_PRO_PREVIEW("gemini-3-pro-preview", ModelProvider.GOOGLE),
+  GEMINI_3_FLASH_PREVIEW("gemini-3-flash-preview", ModelProvider.GOOGLE);
 
   private final String modelName;
-  private final boolean primary;
   private final ModelProvider provider;
 
   @JsonValue

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ChatModelSettingRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ChatModelSettingRequest.java
@@ -19,4 +19,7 @@ public class ChatModelSettingRequest {
 
     @Builder.Default
     private Boolean isEnabled = true;
+
+    @Builder.Default
+    private Boolean isPrimary = false;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ChatModelSettingResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ChatModelSettingResponse.java
@@ -14,4 +14,5 @@ public class ChatModelSettingResponse {
     private String modelName;
     private String operationType;
     private Boolean isEnabled;
+    private Boolean isPrimary;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/ChatModelSettingRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/ChatModelSettingRepository.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 @Repository
 public interface ChatModelSettingRepository extends JpaRepository<ChatModelSetting, Integer> {
     List<ChatModelSetting> findByIsEnabledTrue();
+    List<ChatModelSetting> findByIsPrimaryTrue();
     List<ChatModelSetting> findByOperationType(String operationType);
     List<ChatModelSetting> findByOperationTypeAndIsEnabledTrue(String operationType);
     Optional<ChatModelSetting> findByModelNameAndOperationType(String modelName, String operationType);

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -74,6 +74,7 @@ CREATE TABLE IF NOT EXISTS learn_language.chat_model_settings (
     model_name character varying(255) NOT NULL,
     operation_type character varying(255) NOT NULL,
     is_enabled boolean NOT NULL DEFAULT true,
+    is_primary boolean NOT NULL DEFAULT false,
     CONSTRAINT chat_model_settings_pkey PRIMARY KEY (id),
     CONSTRAINT chat_model_settings_unique UNIQUE (model_name, operation_type)
 );

--- a/test/tests/chat-model-settings.spec.ts
+++ b/test/tests/chat-model-settings.spec.ts
@@ -38,14 +38,18 @@ test('can set primary model for operation type', async ({ page }) => {
   await page.goto('http://localhost:8180/settings/data-models');
 
   const gptRow = page.locator('tr', { has: page.getByText('gpt-4o', { exact: true }) });
+  const geminiRow = page.locator('tr', { has: page.getByText('gemini-3-pro-preview', { exact: true }) });
   const gptPrimaryRadio = gptRow.getByRole('radio').first();
+  const geminiPrimaryRadio = geminiRow.getByRole('radio').first();
 
   await expect(gptPrimaryRadio).not.toBeChecked();
+  await expect(geminiPrimaryRadio).toBeChecked();
 
   await gptPrimaryRadio.click();
   await page.waitForTimeout(500);
 
   await expect(gptPrimaryRadio).toBeChecked();
+  await expect(geminiPrimaryRadio).not.toBeChecked();
 
   const settings = await getChatModelSettings();
   const gptSetting = settings.find(s => s.modelName === 'gpt-4o' && s.operationType === 'translation_en');

--- a/test/tests/enabled-models-filtering.spec.ts
+++ b/test/tests/enabled-models-filtering.spec.ts
@@ -28,8 +28,10 @@ async function setupChatModelsForAllOperations(config: {
 
   for (const op of operations) {
     const models = config[op] ?? [defaultModel];
-    for (const modelName of models) {
-      await createChatModelSetting({ modelName, operationType: op });
+    for (let i = 0; i < models.length; i++) {
+      const modelName = models[i];
+      const isPrimary = i === 0 || modelName === defaultModel;
+      await createChatModelSetting({ modelName, operationType: op, isPrimary });
     }
   }
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -601,19 +601,21 @@ export async function createChatModelSetting(params: {
   modelName: string;
   operationType: string;
   isEnabled?: boolean;
+  isPrimary?: boolean;
 }): Promise<number> {
   const {
     modelName,
     operationType,
     isEnabled = true,
+    isPrimary = false,
   } = params;
 
   return await withDbConnection(async (client) => {
     const result = await client.query(
-      `INSERT INTO learn_language.chat_model_settings (model_name, operation_type, is_enabled)
-       VALUES ($1, $2, $3)
+      `INSERT INTO learn_language.chat_model_settings (model_name, operation_type, is_enabled, is_primary)
+       VALUES ($1, $2, $3, $4)
        RETURNING id`,
-      [modelName, operationType, isEnabled]
+      [modelName, operationType, isEnabled, isPrimary]
     );
     return result.rows[0].id;
   });
@@ -636,6 +638,7 @@ export async function setupDefaultChatModelSettings(): Promise<void> {
       modelName: DEFAULT_CHAT_MODEL,
       operationType,
       isEnabled: true,
+      isPrimary: true,
     });
   }
 }
@@ -651,11 +654,12 @@ export async function getChatModelSettings(): Promise<Array<{
   modelName: string;
   operationType: string;
   isEnabled: boolean;
+  isPrimary: boolean;
 }>> {
   return await withDbConnection(async (client) => {
     const result = await client.query(
       `SELECT id, model_name as "modelName", operation_type as "operationType",
-              is_enabled as "isEnabled"
+              is_enabled as "isEnabled", is_primary as "isPrimary"
        FROM learn_language.chat_model_settings
        ORDER BY id`
     );


### PR DESCRIPTION
Replace hardcoded primary model flag in ChatModel enum with database- configurable primary model setting per operation type.

Changes:
- Add isPrimary column to chat_model_settings table
- Update ChatModelSettingService to manage primary models per operation
- Update EnvironmentController to expose primaryModelByOperation map
- Remove hardcoded primary flag from ChatModel enum
- Update frontend to use radio buttons for primary model selection
- Update MultiModelService to use configurable primary model
- Add/update tests for primary model functionality