### PR TITLE
Add start button to study page for audio

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
-- Fix ids to include both languages. Same for known words. 
+- Fix ids to include both languages. Same for known words.
 - support for speach card type
 - support for grammar card type
 - support multi part regions
 - support cross-page multi part regions
 - add smart card assigment to maximise the study session effectiveness based on ereview log
-- add a study button to fix the initial no auto audio issue

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -131,6 +131,6 @@ export type StudySession = {
 export type StudySessionCard = {
   card: Card;
   learningPartnerId: number | null;
-  presenterName: string;
+  turnName: string;
   studyMode: 'SOLO' | 'WITH_PARTNER';
 };

--- a/client/src/app/study-session.service.ts
+++ b/client/src/app/study-session.service.ts
@@ -60,6 +60,10 @@ export class StudySessionService {
     return session;
   }
 
+  setSessionId(sessionId: string) {
+    this.sessionId.set(sessionId);
+  }
+
   refreshSession() {
     this.sessionVersion.update((v) => v + 1);
     this.dueCardsService.refetchDueCounts();

--- a/client/src/app/study-session.service.ts
+++ b/client/src/app/study-session.service.ts
@@ -37,13 +37,13 @@ export class StudySessionService {
     injector: this.injector,
   });
 
-  readonly currentPresenter = computed<{ name: string; partnerId: number | null }>(() => {
+  readonly currentTurn = computed<{ name: string; partnerId: number | null }>(() => {
     const cardData = this.currentCard.value();
     if (!cardData) {
       return { name: 'Myself', partnerId: null };
     }
     return {
-      name: cardData.presenterName,
+      name: cardData.turnName,
       partnerId: cardData.learningPartnerId,
     };
   });

--- a/client/src/app/study/learn-card/learn-card.component.css
+++ b/client/src/app/study/learn-card/learn-card.component.css
@@ -35,6 +35,44 @@
   transform: scale(0.98);
 }
 
+.start-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 3rem;
+  min-height: 400px;
+  color: var(--mat-sys-on-surface-variant);
+}
+
+.start-icon {
+  font-size: 4rem;
+  width: 4rem;
+  height: 4rem;
+  margin-bottom: 1.5rem;
+  opacity: 0.6;
+}
+
+.start-state h2 {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+  color: var(--mat-sys-on-surface);
+  font-weight: 500;
+}
+
+.start-state p {
+  font-size: 1.1rem;
+  line-height: 1.6;
+  margin: 0.5rem 0 1.5rem 0;
+  max-width: 400px;
+}
+
+.start-state button {
+  font-size: 1.1rem;
+  padding: 0.75rem 2rem;
+}
+
 .empty-state {
   display: flex;
   flex-direction: column;

--- a/client/src/app/study/learn-card/learn-card.component.css
+++ b/client/src/app/study/learn-card/learn-card.component.css
@@ -6,7 +6,7 @@
   max-width: 1200px;
 }
 
-.presenter-indicator {
+.turn-indicator {
   position: absolute;
   bottom: 12px;
   right: 12px;

--- a/client/src/app/study/learn-card/learn-card.component.html
+++ b/client/src/app/study/learn-card/learn-card.component.html
@@ -1,4 +1,14 @@
-@if (currentCardData.isLoading()) {
+@if (!sessionStarted()) {
+<div class="start-state">
+  <mat-icon class="start-icon">school</mat-icon>
+  <h2>Ready to study?</h2>
+  <p>Click start to begin your study session.</p>
+  <button mat-flat-button color="primary" (click)="startSession()" aria-label="Start study session">
+    <mat-icon>play_arrow</mat-icon>
+    Start
+  </button>
+</div>
+} @else if (currentCardData.isLoading()) {
 <div class="learn-card-container">
   <div class="learn-card">
     <app-learn-card-skeleton />

--- a/client/src/app/study/learn-card/learn-card.component.html
+++ b/client/src/app/study/learn-card/learn-card.component.html
@@ -29,7 +29,7 @@
     (click)="toggleReveal()"
   >
     @if (isStudyingWithPartner()) {
-    <span class="presenter-indicator" role="status" aria-live="polite">
+    <span class="presenter-indicator" role="status" aria-label="Current presenter" aria-live="polite">
       {{ currentPresenter().name }}
     </span>
     }

--- a/client/src/app/study/learn-card/learn-card.component.html
+++ b/client/src/app/study/learn-card/learn-card.component.html
@@ -1,4 +1,4 @@
-@if (!sessionStarted()) {
+@if (!sessionId()) {
 <div class="start-state">
   <mat-icon class="start-icon">school</mat-icon>
   <h2>Ready to study?</h2>

--- a/client/src/app/study/learn-card/learn-card.component.html
+++ b/client/src/app/study/learn-card/learn-card.component.html
@@ -29,7 +29,7 @@
     (click)="toggleReveal()"
   >
     @if (isStudyingWithPartner()) {
-    <span class="presenter-indicator" role="status" aria-label="Current presenter" aria-live="polite">
+    <span class="presenter-indicator" role="status" aria-label="Current turn" aria-live="polite">
       {{ currentPresenter().name }}
     </span>
     }

--- a/client/src/app/study/learn-card/learn-card.component.html
+++ b/client/src/app/study/learn-card/learn-card.component.html
@@ -29,8 +29,8 @@
     (click)="toggleReveal()"
   >
     @if (isStudyingWithPartner()) {
-    <span class="presenter-indicator" role="status" aria-label="Current turn" aria-live="polite">
-      {{ currentPresenter().name }}
+    <span class="turn-indicator" role="status" aria-label="Current turn" aria-live="polite">
+      {{ currentTurn().name }}
     </span>
     }
     <app-card-actions

--- a/client/src/app/study/learn-card/learn-card.component.html
+++ b/client/src/app/study/learn-card/learn-card.component.html
@@ -50,7 +50,7 @@
   @if (isRevealed()) {
     <app-card-grading-buttons
       [card]="cardResource"
-      [learningPartnerId]="currentPresenter().partnerId"
+      [learningPartnerId]="currentTurn().partnerId"
       (cardProcessed)="onCardProcessed()">
     </app-card-grading-buttons>
   }

--- a/client/src/app/study/learn-card/learn-card.component.ts
+++ b/client/src/app/study/learn-card/learn-card.component.ts
@@ -75,8 +75,7 @@ export class LearnCardComponent implements OnDestroy {
         this.sessionId.set(urlSessionId);
         this.studySessionService.setSessionId(urlSessionId);
       } else if (!urlSessionId && this.sessionId()) {
-        this.sessionId.set(null);
-        this.studySessionService.clearSession();
+        this.clearSessionState();
       }
     });
 
@@ -85,15 +84,19 @@ export class LearnCardComponent implements OnDestroy {
         const sourceChanged = this.currentSourceId !== null && this.currentSourceId !== params['sourceId'];
         this.currentSourceId = params['sourceId'];
         if (sourceChanged) {
-          this.sessionId.set(null);
-          this.studySessionService.clearSession();
-          this.router.navigate([], {
-            relativeTo: this.route,
-            queryParams: { session: null },
-            queryParamsHandling: 'merge',
-          });
+          this.clearSessionState();
         }
       }
+    });
+  }
+
+  private clearSessionState() {
+    this.sessionId.set(null);
+    this.studySessionService.clearSession();
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { session: null },
+      queryParamsHandling: 'merge',
     });
   }
 

