### PR TITLE
claude/add-speech-card-type-SxvHT

### DIFF
--- a/client/src/app/cardTypes/card-type.registry.ts
+++ b/client/src/app/cardTypes/card-type.registry.ts
@@ -1,5 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { VocabularyCardType } from './vocabulary-card-type.strategy';
+import { SpeechCardType } from './speech-card-type.strategy';
 import { CardTypeStrategy, CardType } from '../parser/types';
 
 @Injectable({
@@ -7,11 +8,14 @@ import { CardTypeStrategy, CardType } from '../parser/types';
 })
 export class CardTypeRegistry {
   private readonly vocabularyStrategy = inject(VocabularyCardType);
+  private readonly speechStrategy = inject(SpeechCardType);
 
   getStrategy(cardType: CardType | undefined): CardTypeStrategy {
     switch (cardType) {
       case 'vocabulary':
         return this.vocabularyStrategy;
+      case 'speech':
+        return this.speechStrategy;
       default:
         throw new Error(`Unknown card type: ${cardType}. Please configure a valid card type.`);
     }

--- a/client/src/app/cardTypes/speech-card-type.strategy.ts
+++ b/client/src/app/cardTypes/speech-card-type.strategy.ts
@@ -1,0 +1,105 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { fetchJson } from '../utils/fetchJson';
+import { MultiModelService } from '../multi-model.service';
+import {
+  CardTypeStrategy,
+  CardCreationRequest,
+  CardCreationResult,
+  CardType,
+  ImageGenerationInfo,
+  ExtractionRequest,
+  ExtractedItem,
+  SentenceList,
+  Sentence,
+} from '../parser/types';
+
+interface SentenceIdResponse {
+  id: string;
+  exists: boolean;
+}
+
+interface SentenceTranslationResponse {
+  translation: string;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SpeechCardType implements CardTypeStrategy {
+  readonly cardType: CardType = 'speech';
+
+  private readonly http = inject(HttpClient);
+  private readonly multiModelService = inject(MultiModelService);
+
+  async extractItems(request: ExtractionRequest): Promise<ExtractedItem[]> {
+    const { sourceId, pageNumber, x, y, width, height } = request;
+
+    const sentenceList = await this.multiModelService.call<SentenceList>(
+      'sentence_extraction',
+      (model: string) =>
+        fetchJson<SentenceList>(
+          this.http,
+          `/api/source/${sourceId}/page/${pageNumber}/sentences?x=${x}&y=${y}&width=${width}&height=${height}&model=${model}`
+        )
+    );
+
+    return sentenceList.sentences;
+  }
+
+  getItemLabel(item: ExtractedItem): string {
+    const sentence = item as Sentence;
+    return sentence.sentence;
+  }
+
+  filterItemsBySearchTerm(items: ExtractedItem[], searchTerm: string): ExtractedItem[] {
+    const lowerSearchTerm = searchTerm.toLowerCase();
+    return items.filter(item => {
+      const sentence = item as Sentence;
+      return sentence.sentence.toLowerCase().includes(lowerSearchTerm);
+    });
+  }
+
+  async createCardData(
+    request: CardCreationRequest,
+    progressCallback: (progress: number, step: string) => void
+  ): Promise<CardCreationResult> {
+    const sentence = request.item as Sentence;
+
+    try {
+      progressCallback(30, 'Translating sentence to Hungarian...');
+      const translationResponse = await this.multiModelService.call<SentenceTranslationResponse>(
+        'sentence_translation_hu',
+        (model: string) => fetchJson<SentenceTranslationResponse>(
+          this.http,
+          `/api/translate-sentence/hu?model=${model}`,
+          {
+            body: { sentence: sentence.sentence },
+            method: 'POST',
+          }
+        )
+      );
+
+      progressCallback(70, 'Preparing speech card data...');
+
+      const imageGenerationInfo: ImageGenerationInfo = {
+        cardId: sentence.id,
+        exampleIndex: 0,
+        englishTranslation: sentence.sentence,
+      };
+
+      const cardData = {
+        sentence: sentence.sentence,
+        translation: {
+          hu: translationResponse.translation,
+        },
+        images: [],
+      };
+
+      return { cardData, imageGenerationInfos: [imageGenerationInfo] };
+
+    } catch (error) {
+      throw new Error(`Failed to prepare speech card data: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+}

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -28,6 +28,10 @@ export type Word = ExtractedItem & {
   examples: string[];
 };
 
+export type Sentence = ExtractedItem & {
+  sentence: string;
+};
+
 export type ExampleImage = {
   id: string;
   isFavorite?: boolean;
@@ -35,7 +39,8 @@ export type ExampleImage = {
 };
 
 export type CardData = {
-  word: string;
+  word?: string;
+  sentence?: string;
   type?: string;
   gender?: string;
   translation?: Record<string, string | undefined>;
@@ -44,6 +49,7 @@ export type CardData = {
     isSelected?: boolean;
     images?: ExampleImage[];
   })[];
+  images?: ExampleImage[];
   audio?: AudioData[];
   audioVoice?: string;
 };
@@ -83,7 +89,7 @@ export type Page = {
 };
 
 export type LanguageLevel = 'A1' | 'A2' | 'B1' | 'B2' | 'C1' | 'C2';
-export type CardType = 'vocabulary';
+export type CardType = 'vocabulary' | 'speech';
 
 export type ExtractedItem = {
   id: string;
@@ -156,6 +162,14 @@ export type Source = {
 
 export type WordList = {
   words: Word[];
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type SentenceList = {
+  sentences: Sentence[];
   x: number;
   y: number;
   width: number;

--- a/client/src/app/study/learn-card/learn-card.component.html
+++ b/client/src/app/study/learn-card/learn-card.component.html
@@ -41,12 +41,21 @@
       </app-card-actions>
     </div>
 
-    <app-learn-vocabulary-card
-      [card]="cardResource"
-      [isRevealed]="isRevealed()"
-      [onPlayAudio]="playAudioForContent.bind(this)"
-      (languageTextsReady)="onLanguageTextsReady($event)">
-    </app-learn-vocabulary-card>
+    @if (isSpeechCard()) {
+      <app-learn-speech-card
+        [card]="cardResource"
+        [isRevealed]="isRevealed()"
+        [onPlayAudio]="playAudioForContent.bind(this)"
+        (languageTextsReady)="onLanguageTextsReady($event)">
+      </app-learn-speech-card>
+    } @else {
+      <app-learn-vocabulary-card
+        [card]="cardResource"
+        [isRevealed]="isRevealed()"
+        [onPlayAudio]="playAudioForContent.bind(this)"
+        (languageTextsReady)="onLanguageTextsReady($event)">
+      </app-learn-vocabulary-card>
+    }
   </div>
 
   @if (isRevealed()) {

--- a/client/src/app/study/learn-card/learn-card.component.ts
+++ b/client/src/app/study/learn-card/learn-card.component.ts
@@ -15,6 +15,7 @@ import { HttpClient } from '@angular/common/http';
 import { CardGradingButtonsComponent } from '../../shared/card-grading-buttons/card-grading-buttons.component';
 import { CardActionsComponent } from '../../shared/card-actions/card-actions.component';
 import { LearnVocabularyCardComponent } from '../learn-vocabulary-card/learn-vocabulary-card.component';
+import { LearnSpeechCardComponent } from '../learn-speech-card/learn-speech-card.component';
 import { LearnCardSkeletonComponent } from '../learn-card-skeleton/learn-card-skeleton.component';
 import { AudioPlaybackService } from '../../shared/services/audio-playback.service';
 import { LanguageTexts } from '../../shared/voice-selection-dialog/voice-selection-dialog.component';
@@ -32,6 +33,7 @@ import { CardResourceLike } from '../../shared/types/card-resource.types';
     CardGradingButtonsComponent,
     CardActionsComponent,
     LearnVocabularyCardComponent,
+    LearnSpeechCardComponent,
     LearnCardSkeletonComponent,
   ],
   templateUrl: './learn-card.component.html',
@@ -53,6 +55,11 @@ export class LearnCardComponent implements OnDestroy {
 
   readonly card = computed<Card | null | undefined>(() => {
     return this.currentCardData.value()?.card;
+  });
+
+  readonly isSpeechCard = computed(() => {
+    const cardData = this.card()?.data;
+    return cardData?.sentence !== undefined && cardData?.sentence !== null;
   });
 
   readonly isRevealed = signal(false);

--- a/client/src/app/study/learn-speech-card/learn-speech-card.component.css
+++ b/client/src/app/study/learn-speech-card/learn-speech-card.component.css
@@ -1,0 +1,108 @@
+:host {
+  display: flex;
+  position: relative;
+}
+
+.image-section {
+  position: relative;
+  width: 100%;
+  padding-top: 100%;
+  overflow: hidden;
+}
+
+.image-gallery {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+}
+
+.learn-card-image {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+
+.content-section {
+  position: relative;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.sentence-section {
+  margin-top: 5rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.chips-corner {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  z-index: 10;
+}
+
+.sentence-text {
+  font-size: 1.5rem;
+  margin: 0;
+  color: var(--mat-sys-on-surface);
+  font-weight: 400;
+  line-height: 1.6;
+  text-align: center;
+}
+
+.skeleton {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, var(--mat-sys-surface-variant) 25%, var(--mat-sys-surface) 50%, var(--mat-sys-surface-variant) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+@media (min-width: 768px) {
+  .image-section {
+    flex: none;
+    width: 600px;
+    padding-top: 600px;
+  }
+
+  .content-section {
+    flex: 1;
+    max-width: 500px;
+    overflow-y: auto;
+    border-radius: 0 16px 16px 0;
+  }
+
+  .sentence-text {
+    font-size: 1.75rem;
+  }
+}
+
+@media (max-width: 767px) {
+  .sentence-text {
+    font-size: 1.25rem;
+  }
+}

--- a/client/src/app/study/learn-speech-card/learn-speech-card.component.html
+++ b/client/src/app/study/learn-speech-card/learn-speech-card.component.html
@@ -1,0 +1,23 @@
+<div class="image-section">
+  @if (images().length > 0) {
+  <div class="image-gallery">
+    @for (imageResource of images(); track $index) { @if (imageResource.value()?.url) {
+    <img [src]="imageResource.value()?.url" [alt]="sentence()" class="learn-card-image" />
+    } @else if (imageResource.isLoading()) {
+    <div class="skeleton"></div>
+    } }
+  </div>
+  }
+</div>
+
+<div class="content-section">
+  <div class="chips-corner">
+    @let state = card()?.value()?.state; @if (state !== undefined) {
+    <app-state [state]="state" />
+    }
+  </div>
+
+  <div class="sentence-section">
+    <p class="sentence-text">{{ sentence() }}</p>
+  </div>
+</div>

--- a/client/src/app/study/learn-speech-card/learn-speech-card.component.ts
+++ b/client/src/app/study/learn-speech-card/learn-speech-card.component.ts
@@ -1,0 +1,108 @@
+import {
+  Component,
+  computed,
+  inject,
+  input,
+  output,
+  Injector,
+  resource,
+  linkedSignal,
+  untracked,
+  effect,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { fetchAsset } from '../../utils/fetchAsset';
+import { ExampleImage } from '../../parser/types';
+import { StateComponent } from '../../shared/state/state.component';
+import { LanguageTexts } from '../../shared/voice-selection-dialog/voice-selection-dialog.component';
+import { CardResourceLike } from '../../shared/types/card-resource.types';
+
+type ImageResource = ExampleImage & { url: string };
+
+@Component({
+  selector: 'app-learn-speech-card',
+  standalone: true,
+  imports: [
+    CommonModule,
+    StateComponent,
+  ],
+  templateUrl: './learn-speech-card.component.html',
+  styleUrl: './learn-speech-card.component.css',
+  host: { role: 'article', 'aria-label': 'Speech Card' },
+})
+export class LearnSpeechCardComponent {
+  card = input<CardResourceLike | null>(null);
+  isRevealed = input<boolean>(false);
+  onPlayAudio = input<((texts: string[]) => void) | null>(null);
+  languageTextsReady = output<LanguageTexts[]>();
+
+  private readonly http = inject(HttpClient);
+  private readonly injector = inject(Injector);
+
+  readonly sentence = computed(() =>
+    this.isRevealed()
+      ? this.card()?.value()?.data.sentence
+      : this.card()?.value()?.data.translation?.['hu']
+  );
+
+  readonly images = linkedSignal(() => {
+    const cardData = this.card()?.value()?.data;
+
+    return untracked(() => {
+      if (!cardData?.images?.length) return [];
+
+      return cardData.images
+        .filter((img) => img.isFavorite)
+        .map((image) =>
+          resource<ImageResource, never>({
+            injector: this.injector,
+            loader: async () => {
+              return {
+                ...image,
+                url: await fetchAsset(
+                  this.http,
+                  `/api/image/${image.id}?width=1200&height=1200`
+                ),
+              };
+            },
+          })
+        );
+    });
+  });
+
+  constructor() {
+    effect(() => {
+      const currentSentence = this.sentence();
+      const playAudioFn = this.onPlayAudio();
+
+      if (currentSentence && playAudioFn) {
+        playAudioFn([currentSentence]);
+      }
+    });
+
+    effect(() => {
+      const card = this.card();
+      if (card?.value()) {
+        this.languageTextsReady.emit(this.getLanguageTextsForVoiceDialog());
+      }
+    });
+  }
+
+  getLanguageTextsForVoiceDialog(): LanguageTexts[] {
+    const card = this.card()?.value();
+    if (!card?.data) return [];
+
+    const result: LanguageTexts[] = [];
+
+    if (card.data.sentence) {
+      result.push({ language: 'de', texts: [card.data.sentence] });
+    }
+
+    if (card.data.translation?.['hu']) {
+      result.push({ language: 'hu', texts: [card.data.translation['hu']] });
+    }
+
+    return result;
+  }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SentenceIdController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SentenceIdController.java
@@ -1,0 +1,35 @@
+package io.github.mucsi96.learnlanguage.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.github.mucsi96.learnlanguage.model.SentenceIdRequest;
+import io.github.mucsi96.learnlanguage.model.SentenceIdResponse;
+import io.github.mucsi96.learnlanguage.repository.CardRepository;
+import io.github.mucsi96.learnlanguage.service.SentenceIdService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class SentenceIdController {
+
+    private final SentenceIdService sentenceIdService;
+    private final CardRepository cardRepository;
+
+    @PostMapping("/sentence-id")
+    @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
+    public ResponseEntity<SentenceIdResponse> generateSentenceId(@RequestBody SentenceIdRequest request) {
+        String id = sentenceIdService.generateSentenceId(request.getGermanSentence());
+        boolean exists = cardRepository.existsById(id);
+
+        SentenceIdResponse response = SentenceIdResponse.builder()
+                .id(id)
+                .exists(exists)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SentenceTranslationController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SentenceTranslationController.java
@@ -1,0 +1,31 @@
+package io.github.mucsi96.learnlanguage.controller;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.github.mucsi96.learnlanguage.model.ChatModel;
+import io.github.mucsi96.learnlanguage.model.SentenceTranslationRequest;
+import io.github.mucsi96.learnlanguage.model.SentenceTranslationResponse;
+import io.github.mucsi96.learnlanguage.service.SentenceTranslationService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class SentenceTranslationController {
+
+    private final SentenceTranslationService sentenceTranslationService;
+
+    @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
+    @PostMapping("/translate-sentence/hu")
+    public SentenceTranslationResponse translateSentence(
+            @RequestBody SentenceTranslationRequest request,
+            @RequestParam ChatModel model) {
+        String translation = sentenceTranslationService.translateToHungarian(request.getSentence(), model);
+        return SentenceTranslationResponse.builder()
+                .translation(translation)
+                .build();
+    }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardData.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardData.java
@@ -17,12 +17,16 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 public class CardData {
     private String word;
+    @JsonInclude(Include.NON_NULL)
+    private String sentence;
     private String type;
     @JsonInclude(Include.NON_DEFAULT)
     private String gender;
     private Map<String, String> translation;
     private List<String> forms;
     private List<ExampleData> examples;
+    @JsonInclude(Include.NON_NULL)
+    private List<ExampleImageData> images;
 
     @JsonInclude(Include.NON_NULL)
     private List<AudioData> audio;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardType.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardType.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum CardType {
-    VOCABULARY("vocabulary");
+    VOCABULARY("vocabulary"),
+    SPEECH("speech");
 
     private final String typeName;
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/SentenceIdRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/SentenceIdRequest.java
@@ -1,0 +1,14 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SentenceIdRequest {
+    private String germanSentence;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/SentenceIdResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/SentenceIdResponse.java
@@ -1,0 +1,15 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SentenceIdResponse {
+    private String id;
+    private boolean exists;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/SentenceListResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/SentenceListResponse.java
@@ -1,0 +1,20 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SentenceListResponse {
+    private List<SentenceResponse> sentences;
+    private Double x;
+    private Double y;
+    private Double width;
+    private Double height;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/SentenceResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/SentenceResponse.java
@@ -1,0 +1,16 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SentenceResponse {
+    private String id;
+    private boolean exists;
+    private String sentence;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/SentenceTranslationRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/SentenceTranslationRequest.java
@@ -1,0 +1,14 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SentenceTranslationRequest {
+    private String sentence;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/SentenceTranslationResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/SentenceTranslationResponse.java
@@ -1,0 +1,14 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SentenceTranslationResponse {
+    private String translation;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceResponse.java
@@ -13,5 +13,6 @@ public class SourceResponse {
     private Integer pageCount;
     private Integer cardCount;
     private LanguageLevel languageLevel;
+    private CardType cardType;
     private SourceFormatType formatType;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/AreaSentencesService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/AreaSentencesService.java
@@ -1,0 +1,66 @@
+package io.github.mucsi96.learnlanguage.service;
+
+import java.util.List;
+
+import org.springframework.ai.content.Media;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MimeTypeUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.github.mucsi96.learnlanguage.model.ChatModel;
+import io.github.mucsi96.learnlanguage.model.LanguageLevel;
+import io.github.mucsi96.learnlanguage.model.SentenceResponse;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AreaSentencesService {
+
+    record AreaSentences(List<String> sentenceList) {
+    }
+
+    private final ObjectMapper objectMapper;
+    private final ChatService chatService;
+
+    private String buildSystemPrompt(LanguageLevel languageLevel) {
+        String basePrompt = """
+            You are a linguistic expert specializing in German language.
+            Your task is to extract German sentences from the provided page image.
+            These sentences will be used for speech practice and learning.
+            !IMPORTANT! In response please provide all extracted sentences in JSON format with a "sentenceList" property containing a string array of sentences.
+            Extract complete, grammatically correct sentences.
+            Do not extract partial sentences or incomplete phrases.
+            Each sentence should be meaningful and suitable for language learning at %s level.
+            """.formatted(languageLevel != null ? languageLevel.name() : "A1");
+
+        AreaSentences example = new AreaSentences(List.of(
+            "Ich gehe heute ins Kino.",
+            "Das Wetter ist sehr schön.",
+            "Können Sie mir bitte helfen?"
+        ));
+
+        try {
+            String exampleJson = objectMapper.writeValueAsString(example);
+            return basePrompt + "\nExample of the expected JSON response:\n" + exampleJson;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize example to JSON", e);
+        }
+    }
+
+    public List<String> getAreaSentences(byte[] imageData, ChatModel model, LanguageLevel languageLevel) {
+        var result = chatService.callWithLoggingAndMedia(
+            model,
+            "sentence_extraction",
+            buildSystemPrompt(languageLevel),
+            u -> u
+                .text("Here is the image of the page. Extract all German sentences.")
+                .media(Media.builder()
+                    .data(imageData)
+                    .mimeType(MimeTypeUtils.IMAGE_PNG)
+                    .build()),
+            AreaSentences.class);
+
+        return result.sentenceList;
+    }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/SentenceIdService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/SentenceIdService.java
@@ -1,0 +1,39 @@
+package io.github.mucsi96.learnlanguage.service;
+
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+@Service
+public class SentenceIdService {
+
+    public String generateSentenceId(String germanSentence) {
+        if (germanSentence == null || germanSentence.isBlank()) {
+            throw new IllegalArgumentException("German sentence cannot be null or empty");
+        }
+
+        String normalized = germanSentence.trim().toLowerCase();
+
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(normalized.getBytes(StandardCharsets.UTF_8));
+            return bytesToHex(hash).substring(0, 8);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 algorithm not available", e);
+        }
+    }
+
+    private String bytesToHex(byte[] bytes) {
+        StringBuilder hexString = new StringBuilder();
+        for (byte b : bytes) {
+            String hex = Integer.toHexString(0xff & b);
+            if (hex.length() == 1) {
+                hexString.append('0');
+            }
+            hexString.append(hex);
+        }
+        return hexString.toString();
+    }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/SentenceTranslationService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/SentenceTranslationService.java
@@ -1,0 +1,35 @@
+package io.github.mucsi96.learnlanguage.service;
+
+import org.springframework.stereotype.Service;
+
+import io.github.mucsi96.learnlanguage.model.ChatModel;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SentenceTranslationService {
+
+    record SentenceTranslation(String translation) {
+    }
+
+    private final ChatService chatService;
+
+    public String translateToHungarian(String germanSentence, ChatModel model) {
+        String systemPrompt = """
+            You are a Hungarian language expert.
+            Your task is to translate the given German sentence to Hungarian.
+            Provide an accurate translation that captures the meaning and natural flow of the sentence.
+            Pay attention to proper Hungarian grammar and word order.
+            Return only the translation in JSON format with a "translation" property.
+            """;
+
+        var result = chatService.callWithLogging(
+            model,
+            "sentence_translation_hu",
+            systemPrompt,
+            germanSentence,
+            SentenceTranslation.class);
+
+        return result.translation;
+    }
+}

--- a/test/tests/speech-cards.spec.ts
+++ b/test/tests/speech-cards.spec.ts
@@ -1,0 +1,161 @@
+import { test, expect } from '../fixtures';
+import {
+  createCard,
+  createSource,
+  uploadMockImage,
+  yellowImage,
+  greenImage,
+  getImageContent,
+  getColorImageBytes,
+  withDbConnection,
+  setupDefaultChatModelSettings,
+  createChatModelSetting,
+} from '../utils';
+
+test.beforeEach(async () => {
+  await createSource({
+    id: 'speech-test',
+    name: 'Speech Test',
+    startPage: 1,
+    languageLevel: 'A1',
+    cardType: 'SPEECH',
+    formatType: 'WORD_LIST_WITH_EXAMPLES',
+    sourceType: 'PDF',
+  });
+});
+
+test('speech card shows hungarian translation on front', async ({ page }) => {
+  const image1 = uploadMockImage(yellowImage);
+  await createCard({
+    cardId: 'test-sentence-1',
+    sourceId: 'speech-test',
+    sourcePageNumber: 1,
+    data: {
+      sentence: 'Ich gehe heute ins Kino.',
+      translation: { hu: 'Ma moziba megyek.' },
+      images: [{ id: image1, isFavorite: true }],
+    },
+  });
+
+  await page.goto('http://localhost:8180/sources/speech-test/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
+
+  const flashcard = page.getByRole('article', { name: 'Speech Card' });
+  await expect(flashcard.getByText('Ma moziba megyek.')).toBeVisible();
+  await expect(flashcard.getByText('Ich gehe heute ins Kino.')).not.toBeVisible();
+  await expect(flashcard.getByRole('img', { name: 'Ma moziba megyek.' })).toBeVisible();
+});
+
+test('speech card shows german sentence on back when revealed', async ({ page }) => {
+  const image1 = uploadMockImage(greenImage);
+  await createCard({
+    cardId: 'test-sentence-2',
+    sourceId: 'speech-test',
+    sourcePageNumber: 1,
+    data: {
+      sentence: 'Das Wetter ist sehr schön.',
+      translation: { hu: 'Az időjárás nagyon szép.' },
+      images: [{ id: image1, isFavorite: true }],
+    },
+  });
+
+  await page.goto('http://localhost:8180/sources/speech-test/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
+
+  const flashcard = page.getByRole('article', { name: 'Speech Card' });
+  await flashcard.click();
+
+  await expect(flashcard.getByText('Das Wetter ist sehr schön.')).toBeVisible();
+  await expect(flashcard.getByText('Az időjárás nagyon szép.')).not.toBeVisible();
+  await expect(flashcard.getByRole('img', { name: 'Das Wetter ist sehr schön.' })).toBeVisible();
+});
+
+test('speech card displays favorite images correctly', async ({ page }) => {
+  const image1 = uploadMockImage(yellowImage);
+  const image2 = uploadMockImage(greenImage);
+  await createCard({
+    cardId: 'test-sentence-3',
+    sourceId: 'speech-test',
+    sourcePageNumber: 1,
+    data: {
+      sentence: 'Können Sie mir bitte helfen?',
+      translation: { hu: 'Tudna nekem segíteni?' },
+      images: [
+        { id: image1, isFavorite: false },
+        { id: image2, isFavorite: true },
+      ],
+    },
+  });
+
+  await page.goto('http://localhost:8180/sources/speech-test/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
+
+  const flashcard = page.getByRole('article', { name: 'Speech Card' });
+  const imageContent = await getImageContent(flashcard.getByRole('img', { name: 'Tudna nekem segíteni?' }));
+  expect(imageContent.equals(getColorImageBytes('green', 1200))).toBeTruthy();
+});
+
+test('speech card shows grading buttons when revealed', async ({ page }) => {
+  await createCard({
+    cardId: 'test-sentence-4',
+    sourceId: 'speech-test',
+    sourcePageNumber: 1,
+    data: {
+      sentence: 'Wo ist der Bahnhof?',
+      translation: { hu: 'Hol van a pályaudvar?' },
+      images: [],
+    },
+    state: 'LEARNING',
+  });
+
+  await page.goto('http://localhost:8180/sources/speech-test/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
+
+  const flashcard = page.getByRole('article', { name: 'Speech Card' });
+  await flashcard.click();
+
+  await expect(page.getByRole('button', { name: 'Again' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Hard' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Good' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Easy' })).toBeVisible();
+});
+
+test('speech card state indicator is visible', async ({ page }) => {
+  await createCard({
+    cardId: 'test-sentence-5',
+    sourceId: 'speech-test',
+    sourcePageNumber: 1,
+    data: {
+      sentence: 'Ich verstehe nicht.',
+      translation: { hu: 'Nem értem.' },
+      images: [],
+    },
+    state: 'NEW',
+  });
+
+  await page.goto('http://localhost:8180/sources/speech-test/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
+
+  const flashcard = page.getByRole('article', { name: 'Speech Card' });
+  await expect(flashcard.getByLabel('State: New')).toBeVisible();
+});
+
+test('speech card without images displays correctly', async ({ page }) => {
+  await createCard({
+    cardId: 'test-sentence-6',
+    sourceId: 'speech-test',
+    sourcePageNumber: 1,
+    data: {
+      sentence: 'Guten Morgen!',
+      translation: { hu: 'Jó reggelt!' },
+      images: [],
+    },
+  });
+
+  await page.goto('http://localhost:8180/sources/speech-test/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
+
+  const flashcard = page.getByRole('article', { name: 'Speech Card' });
+  await expect(flashcard.getByText('Jó reggelt!')).toBeVisible();
+  await expect(flashcard.locator('img')).toHaveCount(0);
+});


### PR DESCRIPTION
Adds a new card type for speech practice with German sentences:
- Backend: SPEECH enum, SentenceIdService for hash-based IDs, sentence extraction and translation endpoints
- Frontend: SpeechCardTypeStrategy, LearnSpeechCardComponent for study mode
- Study display: Front shows Hungarian translation + image, back shows German sentence + image
- Batch audio/image generation support for speech cards
- E2E tests for speech card study flow