### PR TITLE
claude/card-actions-context-menu-3t1Pq

### DIFF
--- a/client/src/app/shared/card-actions/card-actions.component.css
+++ b/client/src/app/shared/card-actions/card-actions.component.css
@@ -10,6 +10,9 @@
   color: var(--mat-sys-on-surface-variant) !important;
   width: 32px !important;
   height: 32px !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
 }
 
 .menu-trigger:hover {

--- a/client/src/app/shared/card-actions/card-actions.component.css
+++ b/client/src/app/shared/card-actions/card-actions.component.css
@@ -1,31 +1,24 @@
 .card-actions {
-  position: absolute;
-  top: 0.75rem;
-  left: 0.75rem;
   display: flex;
-  gap: 0.25rem;
-  z-index: 10;
+  align-items: center;
 }
 
-.action-button {
+.menu-trigger {
   opacity: 0.6;
   transition: opacity 0.2s ease;
   background: rgba(0, 0, 0, 0.1) !important;
   color: var(--mat-sys-on-surface-variant) !important;
   width: 32px !important;
   height: 32px !important;
-  display: flex !important;
-  align-items: center !important;
-  justify-content: center !important;
 }
 
-.action-button:hover {
+.menu-trigger:hover {
   opacity: 1;
   background: rgba(0, 0, 0, 0.2) !important;
 }
 
-.action-button mat-icon {
-  font-size: 18px;
-  width: 18px;
-  height: 18px;
+.menu-trigger mat-icon {
+  font-size: 20px;
+  width: 20px;
+  height: 20px;
 }

--- a/client/src/app/shared/card-actions/card-actions.component.html
+++ b/client/src/app/shared/card-actions/card-actions.component.html
@@ -1,27 +1,27 @@
 <div class="card-actions">
   <button
     mat-icon-button
-    class="action-button"
-    (click)="openVoiceSelection($event)"
-    title="Voice Selection"
-    matTooltip="Voice Selection">
-    <mat-icon>record_voice_over</mat-icon>
-  </button>
-  <button
-    mat-icon-button
-    class="action-button"
-    (click)="markForReview($event)"
-    title="Mark for Review"
-    matTooltip="Mark for Review">
-    <mat-icon>flag</mat-icon>
-  </button>
-  <a
-    mat-icon-button
-    class="action-button"
-    [routerLink]="['/sources', card()?.value()?.source?.id, 'page', card()?.value()?.sourcePageNumber, 'cards', card()?.value()?.id]"
+    class="menu-trigger"
+    [matMenuTriggerFor]="actionsMenu"
     (click)="$event.stopPropagation()"
-    title="Edit Card"
-    matTooltip="Edit Card">
-    <mat-icon>edit</mat-icon>
-  </a>
+    aria-label="Card actions">
+    <mat-icon>more_vert</mat-icon>
+  </button>
+
+  <mat-menu #actionsMenu="matMenu">
+    <button mat-menu-item (click)="openVoiceSelection()">
+      <mat-icon>record_voice_over</mat-icon>
+      <span>Voice Selection</span>
+    </button>
+    <button mat-menu-item (click)="markForReview()">
+      <mat-icon>flag</mat-icon>
+      <span>Mark for Review</span>
+    </button>
+    <a
+      mat-menu-item
+      [routerLink]="['/sources', card()?.value()?.source?.id, 'page', card()?.value()?.sourcePageNumber, 'cards', card()?.value()?.id]">
+      <mat-icon>edit</mat-icon>
+      <span>Edit Card</span>
+    </a>
+  </mat-menu>
 </div>

--- a/client/src/app/shared/card-actions/card-actions.component.ts
+++ b/client/src/app/shared/card-actions/card-actions.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, input, output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
-import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatMenuModule } from '@angular/material/menu';
 import { RouterModule } from '@angular/router';
 import { HttpClient } from '@angular/common/http';
 import { MatDialog } from '@angular/material/dialog';
@@ -16,7 +16,7 @@ import { CardResourceLike } from '../types/card-resource.types';
   imports: [
     MatButtonModule,
     MatIconModule,
-    MatTooltipModule,
+    MatMenuModule,
     RouterModule,
   ],
   templateUrl: './card-actions.component.html',

--- a/client/src/app/study/learn-card/learn-card.component.css
+++ b/client/src/app/study/learn-card/learn-card.component.css
@@ -6,17 +6,27 @@
   max-width: 1200px;
 }
 
-.turn-indicator {
+.card-bottom-controls {
   position: absolute;
   bottom: 12px;
   right: 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  z-index: 10;
+}
+
+.card-bottom-controls app-card-actions {
+  display: contents;
+}
+
+.turn-indicator {
   padding: 4px 10px;
   background: rgba(255, 255, 255, 0.1);
   color: var(--mat-sys-on-surface-variant);
   border-radius: 12px;
   font-size: 0.75rem;
   font-weight: 500;
-  z-index: 10;
 }
 
 .learn-card {

--- a/client/src/app/study/learn-card/learn-card.component.css
+++ b/client/src/app/study/learn-card/learn-card.component.css
@@ -41,7 +41,7 @@
   margin-bottom: 1rem;
 }
 
-.learn-card:active {
+.learn-card:active:not(:has(.card-bottom-controls:active)) {
   transform: scale(0.98);
 }
 

--- a/client/src/app/study/learn-card/learn-card.component.html
+++ b/client/src/app/study/learn-card/learn-card.component.html
@@ -28,16 +28,18 @@
     [class.revealed]="isRevealed()"
     (click)="toggleReveal()"
   >
-    @if (isStudyingWithPartner()) {
-    <span class="turn-indicator" role="status" aria-label="Current turn" aria-live="polite">
-      {{ currentTurn().name }}
-    </span>
-    }
-    <app-card-actions
-      [card]="cardResource"
-      [languageTexts]="languageTexts()"
-      (cardProcessed)="onCardProcessed()">
-    </app-card-actions>
+    <div class="card-bottom-controls">
+      <app-card-actions
+        [card]="cardResource"
+        [languageTexts]="languageTexts()"
+        (cardProcessed)="onCardProcessed()">
+      </app-card-actions>
+      @if (isStudyingWithPartner()) {
+      <span class="turn-indicator" role="status" aria-label="Current turn" aria-live="polite">
+        {{ currentTurn().name }}
+      </span>
+      }
+    </div>
 
     <app-learn-vocabulary-card
       [card]="cardResource"

--- a/client/src/app/study/learn-card/learn-card.component.html
+++ b/client/src/app/study/learn-card/learn-card.component.html
@@ -29,16 +29,16 @@
     (click)="toggleReveal()"
   >
     <div class="card-bottom-controls">
-      <app-card-actions
-        [card]="cardResource"
-        [languageTexts]="languageTexts()"
-        (cardProcessed)="onCardProcessed()">
-      </app-card-actions>
       @if (isStudyingWithPartner()) {
       <span class="turn-indicator" role="status" aria-label="Current turn" aria-live="polite">
         {{ currentTurn().name }}
       </span>
       }
+      <app-card-actions
+        [card]="cardResource"
+        [languageTexts]="languageTexts()"
+        (cardProcessed)="onCardProcessed()">
+      </app-card-actions>
     </div>
 
     <app-learn-vocabulary-card

--- a/test/tests/audio-sequencing.spec.ts
+++ b/test/tests/audio-sequencing.spec.ts
@@ -123,8 +123,8 @@ test('voice selection dialog shows only enabled voice configurations', async ({ 
   await page.getByRole('button', { name: 'Start study session' }).click();
   await expect(page.getByRole('heading', { name: 'ház' })).toBeVisible();
 
-  // Click the voice selection button
-  await page.getByRole('button', { name: 'Voice Selection' }).click();
+  await page.getByRole('button', { name: 'Card actions' }).click();
+  await page.getByRole('menuitem', { name: 'Voice Selection' }).click();
 
   // Wait for dialog to open
   await expect(page.getByRole('heading', { name: 'Voice Selection' })).toBeVisible();
@@ -163,8 +163,8 @@ test('voice selection dialog shows no voices when no configurations exist', asyn
   await page.getByRole('button', { name: 'Start study session' }).click();
   await expect(page.getByRole('heading', { name: 'autó' })).toBeVisible();
 
-  // Click the voice selection button
-  await page.getByRole('button', { name: 'Voice Selection' }).click();
+  await page.getByRole('button', { name: 'Card actions' }).click();
+  await page.getByRole('menuitem', { name: 'Voice Selection' }).click();
 
   // Wait for dialog to open
   await expect(page.getByRole('heading', { name: 'Voice Selection' })).toBeVisible();
@@ -207,7 +207,8 @@ test('voice selection dialog displays model for each voice configuration', async
   await page.getByRole('button', { name: 'Start study session' }).click();
   await expect(page.getByRole('heading', { name: 'teszt' })).toBeVisible();
 
-  await page.getByRole('button', { name: 'Voice Selection' }).click();
+  await page.getByRole('button', { name: 'Card actions' }).click();
+  await page.getByRole('menuitem', { name: 'Voice Selection' }).click();
   await expect(page.getByRole('heading', { name: 'Voice Selection' })).toBeVisible();
 
   // Verify both voices with their respective models are displayed

--- a/test/tests/study-page.spec.ts
+++ b/test/tests/study-page.spec.ts
@@ -347,7 +347,7 @@ test('cards with in review readiness not shown on study page', async ({ page }) 
   await expect(flashcard.getByLabel('State: Review')).toBeVisible();
 });
 
-test('mark for review button visible on study page', async ({ page }) => {
+test('mark for review menu item visible in context menu', async ({ page }) => {
   await createCard({
     cardId: 'testen-tesztelni',
     sourceId: 'goethe-a1',
@@ -372,13 +372,11 @@ test('mark for review button visible on study page', async ({ page }) => {
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
   await page.getByRole('button', { name: 'Start study session' }).click();
 
-  // Verify Mark for Review button is visible
-  const markReviewButton = page.getByRole('button', { name: 'Mark for Review' });
-  await expect(markReviewButton).toBeVisible();
-  await expect(markReviewButton.getByText('flag')).toBeVisible();
+  await page.getByRole('button', { name: 'Card actions' }).click();
+  await expect(page.getByRole('menuitem', { name: 'Mark for Review' })).toBeVisible();
 });
 
-test('edit card button visible on study page', async ({ page }) => {
+test('edit card menu item visible in context menu', async ({ page }) => {
   await createCard({
     cardId: 'bearbeiten-szerkeszteni',
     sourceId: 'goethe-a1',
@@ -404,10 +402,8 @@ test('edit card button visible on study page', async ({ page }) => {
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
   await page.getByRole('button', { name: 'Start study session' }).click();
 
-  // Verify Edit Card button is visible
-  const editButton = page.getByRole('link', { name: 'Edit Card' });
-  await expect(editButton).toBeVisible();
-  await expect(editButton.getByText('edit')).toBeVisible();
+  await page.getByRole('button', { name: 'Card actions' }).click();
+  await expect(page.getByRole('menuitem', { name: 'Edit Card' })).toBeVisible();
 });
 
 test('mark for review button functionality', async ({ page }) => {
@@ -435,8 +431,8 @@ test('mark for review button functionality', async ({ page }) => {
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
   await page.getByRole('button', { name: 'Start study session' }).click();
 
-  // Click the Mark for Review button
-  await page.getByRole('button', { name: 'Mark for Review' }).click();
+  await page.getByRole('button', { name: 'Card actions' }).click();
+  await page.getByRole('menuitem', { name: 'Mark for Review' }).click();
 
   await expect(page.getByText('All caught up!')).toBeVisible();
 
@@ -500,8 +496,8 @@ test('mark for review button loads next card', async ({ page }) => {
   // Verify first card is showing (due earlier)
   await expect(flashcard.getByRole('heading', { name: 'első' })).toBeVisible();
 
-  // Click Mark for Review button
-  await page.getByRole('button', { name: 'Mark for Review' }).click();
+  await page.getByRole('button', { name: 'Card actions' }).click();
+  await page.getByRole('menuitem', { name: 'Mark for Review' }).click();
 
   // Verify the second card is now showing
   await expect(flashcard.getByRole('heading', { name: 'második' })).toBeVisible();
@@ -535,8 +531,8 @@ test('edit card button navigation', async ({ page }) => {
   await page.goto('http://localhost:8180/sources/goethe-a1/study');
   await page.getByRole('button', { name: 'Start study session' }).click();
 
-  // Click the Edit Card button
-  await page.getByRole('link', { name: 'Edit Card' }).click();
+  await page.getByRole('button', { name: 'Card actions' }).click();
+  await page.getByRole('menuitem', { name: 'Edit Card' }).click();
 
   // Verify we navigated to the correct card editing page
   await expect(page.getByLabel('German translation', { exact: true })).toHaveValue('navigieren');


### PR DESCRIPTION
Move card actions from top-left icon buttons to a bottom-right context menu with three-dots trigger button. The menu is positioned just before the turn indicator for better UX and follows Angular Material guidelines.