--- a/client/src/app/study/learn-card/learn-card.component.ts
+++ b/client/src/app/study/learn-card/learn-card.component.ts
@@ -66,7 +66,7 @@ export class LearnCardComponent implements OnDestroy {
     return cardData?.studyMode === 'WITH_PARTNER';
   });
 
-  readonly currentPresenter = this.studySessionService.currentPresenter;
+  readonly currentTurn = this.studySessionService.currentTurn;
 
   constructor() {
     this.route.queryParams.subscribe((queryParams) => {

--- a/client/src/app/study/learn-card/learn-card.component.ts
+++ b/client/src/app/study/learn-card/learn-card.component.ts
@@ -6,6 +6,7 @@ import {
   OnDestroy,
 } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
 import { StudySessionService } from '../../study-session.service';
 import { ActivatedRoute } from '@angular/router';
 import { CommonModule } from '@angular/common';
@@ -26,6 +27,7 @@ import { CardResourceLike } from '../../shared/types/card-resource.types';
   imports: [
     CommonModule,
     MatCardModule,
+    MatButtonModule,
     MatIconModule,
     CardGradingButtonsComponent,
     CardActionsComponent,
@@ -53,8 +55,10 @@ export class LearnCardComponent implements OnDestroy {
   });
 
   readonly isRevealed = signal(false);
+  readonly sessionStarted = signal(false);
   private lastPlayedTexts: string[] = [];
   readonly languageTexts = signal<LanguageTexts[]>([]);
+  private currentSourceId: string | null = null;
 
   readonly isStudyingWithPartner = computed(() => {
     const cardData = this.currentCardData.value();
@@ -66,9 +70,17 @@ export class LearnCardComponent implements OnDestroy {
   constructor() {
     this.route.params.subscribe((params) => {
       if (params['sourceId']) {
-        this.studySessionService.createSession(params['sourceId']);
+        this.currentSourceId = params['sourceId'];
+        this.sessionStarted.set(false);
       }
     });
+  }
+
+  startSession() {
+    if (this.currentSourceId) {
+      this.studySessionService.createSession(this.currentSourceId);
+      this.sessionStarted.set(true);
+    }
   }
 
   ngOnDestroy() {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/StudySessionCardResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/StudySessionCardResponse.java
@@ -13,6 +13,6 @@ import lombok.NoArgsConstructor;
 public class StudySessionCardResponse {
     private Card card;
     private Integer learningPartnerId;
-    private String presenterName;
+    private String turnName;
     private String studyMode;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/StudySessionService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/StudySessionService.java
@@ -121,7 +121,7 @@ public class StudySessionService {
                             .min(Comparator.comparing(StudySessionCard::getPosition));
 
                     return nextCard.map(sessionCard -> {
-                        String presenterName = sessionCard.getLearningPartner() != null
+                        String turnName = sessionCard.getLearningPartner() != null
                                 ? sessionCard.getLearningPartner().getName()
                                 : getCurrentUserFirstName();
 
@@ -130,7 +130,7 @@ public class StudySessionService {
                                 .learningPartnerId(sessionCard.getLearningPartner() != null
                                         ? sessionCard.getLearningPartner().getId()
                                         : null)
-                                .presenterName(presenterName)
+                                .turnName(turnName)
                                 .studyMode(session.getStudyMode())
                                 .build();
                     });

--- a/test/tests/audio-sequencing.spec.ts
+++ b/test/tests/audio-sequencing.spec.ts
@@ -29,6 +29,7 @@ test('audio plays sequentially', async ({ page }) => {
 
   // Navigate to a study page with cards that have audio
   await page.goto('/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   await page.getByRole('heading', { name: 'helló' }).click();
 
@@ -119,6 +120,7 @@ test('voice selection dialog shows only enabled voice configurations', async ({ 
 
   // Navigate to study page
   await page.goto('/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
   await expect(page.getByRole('heading', { name: 'ház' })).toBeVisible();
 
   // Click the voice selection button
@@ -158,6 +160,7 @@ test('voice selection dialog shows no voices when no configurations exist', asyn
 
   // Navigate to study page
   await page.goto('/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
   await expect(page.getByRole('heading', { name: 'autó' })).toBeVisible();
 
   // Click the voice selection button
@@ -201,6 +204,7 @@ test('voice selection dialog displays model for each voice configuration', async
   });
 
   await page.goto('/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
   await expect(page.getByRole('heading', { name: 'teszt' })).toBeVisible();
 
   await page.getByRole('button', { name: 'Voice Selection' }).click();

--- a/test/tests/learning-partners.spec.ts
+++ b/test/tests/learning-partners.spec.ts
@@ -107,8 +107,9 @@ test('study page shows presenter indicator when partner is active', async ({ pag
   });
 
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
-  await expect(page.locator('.presenter-indicator')).toBeVisible();
+  await expect(page.getByRole('status', { name: 'Current presenter' })).toBeVisible();
 });
 
 test('study page alternates between user and active partner', async ({ page }) => {
@@ -137,9 +138,9 @@ test('study page alternates between user and active partner', async ({ page }) =
   });
 
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
-  const presenterIndicator = page.locator('.presenter-indicator');
-  const initialPresenter = await presenterIndicator.textContent();
+  const presenterIndicator = page.getByRole('status', { name: 'Current presenter' });
 
   await page.getByRole('heading', { name: 'első' }).click();
   await page.getByRole('button', { name: 'Good' }).click();
@@ -160,8 +161,9 @@ test('study page does not show presenter indicator when no partner is active', a
   });
 
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
-  await expect(page.locator('.presenter-indicator')).not.toBeVisible();
+  await expect(page.getByRole('status', { name: 'Current presenter' })).not.toBeVisible();
 });
 
 test('review log records learning partner when grading', async ({ page }) => {
@@ -190,6 +192,7 @@ test('review log records learning partner when grading', async ({ page }) => {
   });
 
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   const flashcard = page.getByRole('article', { name: 'Flashcard' });
   await flashcard.getByRole('heading', { name: 'első' }).click();
@@ -219,6 +222,7 @@ test('review log has null learning partner when no partner is active', async ({ 
   });
 
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   const flashcard = page.getByRole('article', { name: 'Flashcard' });
   await flashcard.getByRole('heading', { name: 'tanulni' }).click();

--- a/test/tests/learning-partners.spec.ts
+++ b/test/tests/learning-partners.spec.ts
@@ -93,7 +93,7 @@ test('can delete a learning partner', async ({ page }) => {
   expect(partners.length).toBe(0);
 });
 
-test('study page shows presenter indicator when partner is active', async ({ page }) => {
+test('study page shows turn indicator when partner is active', async ({ page }) => {
   await createLearningPartner({ name: 'Alice', isActive: true });
   await createCard({
     cardId: 'test-card',
@@ -140,15 +140,15 @@ test('study page alternates between user and active partner', async ({ page }) =
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
   await page.getByRole('button', { name: 'Start study session' }).click();
 
-  const presenterIndicator = page.getByRole('status', { name: 'Current turn' });
+  const turnIndicator = page.getByRole('status', { name: 'Current turn' });
 
   await page.getByRole('heading', { name: 'első' }).click();
   await page.getByRole('button', { name: 'Good' }).click();
 
-  await expect(presenterIndicator).toContainText('Alice');
+  await expect(turnIndicator).toContainText('Alice');
 });
 
-test('study page does not show presenter indicator when no partner is active', async ({ page }) => {
+test('study page does not show turn indicator when no partner is active', async ({ page }) => {
   await createCard({
     cardId: 'test-card',
     sourceId: 'goethe-a1',

--- a/test/tests/learning-partners.spec.ts
+++ b/test/tests/learning-partners.spec.ts
@@ -109,7 +109,7 @@ test('study page shows presenter indicator when partner is active', async ({ pag
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
   await page.getByRole('button', { name: 'Start study session' }).click();
 
-  await expect(page.getByRole('status', { name: 'Current presenter' })).toBeVisible();
+  await expect(page.getByRole('status', { name: 'Current turn' })).toBeVisible();
 });
 
 test('study page alternates between user and active partner', async ({ page }) => {
@@ -140,7 +140,7 @@ test('study page alternates between user and active partner', async ({ page }) =
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
   await page.getByRole('button', { name: 'Start study session' }).click();
 
-  const presenterIndicator = page.getByRole('status', { name: 'Current presenter' });
+  const presenterIndicator = page.getByRole('status', { name: 'Current turn' });
 
   await page.getByRole('heading', { name: 'első' }).click();
   await page.getByRole('button', { name: 'Good' }).click();
@@ -163,7 +163,7 @@ test('study page does not show presenter indicator when no partner is active', a
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
   await page.getByRole('button', { name: 'Start study session' }).click();
 
-  await expect(page.getByRole('status', { name: 'Current presenter' })).not.toBeVisible();
+  await expect(page.getByRole('status', { name: 'Current turn' })).not.toBeVisible();
 });
 
 test('review log records learning partner when grading', async ({ page }) => {

--- a/test/tests/study-page.spec.ts
+++ b/test/tests/study-page.spec.ts
@@ -19,6 +19,33 @@ test('study page shows start button initially', async ({ page }) => {
   await expect(page.getByRole('button', { name: 'Start study session' })).toBeVisible();
 });
 
+test('study session persists in URL and survives page refresh', async ({ page }) => {
+  await createCard({
+    cardId: 'persist_test',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 5,
+    data: {
+      word: 'bleiben',
+      type: 'VERB',
+      translation: { en: 'to stay', hu: 'maradni', ch: 'bliibe' },
+    },
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
+
+  const flashcard = page.getByRole('article', { name: 'Flashcard' });
+  await expect(flashcard.getByRole('heading', { name: 'maradni' })).toBeVisible();
+
+  const url = page.url();
+  expect(url).toContain('session=');
+
+  await page.reload();
+
+  await expect(flashcard.getByRole('heading', { name: 'maradni' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Start study session' })).not.toBeVisible();
+});
+
 test('study page initial state', async ({ page }) => {
   const image1 = uploadMockImage(yellowImage);
   const image2 = uploadMockImage(greenImage);

--- a/test/tests/study-page.spec.ts
+++ b/test/tests/study-page.spec.ts
@@ -11,6 +11,14 @@ import {
 } from '../utils';
 import { v4 as uuidv4 } from 'uuid';
 
+test('study page shows start button initially', async ({ page }) => {
+  await page.goto('http://localhost:8180/sources/goethe-a1/study');
+
+  await expect(page.getByRole('heading', { name: 'Ready to study?' })).toBeVisible();
+  await expect(page.getByText('Click start to begin your study session.')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Start study session' })).toBeVisible();
+});
+
 test('study page initial state', async ({ page }) => {
   const image1 = uploadMockImage(yellowImage);
   const image2 = uploadMockImage(greenImage);
@@ -45,6 +53,7 @@ test('study page initial state', async ({ page }) => {
   });
 
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   const flashcard = page.getByRole('article', { name: 'Flashcard' });
   await expect(flashcard.getByRole('heading', { level: 2, name: 'elindulni, elhagyni' })).toBeVisible();
@@ -99,6 +108,7 @@ test('study page revealed state', async ({ page }) => {
 
   // Navigate to study page
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   const flashcard = page.getByRole('article', { name: 'Flashcard' });
   await flashcard.getByText('elindulni, elhagyni', { exact: true }).click();
@@ -169,6 +179,7 @@ test('source selector routing works', async ({ page }) => {
 
   // Start from the first source
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
   const flashcard = page.getByRole('article', { name: 'Flashcard' });
   await expect(flashcard.getByRole('heading', { name: 'tanulni' })).toBeVisible();
 
@@ -180,6 +191,9 @@ test('source selector routing works', async ({ page }) => {
 
   // URL should change
   await expect(page).toHaveURL('http://localhost:8180/sources/goethe-a2/study');
+
+  // Click start button for new source
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   // Content should change to the card from the second source
   await expect(flashcard.getByRole('heading', { name: 'írni' })).toBeVisible();
@@ -196,6 +210,7 @@ test('source selector shows proper stats', async ({ page }) => {
 
   // Navigate to the study page
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   await expect(page.getByRole('navigation').getByTitle('New', { exact: true })).toHaveText('3');
   await expect(page.getByRole('navigation').getByTitle('Learning', { exact: true })).toHaveText('2');
@@ -217,6 +232,7 @@ test('source selector stats update after changing source', async ({ page }) => {
 
   // Navigate to the first source
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   await expect(page.getByRole('navigation').getByTitle('New', { exact: true })).toHaveText('3');
   await expect(page.getByRole('navigation').getByTitle('Learning', { exact: true })).toHaveText('2');
@@ -226,6 +242,9 @@ test('source selector stats update after changing source', async ({ page }) => {
 
   // Select the second source
   await page.getByRole('menuitem', { name: 'Goethe A2' }).click();
+
+  // Click start button for new source
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   await expect(page.getByRole('navigation').getByTitle('New', { exact: true })).toHaveText('1');
   await expect(page.getByRole('navigation').getByTitle('Learning', { exact: true })).toHaveText('4');
@@ -246,6 +265,7 @@ test('source selector dropdown shows stats', async ({ page }) => {
 
   // Navigate to the study page
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   // Open the source selector dropdown
   await page.getByRole('button', { name: 'Goethe A1' }).click();
@@ -292,6 +312,7 @@ test('cards with in review readiness not shown on study page', async ({ page }) 
 
   // Navigate to the study page
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   const flashcard = page.getByRole('article', { name: 'Flashcard' });
   await expect(page.getByRole('navigation').getByTitle('Review', { exact: true })).toHaveText('1');
@@ -322,6 +343,7 @@ test('mark for review button visible on study page', async ({ page }) => {
   });
 
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   // Verify Mark for Review button is visible
   const markReviewButton = page.getByRole('button', { name: 'Mark for Review' });
@@ -353,6 +375,7 @@ test('edit card button visible on study page', async ({ page }) => {
   });
 
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   // Verify Edit Card button is visible
   const editButton = page.getByRole('link', { name: 'Edit Card' });
@@ -383,6 +406,7 @@ test('mark for review button functionality', async ({ page }) => {
   });
 
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   // Click the Mark for Review button
   await page.getByRole('button', { name: 'Mark for Review' }).click();
@@ -442,6 +466,7 @@ test('mark for review button loads next card', async ({ page }) => {
   });
 
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   const flashcard = page.getByRole('article', { name: 'Flashcard' });
 
@@ -481,6 +506,7 @@ test('edit card button navigation', async ({ page }) => {
   });
 
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   // Click the Edit Card button
   await page.getByRole('link', { name: 'Edit Card' }).click();
@@ -513,6 +539,7 @@ test('grading buttons visibility after reveal', async ({ page }) => {
   });
 
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   const flashcard = page.getByRole('article', { name: 'Flashcard' });
 
@@ -576,6 +603,7 @@ test('again button functionality', async ({ page }) => {
   });
 
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   const flashcard = page.getByRole('article', { name: 'Flashcard' });
 
@@ -636,6 +664,7 @@ test('hard button functionality', async ({ page }) => {
   });
 
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   const flashcard = page.getByRole('article', { name: 'Flashcard' });
 
@@ -695,6 +724,7 @@ test('good button functionality', async ({ page }) => {
   });
 
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   const flashcard = page.getByRole('article', { name: 'Flashcard' });
 
@@ -754,6 +784,7 @@ test('easy button functionality', async ({ page }) => {
   });
 
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   const flashcard = page.getByRole('article', { name: 'Flashcard' });
 
@@ -794,6 +825,7 @@ test('grading card updates database', async ({ page }) => {
   });
 
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   const flashcard = page.getByRole('article', { name: 'Flashcard' });
 
@@ -847,6 +879,7 @@ test('grading card creates review log', async ({ page }) => {
   });
 
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   const flashcard = page.getByRole('article', { name: 'Flashcard' });
 
@@ -895,6 +928,7 @@ test('grading with no next card shows empty state', async ({ page }) => {
   });
 
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   const flashcard = page.getByRole('article', { name: 'Flashcard' });
 
@@ -942,6 +976,7 @@ test('cards due more than 1 hour from now are removed from session', async ({ pa
   });
 
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   const flashcard = page.getByRole('article', { name: 'Flashcard' });
 
@@ -1003,6 +1038,7 @@ test('most recently reviewed card moves to back of queue', async ({ page }) => {
   });
 
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   const flashcard = page.getByRole('article', { name: 'Flashcard' });
 
@@ -1053,6 +1089,7 @@ test('card graded with Again reappears after other due cards', async ({ page }) 
   });
 
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
 
   const flashcard = page.getByRole('article', { name: 'Flashcard' });
 


### PR DESCRIPTION
Browsers block audio autoplay without prior user interaction. This adds a start button that creates the study session only when clicked, ensuring subsequent audio playback is allowed by the browser.