### PR TITLE
claude/refactor-batch-audio-service-v1IQJ

### DIFF
--- a/client/src/app/batch-audio-creation-dialog/batch-audio-creation-dialog.component.ts
+++ b/client/src/app/batch-audio-creation-dialog/batch-audio-creation-dialog.component.ts
@@ -32,9 +32,7 @@ export class BatchAudioCreationDialogComponent {
     switch (status) {
       case 'pending':
         return 'schedule';
-      case 'generating-word-audio':
-      case 'generating-translation-audio':
-      case 'generating-example-audio':
+      case 'generating-audio':
       case 'updating-card':
         return 'sync';
       case 'completed':
@@ -50,9 +48,7 @@ export class BatchAudioCreationDialogComponent {
     switch (status) {
       case 'pending':
         return 'status-icon pending';
-      case 'generating-word-audio':
-      case 'generating-translation-audio':
-      case 'generating-example-audio':
+      case 'generating-audio':
       case 'updating-card':
         return 'status-icon in-progress';
       case 'completed':

--- a/client/src/app/batch-audio-creation.service.ts
+++ b/client/src/app/batch-audio-creation.service.ts
@@ -1,15 +1,14 @@
 import { Injectable, inject, signal, computed } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { fetchJson } from './utils/fetchJson';
-import { Card } from './parser/types';
+import { Card, CardTypeStrategy } from './parser/types';
 import { mapCardDatesToISOStrings } from './utils/date-mapping.util';
 import {
   AudioSourceRequest,
-  AudioResponse,
   AudioData,
-  LANGUAGE_CODES,
   VoiceModelPair
 } from './shared/types/audio-generation.types';
+import { VocabularyCardType } from './cardTypes/vocabulary-card-type.strategy';
 
 interface VoiceConfiguration {
   id: number;
@@ -26,13 +25,11 @@ export interface AudioCreationProgress {
   cardWord: string;
   status:
     | 'pending'
-    | 'generating-word-audio'
-    | 'generating-translation-audio'
-    | 'generating-example-audio'
+    | 'generating-audio'
     | 'updating-card'
     | 'completed'
     | 'error';
-  progress: number; // 0-100
+  progress: number;
   error?: string;
   currentStep?: string;
 }
@@ -49,6 +46,7 @@ export interface BatchAudioCreationResult {
 })
 export class BatchAudioCreationService {
   private readonly http = inject(HttpClient);
+  private readonly strategy: CardTypeStrategy = inject(VocabularyCardType);
   readonly creationProgress = signal<AudioCreationProgress[]>([]);
   readonly isCreating = signal(false);
   private voiceConfigs: VoiceConfiguration[] = [];
@@ -80,7 +78,6 @@ export class BatchAudioCreationService {
 
     this.isCreating.set(true);
 
-    // Fetch enabled voice configurations from database
     try {
       this.voiceConfigs = await fetchJson<VoiceConfiguration[]>(
         this.http,
@@ -91,28 +88,20 @@ export class BatchAudioCreationService {
       throw new Error('Failed to fetch voice configurations');
     }
 
-    // Check if we have at least one voice for each language
-    const hasGermanVoice = this.voiceConfigs.some(
-      (config) => config.language === LANGUAGE_CODES.GERMAN
-    );
-    const hasHungarianVoice = this.voiceConfigs.some(
-      (config) => config.language === LANGUAGE_CODES.HUNGARIAN
-    );
-
-    if (!hasGermanVoice ) {
-      this.isCreating.set(false);
-      throw new Error('No enabled voice configurations for German language');
+    const requiredLanguages = this.strategy.getRequiredLanguagesForAudio();
+    for (const language of requiredLanguages) {
+      const hasVoice = this.voiceConfigs.some(
+        (config) => config.language === language
+      );
+      if (!hasVoice) {
+        this.isCreating.set(false);
+        throw new Error(`No enabled voice configurations for language: ${language}`);
+      }
     }
 
-    if (!hasHungarianVoice ) {
-      this.isCreating.set(false);
-      throw new Error('No enabled voice configurations for Hungarian language');
-    }
-
-    // Initialize progress tracking
     const initialProgress: AudioCreationProgress[] = cards.map((card) => ({
       cardId: card.id,
-      cardWord: card.data.word || card.id,
+      cardWord: this.strategy.getCardDisplayLabel(card),
       status: 'pending',
       progress: 0,
       currentStep: 'Queued for processing',
@@ -151,123 +140,52 @@ export class BatchAudioCreationService {
     card: Card,
     progressIndex: number
   ): Promise<void> {
-    const audioList: AudioData[] = card.data.audio || [];
-
-    // Select one voice/model pair for each language for this card
-    const germanVoice = this.getVoiceForLanguage(LANGUAGE_CODES.GERMAN);
-    const hungarianVoice = this.getVoiceForLanguage(LANGUAGE_CODES.HUNGARIAN);
+    let audioList: AudioData[] = card.data.audio || [];
 
     try {
-      // Step 0: Clean up unused audio entries (15% progress)
       this.updateProgress(
         progressIndex,
         'updating-card',
-        15,
+        10,
         'Cleaning up unused audio...'
       );
-      const cleanedAudioList = await this.cleanupUnusedAudioKeys(card, audioList);
+      audioList = await this.cleanupUnusedAudioKeys(card, audioList);
 
-      // Step 1: Generate audio for the German word (30% progress)
-      this.updateProgress(
-        progressIndex,
-        'generating-word-audio',
-        30,
-        'Generating audio for German word...'
-      );
-      if (card.data.word && !this.hasAudioForText(cleanedAudioList, card.data.word)) {
-        const wordAudioResponse = await fetchJson<AudioData>(
-          this.http,
-          `/api/audio`,
-          {
-            body: {
-              input: card.data.word,
-              voice: germanVoice.voice,
-              model: germanVoice.model,
-              language: LANGUAGE_CODES.GERMAN,
-              selected: true
-            } satisfies AudioSourceRequest,
-            method: 'POST',
-          }
+      const audioItems = this.strategy.getAudioItemsFromCard(card);
+      const totalItems = audioItems.length;
+      const progressPerItem = totalItems > 0 ? 70 / totalItems : 0;
+
+      for (let i = 0; i < audioItems.length; i++) {
+        const item = audioItems[i];
+        const itemProgress = 15 + (i + 1) * progressPerItem;
+
+        this.updateProgress(
+          progressIndex,
+          'generating-audio',
+          Math.round(itemProgress),
+          `Generating audio for "${item.text.substring(0, 30)}${item.text.length > 30 ? '...' : ''}"...`
         );
-        cleanedAudioList.push(wordAudioResponse);
-      }
 
-      // Step 2: Generate audio for Hungarian translation (55% progress)
-      this.updateProgress(
-        progressIndex,
-        'generating-translation-audio',
-        55,
-        'Generating audio for translation...'
-      );
-      if (
-        card.data.translation?.['hu'] &&
-        !this.hasAudioForText(cleanedAudioList, card.data.translation['hu'])
-      ) {
-        const translationAudioResponse = await fetchJson<AudioData>(
-          this.http,
-          `/api/audio`,
-          {
-            body: {
-              input: card.data.translation['hu'],
-              voice: hungarianVoice.voice,
-              model: hungarianVoice.model,
-              language: LANGUAGE_CODES.HUNGARIAN,
-              selected: true
-            } satisfies AudioSourceRequest,
-            method: 'POST',
-          }
-        );
-        cleanedAudioList.push(translationAudioResponse);
-      }
-
-      // Step 3: Generate audio for selected example and its translation (80% progress)
-      this.updateProgress(
-        progressIndex,
-        'generating-example-audio',
-        80,
-        'Generating audio for examples...'
-      );
-      const selectedExample = card.data.examples?.find(
-        (example: any) => example.isSelected
-      );
-      if (selectedExample) {
-        // German example
-        if (selectedExample['de'] && !this.hasAudioForText(cleanedAudioList, selectedExample['de'])) {
-          const exampleAudioResponse = await fetchJson<AudioData>(
+        if (!this.hasAudioForText(audioList, item.text)) {
+          const voice = this.getVoiceForLanguage(item.language);
+          const audioResponse = await fetchJson<AudioData>(
             this.http,
             `/api/audio`,
             {
               body: {
-                input: selectedExample['de'],
-                voice: germanVoice.voice,
-                model: germanVoice.model,
-                language: LANGUAGE_CODES.GERMAN,
+                input: item.text,
+                voice: voice.voice,
+                model: voice.model,
+                language: item.language,
                 selected: true
               } satisfies AudioSourceRequest,
               method: 'POST',
             }
           );
-          cleanedAudioList.push(exampleAudioResponse);
-        }
-
-        // Hungarian example translation
-        if (selectedExample['hu'] && !this.hasAudioForText(cleanedAudioList, selectedExample['hu'])) {
-          const exampleTranslationAudioResponse = await fetchJson<AudioData>(
-            this.http, `/api/audio`, {
-            body: {
-              input: selectedExample['hu'],
-              voice: hungarianVoice.voice,
-              model: hungarianVoice.model,
-              language: LANGUAGE_CODES.HUNGARIAN,
-              selected: true
-            } satisfies AudioSourceRequest,
-            method: 'POST',
-          });
-          cleanedAudioList.push(exampleTranslationAudioResponse);
+          audioList.push(audioResponse);
         }
       }
 
-      // Step 4: Update card with audio IDs (90% progress)
       this.updateProgress(
         progressIndex,
         'updating-card',
@@ -275,22 +193,19 @@ export class BatchAudioCreationService {
         'Updating card with audio data...'
       );
 
-      // Create the updated card data by merging existing data with new audio
       const updatedCardData: Partial<Card> = {
         data: {
           ...card.data,
-          audio: cleanedAudioList,
+          audio: audioList,
         },
         readiness: 'READY',
       };
 
-      // Update the card
       await fetchJson(this.http, `/api/card/${card.id}`, {
         body: mapCardDatesToISOStrings(updatedCardData),
         method: 'PUT',
       });
 
-      // Step 5: Complete (100% progress)
       this.updateProgress(progressIndex, 'completed', 100);
     } catch (error) {
       this.updateProgress(
@@ -323,58 +238,24 @@ export class BatchAudioCreationService {
     });
   }
 
-  /**
-   * Clean up audio keys that are no longer needed based on current card data
-   */
   private async cleanupUnusedAudioKeys(
     card: Card,
     audioList: AudioData[]
   ): Promise<AudioData[]> {
-    // Collect all text keys that should have audio based on current card data
-    const validAudioKeys = new Set<string>();
-
-    // Add word if exists
-    if (card.data.word) {
-      validAudioKeys.add(card.data.word);
-    }
-
-    // Add Hungarian translation if exists
-    if (card.data.translation?.['hu']) {
-      validAudioKeys.add(card.data.translation['hu']);
-    }
-
-    // Add selected example texts if they exist
-    const selectedExample = card.data.examples?.find(
-      (example: any) => example.isSelected
-    );
-    if (selectedExample) {
-      if (selectedExample['de']) {
-        validAudioKeys.add(selectedExample['de']);
-      }
-      if (selectedExample['hu']) {
-        validAudioKeys.add(selectedExample['hu']);
-      }
-    }
-
-    // Create new audio list with only valid keys
+    const validAudioKeys = this.strategy.getValidAudioTextsFromCard(card);
     const cleanedAudioList: AudioData[] = [];
     const audioKeysToDelete: string[] = [];
 
-    // Check existing audio entries
     for (const audioEntry of audioList) {
       if (audioEntry.text && validAudioKeys.has(audioEntry.text)) {
-        // Keep this audio entry
         cleanedAudioList.push(audioEntry);
       } else {
-        // Mark for deletion
         audioKeysToDelete.push(audioEntry.id);
       }
     }
 
-    // Delete unused audio files from blob storage
     if (audioKeysToDelete.length > 0) {
       try {
-        // Call backend to delete audio files
         for (const audioId of audioKeysToDelete) {
           await fetchJson(this.http, `/api/audio/${audioId}`, {
             method: 'DELETE',
@@ -382,7 +263,6 @@ export class BatchAudioCreationService {
         }
       } catch (error) {
         console.warn('Failed to delete some unused audio files:', error);
-        // Continue processing even if cleanup fails
       }
     }
 

--- a/client/src/app/cardTypes/vocabulary-card-type.strategy.ts
+++ b/client/src/app/cardTypes/vocabulary-card-type.strategy.ts
@@ -12,7 +12,10 @@ import {
   ExtractionRequest,
   ExtractedItem,
   WordList,
+  AudioGenerationItem,
+  Card,
 } from '../parser/types';
+import { LANGUAGE_CODES } from '../shared/types/audio-generation.types';
 
 interface WordTypeResponse {
   type: string;
@@ -209,5 +212,61 @@ export class VocabularyCardType implements CardTypeStrategy {
     } catch (error) {
       throw new Error(`Failed to prepare vocabulary card data: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
+  }
+
+  getRequiredLanguagesForAudio(): string[] {
+    return [LANGUAGE_CODES.GERMAN, LANGUAGE_CODES.HUNGARIAN];
+  }
+
+  getAudioItemsFromCard(card: Card): AudioGenerationItem[] {
+    const items: AudioGenerationItem[] = [];
+
+    if (card.data.word) {
+      items.push({ text: card.data.word, language: LANGUAGE_CODES.GERMAN });
+    }
+
+    if (card.data.translation?.['hu']) {
+      items.push({ text: card.data.translation['hu'], language: LANGUAGE_CODES.HUNGARIAN });
+    }
+
+    const selectedExample = card.data.examples?.find(example => example.isSelected);
+    if (selectedExample) {
+      if (selectedExample['de']) {
+        items.push({ text: selectedExample['de'], language: LANGUAGE_CODES.GERMAN });
+      }
+      if (selectedExample['hu']) {
+        items.push({ text: selectedExample['hu'], language: LANGUAGE_CODES.HUNGARIAN });
+      }
+    }
+
+    return items;
+  }
+
+  getValidAudioTextsFromCard(card: Card): Set<string> {
+    const validTexts = new Set<string>();
+
+    if (card.data.word) {
+      validTexts.add(card.data.word);
+    }
+
+    if (card.data.translation?.['hu']) {
+      validTexts.add(card.data.translation['hu']);
+    }
+
+    const selectedExample = card.data.examples?.find(example => example.isSelected);
+    if (selectedExample) {
+      if (selectedExample['de']) {
+        validTexts.add(selectedExample['de']);
+      }
+      if (selectedExample['hu']) {
+        validTexts.add(selectedExample['hu']);
+      }
+    }
+
+    return validTexts;
+  }
+
+  getCardDisplayLabel(card: Card): string {
+    return card.data.word || card.id;
   }
 }

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -122,6 +122,11 @@ export type CardCreationResult = {
   imageGenerationInfos: ImageGenerationInfo[];
 };
 
+export type AudioGenerationItem = {
+  text: string;
+  language: string;
+};
+
 export type CardTypeStrategy = {
   cardType: CardType;
   extractItems(request: ExtractionRequest): Promise<ExtractedItem[]>;
@@ -134,6 +139,10 @@ export type CardTypeStrategy = {
     request: CardCreationRequest,
     progressCallback: (progress: number, step: string) => void
   ): Promise<CardCreationResult>;
+  getRequiredLanguagesForAudio(): string[];
+  getAudioItemsFromCard(card: Card): AudioGenerationItem[];
+  getValidAudioTextsFromCard(card: Card): Set<string>;
+  getCardDisplayLabel(card: Card): string;
 };
 
 export type SourceFormatType =


### PR DESCRIPTION
Move card-specific audio generation logic to VocabularyCardType strategy:
- Add AudioGenerationItem type and audio methods to CardTypeStrategy interface
- Implement getRequiredLanguagesForAudio, getAudioItemsFromCard, getValidAudioTextsFromCard, getCardDisplayLabel in VocabularyCardType
- Refactor BatchAudioCreationService to use strategy methods instead of direct card data access
- Simplify audio generation status to single 'generating-audio' state