### PR TITLE
Add source format types for word extraction

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,6 @@
 - Assign cards / multiperson
 
-- introduce source type: word list with examples, word list with forms and examples, flowing text
 - allow adding more documents per source and make it veyr easy on page route itself as well
-- enhance word extraction to support extraction from flowing text sources. It should generate word forms and context relevant example.
 
 - support for speach card type
 - support for grammar card type

--- a/client/src/app/environment/environment.config.ts
+++ b/client/src/app/environment/environment.config.ts
@@ -35,6 +35,16 @@ export interface OperationTypeInfo {
   displayName: string;
 }
 
+export interface LanguageLevelInfo {
+  code: string;
+  displayName: string;
+}
+
+export interface SourceFormatTypeInfo {
+  code: string;
+  displayName: string;
+}
+
 export interface EnvironmentConfig {
   tenantId: string;
   clientId: string;
@@ -48,6 +58,8 @@ export interface EnvironmentConfig {
   enabledModelsByOperation: Record<string, string[]>;
   primaryModelByOperation: Record<string, string>;
   operationTypes: OperationTypeInfo[];
+  languageLevels: LanguageLevelInfo[];
+  sourceFormatTypes: SourceFormatTypeInfo[];
 }
 
 export const ENVIRONMENT_CONFIG = new InjectionToken<EnvironmentConfig>('ENVIRONMENT_CONFIG');

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -85,6 +85,10 @@ export type Page = {
 
 export type LanguageLevel = 'A1' | 'A2' | 'B1' | 'B2' | 'C1' | 'C2';
 export type CardType = 'vocabulary';
+export type SourceFormatType =
+  | 'wordListWithExamples'
+  | 'wordListWithFormsAndExamples'
+  | 'flowingText';
 
 export type Source = {
   id: string;
@@ -94,6 +98,7 @@ export type Source = {
   cardCount?: number;
   languageLevel?: LanguageLevel;
   cardType?: CardType;
+  formatType?: SourceFormatType;
 };
 
 export type WordList = {

--- a/client/src/app/shared/source-dialog/source-dialog.component.html
+++ b/client/src/app/shared/source-dialog/source-dialog.component.html
@@ -89,8 +89,8 @@
         name="languageLevel"
         required
       >
-        @for (level of languageLevels; track level) {
-        <mat-option [value]="level">{{ level }}</mat-option>
+        @for (level of languageLevels; track level.code) {
+        <mat-option [value]="level.code">{{ level.displayName }}</mat-option>
         }
       </mat-select>
     </mat-form-field>
@@ -102,8 +102,8 @@
         name="formatType"
         required
       >
-        @for (formatType of formatTypes; track formatType.value) {
-        <mat-option [value]="formatType.value">{{ formatType.label }}</mat-option>
+        @for (formatType of formatTypes; track formatType.code) {
+        <mat-option [value]="formatType.code">{{ formatType.displayName }}</mat-option>
         }
       </mat-select>
     </mat-form-field>

--- a/client/src/app/shared/source-dialog/source-dialog.component.html
+++ b/client/src/app/shared/source-dialog/source-dialog.component.html
@@ -96,6 +96,19 @@
     </mat-form-field>
 
     <mat-form-field appearance="fill" class="full-width">
+      <mat-label>Format Type</mat-label>
+      <mat-select
+        [(ngModel)]="formData.formatType"
+        name="formatType"
+        required
+      >
+        @for (formatType of formatTypes; track formatType.value) {
+        <mat-option [value]="formatType.value">{{ formatType.label }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="fill" class="full-width">
       <mat-label>Card Type</mat-label>
       <mat-select [(ngModel)]="formData.cardType" name="cardType" disabled>
         <mat-option value="vocabulary">Vocabulary</mat-option>

--- a/client/src/app/shared/source-dialog/source-dialog.component.ts
+++ b/client/src/app/shared/source-dialog/source-dialog.component.ts
@@ -11,11 +11,12 @@ import {
 import { MatFormFieldModule, MatLabel } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
-import { LanguageLevel, Source, SourceFormatType } from '../../parser/types';
+import { Source } from '../../parser/types';
 import { uploadDocument } from '../../utils/uploadDocument';
 import { MatRadioModule } from '@angular/material/radio';
 import { CommonModule } from '@angular/common';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { ENVIRONMENT_CONFIG } from '../../environment/environment.config';
 
 @Component({
   selector: 'app-source-dialog',
@@ -37,27 +38,21 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 })
 export class SourceDialogComponent {
   private readonly http = inject(HttpClient);
+  private readonly environment = inject(ENVIRONMENT_CONFIG);
   data: { source?: Source; mode: 'create' | 'edit' } = inject(MAT_DIALOG_DATA);
   dialogRef: MatDialogRef<SourceDialogComponent> = inject(MatDialogRef);
 
-  languageLevels: LanguageLevel[] = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'];
-  formatTypes: { value: SourceFormatType; label: string }[] = [
-    { value: 'wordListWithExamples', label: 'Word list with examples' },
-    {
-      value: 'wordListWithFormsAndExamples',
-      label: 'Word list with forms and examples',
-    },
-    { value: 'flowingText', label: 'Flowing text' },
-  ];
+  readonly languageLevels = this.environment.languageLevels;
+  readonly formatTypes = this.environment.sourceFormatTypes;
 
   formData: Partial<Source> = {
     id: this.data.source?.id || '',
     name: this.data.source?.name || '',
     fileName: this.data.source?.fileName || '',
     startPage: this.data.source?.startPage || 1,
-    languageLevel: this.data.source?.languageLevel || 'A1',
+    languageLevel: this.data.source?.languageLevel,
     cardType: 'vocabulary',
-    formatType: this.data.source?.formatType || 'wordListWithFormsAndExamples',
+    formatType: this.data.source?.formatType,
   };
 
   uploadedFile = signal<File | null>(null);
@@ -71,7 +66,6 @@ export class SourceDialogComponent {
 
   async onSaveClick(): Promise<void> {
     if (this.isValid()) {
-      // If a new file was uploaded, upload it first
       if (this.uploadedFile()) {
         await this.uploadFile();
         if (this.uploadError()) {
@@ -130,7 +124,6 @@ export class SourceDialogComponent {
   }
 
   handleFile(file: File): void {
-    // Validate file type
     if (!file.name.toLowerCase().endsWith('.pdf')) {
       this.uploadError.set('Only PDF files are allowed');
       return;

--- a/client/src/app/shared/source-dialog/source-dialog.component.ts
+++ b/client/src/app/shared/source-dialog/source-dialog.component.ts
@@ -11,7 +11,7 @@ import {
 import { MatFormFieldModule, MatLabel } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
-import { LanguageLevel, Source } from '../../parser/types';
+import { LanguageLevel, Source, SourceFormatType } from '../../parser/types';
 import { uploadDocument } from '../../utils/uploadDocument';
 import { MatRadioModule } from '@angular/material/radio';
 import { CommonModule } from '@angular/common';
@@ -41,6 +41,14 @@ export class SourceDialogComponent {
   dialogRef: MatDialogRef<SourceDialogComponent> = inject(MatDialogRef);
 
   languageLevels: LanguageLevel[] = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'];
+  formatTypes: { value: SourceFormatType; label: string }[] = [
+    { value: 'wordListWithExamples', label: 'Word list with examples' },
+    {
+      value: 'wordListWithFormsAndExamples',
+      label: 'Word list with forms and examples',
+    },
+    { value: 'flowingText', label: 'Flowing text' },
+  ];
 
   formData: Partial<Source> = {
     id: this.data.source?.id || '',
@@ -48,7 +56,8 @@ export class SourceDialogComponent {
     fileName: this.data.source?.fileName || '',
     startPage: this.data.source?.startPage || 1,
     languageLevel: this.data.source?.languageLevel || 'A1',
-    cardType: 'vocabulary', // Only vocabulary is supported for now
+    cardType: 'vocabulary',
+    formatType: this.data.source?.formatType || 'wordListWithFormsAndExamples',
   };
 
   uploadedFile = signal<File | null>(null);
@@ -79,7 +88,8 @@ export class SourceDialogComponent {
       this.formData.name &&
       this.formData.startPage &&
       this.formData.startPage > 0 &&
-      this.formData.languageLevel
+      this.formData.languageLevel &&
+      this.formData.formatType
     );
 
     if (!hasRequiredFields) {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/EnvironmentController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/EnvironmentController.java
@@ -14,6 +14,8 @@ import io.github.mucsi96.learnlanguage.model.ChatModel;
 import io.github.mucsi96.learnlanguage.model.ChatOperationType;
 import io.github.mucsi96.learnlanguage.model.ImageGenerationModel;
 import io.github.mucsi96.learnlanguage.model.ImageModelResponse;
+import io.github.mucsi96.learnlanguage.model.LanguageLevel;
+import io.github.mucsi96.learnlanguage.model.SourceFormatType;
 import io.github.mucsi96.learnlanguage.model.VoiceResponse;
 import io.github.mucsi96.learnlanguage.service.AudioService;
 import io.github.mucsi96.learnlanguage.service.ChatModelSettingService;
@@ -51,6 +53,14 @@ public class EnvironmentController {
         .map(op -> new OperationTypeInfo(op.getCode(), op.getDisplayName()))
         .toList();
 
+    List<LanguageLevelInfo> languageLevels = Arrays.stream(LanguageLevel.values())
+        .map(level -> new LanguageLevelInfo(level.getCode(), level.getDisplayName()))
+        .toList();
+
+    List<SourceFormatTypeInfo> sourceFormatTypes = Arrays.stream(SourceFormatType.values())
+        .map(type -> new SourceFormatTypeInfo(type.getCode(), type.getDisplayName()))
+        .toList();
+
     return new ConfigResponse(
         tenantId,
         uiClientId,
@@ -67,7 +77,9 @@ public class EnvironmentController {
         SUPPORTED_LANGUAGES,
         enabledModelsByOperation,
         primaryModelByOperation,
-        operationTypes);
+        operationTypes,
+        languageLevels,
+        sourceFormatTypes);
   }
 
   public record ChatModelInfo(String modelName, String provider) {
@@ -77,6 +89,12 @@ public class EnvironmentController {
   }
 
   public record OperationTypeInfo(String code, String displayName) {
+  }
+
+  public record LanguageLevelInfo(String code, String displayName) {
+  }
+
+  public record SourceFormatTypeInfo(String code, String displayName) {
   }
 
   public record ConfigResponse(
@@ -91,6 +109,8 @@ public class EnvironmentController {
       List<SupportedLanguage> supportedLanguages,
       Map<String, List<String>> enabledModelsByOperation,
       Map<String, String> primaryModelByOperation,
-      List<OperationTypeInfo> operationTypes) {
+      List<OperationTypeInfo> operationTypes,
+      List<LanguageLevelInfo> languageLevels,
+      List<SourceFormatTypeInfo> sourceFormatTypes) {
   }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
@@ -66,6 +66,7 @@ public class SourceController {
           .fileName(source.getFileName())
           .startPage(source.getBookmarkedPage() != null ? source.getBookmarkedPage() : source.getStartPage())
           .cardCount(cardCount)
+          .formatType(source.getFormatType())
           .build();
     }).collect(Collectors.toList());
   }
@@ -111,7 +112,7 @@ public class SourceController {
 
     byte[] imageData = documentProcessorService.getPageArea(source, pageNumber, x, y, width, height);
 
-    var areaWords = areaWordsService.getAreaWords(imageData, model);
+    var areaWords = areaWordsService.getAreaWords(imageData, model, source.getFormatType());
     List<String> ids = areaWords.stream()
         .map(word -> word.getId())
         .toList();
@@ -148,6 +149,7 @@ public class SourceController {
         .startPage(request.getStartPage())
         .languageLevel(request.getLanguageLevel())
         .cardType(request.getCardType())
+        .formatType(request.getFormatType())
         .build();
 
     sourceService.saveSource(source);
@@ -163,13 +165,13 @@ public class SourceController {
     Source existingSource = sourceService.getSourceById(sourceId)
         .orElseThrow(() -> new ResourceNotFoundException("Source not found with id: " + sourceId));
 
-    // Copy only non-null properties from request to existing source
     Source updates = Source.builder()
         .name(request.getName())
         .fileName(request.getFileName())
         .startPage(request.getStartPage())
         .languageLevel(request.getLanguageLevel())
         .cardType(request.getCardType())
+        .formatType(request.getFormatType())
         .build();
 
     BeanUtils.copyNonNullProperties(updates, existingSource);

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
@@ -66,6 +66,7 @@ public class SourceController {
           .fileName(source.getFileName())
           .startPage(source.getBookmarkedPage() != null ? source.getBookmarkedPage() : source.getStartPage())
           .cardCount(cardCount)
+          .languageLevel(source.getLanguageLevel())
           .formatType(source.getFormatType())
           .build();
     }).collect(Collectors.toList());

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/entity/Source.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/entity/Source.java
@@ -2,6 +2,7 @@ package io.github.mucsi96.learnlanguage.entity;
 
 import io.github.mucsi96.learnlanguage.model.CardType;
 import io.github.mucsi96.learnlanguage.model.LanguageLevel;
+import io.github.mucsi96.learnlanguage.model.SourceFormatType;
 import jakarta.annotation.Nonnull;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -38,4 +39,8 @@ public class Source {
   @Enumerated(EnumType.STRING)
   @Column(name = "card_type")
   private CardType cardType;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "format_type")
+  private SourceFormatType formatType;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/LanguageLevel.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/LanguageLevel.java
@@ -3,31 +3,34 @@ package io.github.mucsi96.learnlanguage.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@Getter
 public enum LanguageLevel {
-    A1("A1"),
-    A2("A2"),
-    B1("B1"),
-    B2("B2"),
-    C1("C1"),
-    C2("C2");
+    A1("A1", "A1 - Beginner"),
+    A2("A2", "A2 - Elementary"),
+    B1("B1", "B1 - Intermediate"),
+    B2("B2", "B2 - Upper Intermediate"),
+    C1("C1", "C1 - Advanced"),
+    C2("C2", "C2 - Proficient");
 
-    private final String level;
+    private final String code;
+    private final String displayName;
 
     @JsonValue
-    public String getLevel() {
-        return level;
+    public String getCode() {
+        return code;
     }
 
     @JsonCreator
-    public static LanguageLevel fromString(String level) {
+    public static LanguageLevel fromString(String code) {
         for (LanguageLevel languageLevel : values()) {
-            if (languageLevel.level.equalsIgnoreCase(level)) {
+            if (languageLevel.code.equalsIgnoreCase(code)) {
                 return languageLevel;
             }
         }
-        throw new IllegalArgumentException("Unknown language level: " + level);
+        throw new IllegalArgumentException("Unknown language level: " + code);
     }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceFormatType.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceFormatType.java
@@ -3,28 +3,31 @@ package io.github.mucsi96.learnlanguage.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@Getter
 public enum SourceFormatType {
-    WORD_LIST_WITH_EXAMPLES("wordListWithExamples"),
-    WORD_LIST_WITH_FORMS_AND_EXAMPLES("wordListWithFormsAndExamples"),
-    FLOWING_TEXT("flowingText");
+    WORD_LIST_WITH_EXAMPLES("wordListWithExamples", "Word list with examples"),
+    WORD_LIST_WITH_FORMS_AND_EXAMPLES("wordListWithFormsAndExamples", "Word list with forms and examples"),
+    FLOWING_TEXT("flowingText", "Flowing text");
 
-    private final String typeName;
+    private final String code;
+    private final String displayName;
 
     @JsonValue
-    public String getTypeName() {
-        return typeName;
+    public String getCode() {
+        return code;
     }
 
     @JsonCreator
-    public static SourceFormatType fromString(String typeName) {
+    public static SourceFormatType fromString(String code) {
         for (SourceFormatType type : values()) {
-            if (type.typeName.equalsIgnoreCase(typeName)) {
+            if (type.code.equalsIgnoreCase(code)) {
                 return type;
             }
         }
-        throw new IllegalArgumentException("Unknown source format type: " + typeName);
+        throw new IllegalArgumentException("Unknown source format type: " + code);
     }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceFormatType.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceFormatType.java
@@ -1,0 +1,30 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum SourceFormatType {
+    WORD_LIST_WITH_EXAMPLES("wordListWithExamples"),
+    WORD_LIST_WITH_FORMS_AND_EXAMPLES("wordListWithFormsAndExamples"),
+    FLOWING_TEXT("flowingText");
+
+    private final String typeName;
+
+    @JsonValue
+    public String getTypeName() {
+        return typeName;
+    }
+
+    @JsonCreator
+    public static SourceFormatType fromString(String typeName) {
+        for (SourceFormatType type : values()) {
+            if (type.typeName.equalsIgnoreCase(typeName)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown source format type: " + typeName);
+    }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceRequest.java
@@ -16,4 +16,5 @@ public class SourceRequest {
     private Integer startPage;
     private LanguageLevel languageLevel;
     private CardType cardType;
+    private SourceFormatType formatType;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceResponse.java
@@ -11,4 +11,5 @@ public class SourceResponse {
     private String fileName;
     private Integer startPage;
     private Integer cardCount;
+    private SourceFormatType formatType;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceResponse.java
@@ -11,5 +11,6 @@ public class SourceResponse {
     private String fileName;
     private Integer startPage;
     private Integer cardCount;
+    private LanguageLevel languageLevel;
     private SourceFormatType formatType;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/AreaWordsService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/AreaWordsService.java
@@ -37,7 +37,7 @@ public class AreaWordsService {
           The forms is a string array representing the different forms extracted from the document.
           In case of a noun it's the plural form.
           In case of verb it's the 3 forms of conjugation (Eg. Du gehst, Er/Sie/Es geht, Er/Sie/Es ist gegangen). Please enhance it to make those full words. Not just endings.""";
-      case WORD_LIST_WITH_EXAMPLES, FLOWING_TEXT, null -> """
+      case null, default -> """
 
           The forms is a string array representing the different forms. Since the document does not contain word forms, you must generate them.
           In case of a noun generate the plural form.
@@ -48,7 +48,7 @@ public class AreaWordsService {
       case WORD_LIST_WITH_EXAMPLES, WORD_LIST_WITH_FORMS_AND_EXAMPLES -> """
 
           The examples property is a string array enlisting the examples provided in the document.""";
-      case FLOWING_TEXT, null -> """
+      case null, default -> """
 
           The examples property is a string array. Since the document is flowing text without explicit examples, you must generate one context-relevant example sentence for each word that demonstrates its meaning and usage.""";
     };

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/AreaWordsService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/AreaWordsService.java
@@ -36,12 +36,12 @@ public class AreaWordsService {
 
           The forms is a string array representing the different forms extracted from the document.
           In case of a noun it's the plural form.
-          In case of verb it's the 3 forms of conjugation (Eg. Du gehst, Er/Sie/Es geht, Er/Sie/Es ist gegangen). Please enhance it to make those full words. Not just endings.""";
+          In case of verb it's the 3 forms of conjugation. Do NOT include pronouns (Du, Er/Sie/Es, etc.) - only the verb forms themselves (e.g., "gehst", "geht", "ist gegangen").""";
       case null, default -> """
 
           The forms is a string array representing the different forms. Since the document does not contain word forms, you must generate them.
           In case of a noun generate the plural form.
-          In case of verb generate the 3 forms of conjugation (Eg. Du gehst, Er/Sie/Es geht, Er/Sie/Es ist gegangen). Please make those full words. Not just endings.""";
+          In case of verb generate the 3 forms of conjugation. Do NOT include pronouns (Du, Er/Sie/Es, etc.) - only the verb forms themselves (e.g., "gehst", "geht", "ist gegangen").""";
     };
 
     String examplesPrompt = switch (formatType) {

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -8,8 +8,11 @@ CREATE TABLE IF NOT EXISTS learn_language.sources (
     name character varying(255),
     language_level character varying(255),
     card_type character varying(255),
+    format_type character varying(255),
     CONSTRAINT sources_pkey PRIMARY KEY (id)
 );
+
+ALTER TABLE learn_language.sources ADD COLUMN IF NOT EXISTS format_type character varying(255);
 
 CREATE TABLE IF NOT EXISTS learn_language.cards (
     id character varying(255) NOT NULL,

--- a/test/tests/sources.spec.ts
+++ b/test/tests/sources.spec.ts
@@ -120,6 +120,8 @@ test('can create a new source', async ({ page }) => {
   await page.getByLabel('Start Page').fill('1');
   await page.getByLabel('Language Level').click();
   await page.getByRole('option', { name: 'B2' }).click();
+  await page.getByLabel('Format Type').click();
+  await page.getByRole('option', { name: 'Word list with examples' }).click();
 
   // Click Create button
   await page.getByRole('button', { name: 'Create' }).click();
@@ -138,6 +140,7 @@ test('can create a new source', async ({ page }) => {
   expect(createdSource?.startPage).toBe(1);
   expect(createdSource?.languageLevel).toBe('B2');
   expect(createdSource?.cardType).toBe('VOCABULARY');
+  expect(createdSource?.formatType).toBe('WORD_LIST_WITH_EXAMPLES');
 });
 
 test('can edit an existing source', async ({ page }) => {
@@ -333,6 +336,10 @@ test('validates required fields when creating source', async ({ page }) => {
   });
 
   await page.getByLabel('Start Page').fill('1');
+  await page.getByLabel('Language Level').click();
+  await page.getByRole('option', { name: 'A1' }).click();
+  await page.getByLabel('Format Type').click();
+  await page.getByRole('option', { name: 'Word list with forms and examples' }).click();
 
   // Create button should now be enabled
   await expect(createButton).toBeEnabled();

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -42,6 +42,7 @@ export async function createSource(params: {
   startPage: number;
   languageLevel: string;
   cardType: string;
+  formatType: string;
   bookmarkedPage?: number | null;
 }): Promise<void> {
   const {
@@ -51,14 +52,15 @@ export async function createSource(params: {
     startPage,
     languageLevel,
     cardType,
+    formatType,
     bookmarkedPage = null,
   } = params;
 
   await withDbConnection(async (client) => {
     await client.query(
-      `INSERT INTO learn_language.sources (id, name, file_name, start_page, language_level, card_type, bookmarked_page)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-      [id, name, fileName, startPage, languageLevel, cardType, bookmarkedPage]
+      `INSERT INTO learn_language.sources (id, name, file_name, start_page, language_level, card_type, format_type, bookmarked_page)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+      [id, name, fileName, startPage, languageLevel, cardType, formatType, bookmarkedPage]
     );
   });
 }
@@ -70,13 +72,14 @@ export async function getSource(id: string): Promise<{
   startPage: number;
   languageLevel: string;
   cardType: string;
+  formatType: string;
   bookmarkedPage: number | null;
 } | null> {
   return withDbConnection(async (client) => {
     const result = await client.query(
       `SELECT id, name, file_name as "fileName", start_page as "startPage",
               language_level as "languageLevel", card_type as "cardType",
-              bookmarked_page as "bookmarkedPage"
+              format_type as "formatType", bookmarked_page as "bookmarkedPage"
        FROM learn_language.sources
        WHERE id = $1`,
       [id]
@@ -107,6 +110,7 @@ export async function cleanupDbRecords({ withSources }: { withSources?: boolean 
       startPage: 9,
       languageLevel: 'A1',
       cardType: 'VOCABULARY',
+      formatType: 'WORD_LIST_WITH_FORMS_AND_EXAMPLES',
       bookmarkedPage: 9,
     });
 
@@ -117,6 +121,7 @@ export async function cleanupDbRecords({ withSources }: { withSources?: boolean 
       startPage: 8,
       languageLevel: 'A2',
       cardType: 'VOCABULARY',
+      formatType: 'WORD_LIST_WITH_FORMS_AND_EXAMPLES',
       bookmarkedPage: 8,
     });
 
@@ -127,6 +132,7 @@ export async function cleanupDbRecords({ withSources }: { withSources?: boolean 
       startPage: 16,
       languageLevel: 'B1',
       cardType: 'VOCABULARY',
+      formatType: 'WORD_LIST_WITH_FORMS_AND_EXAMPLES',
       bookmarkedPage: null,
     });
   }


### PR DESCRIPTION
Introduce three source format types that affect word extraction:
- Word list with examples: expects examples in document, generates forms
- Word list with forms and examples: expects both forms and examples
- Flowing text: generates both forms and context-relevant examples

The AI prompt adapts based on format type to either extract or generate word forms and example sentences as needed.