### PR TITLE
claude/refactor-batch-audio-service-qgIC4

### DIFF
--- a/client/src/app/batch-audio-creation-dialog/batch-audio-creation-dialog.component.ts
+++ b/client/src/app/batch-audio-creation-dialog/batch-audio-creation-dialog.component.ts
@@ -32,17 +32,13 @@ export class BatchAudioCreationDialogComponent {
     switch (status) {
       case 'pending':
         return 'schedule';
-      case 'generating-word-audio':
-      case 'generating-translation-audio':
-      case 'generating-example-audio':
+      case 'generating-audio':
       case 'updating-card':
         return 'sync';
       case 'completed':
         return 'check_circle';
       case 'error':
         return 'error';
-      default:
-        return 'help';
     }
   }
 
@@ -50,17 +46,13 @@ export class BatchAudioCreationDialogComponent {
     switch (status) {
       case 'pending':
         return 'status-icon pending';
-      case 'generating-word-audio':
-      case 'generating-translation-audio':
-      case 'generating-example-audio':
+      case 'generating-audio':
       case 'updating-card':
         return 'status-icon in-progress';
       case 'completed':
         return 'status-icon completed';
       case 'error':
         return 'status-icon error';
-      default:
-        return 'status-icon';
     }
   }
 

--- a/client/src/app/batch-audio-creation-fab/batch-audio-creation-fab.component.ts
+++ b/client/src/app/batch-audio-creation-fab/batch-audio-creation-fab.component.ts
@@ -7,7 +7,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { CommonModule } from '@angular/common';
 import { BatchAudioCreationService } from '../batch-audio-creation.service';
 import { BatchAudioCreationDialogComponent } from '../batch-audio-creation-dialog/batch-audio-creation-dialog.component';
-import { Card } from '../parser/types';
+import { Card, CardType, Source } from '../parser/types';
 import { fetchJson } from '../utils/fetchJson';
 import { HttpClient } from '@angular/common/http';
 import { mapCardDatesFromISOStrings } from '../utils/date-mapping.util';
@@ -56,12 +56,41 @@ export class BatchAudioCreationFabComponent {
     });
 
     try {
-      const result = await this.batchAudioService.createAudioInBatch(cards, 'vocabulary');
+      const cardsBySource = this.groupCardsBySource(cards);
+      const sourceIds = Object.keys(cardsBySource);
+      const sources = await Promise.all(
+        sourceIds.map(id => fetchJson<Source>(this.http, `/api/sources/${id}`))
+      );
+      const sourceCardTypes = new Map(
+        sources.map(source => [source.id, source.cardType])
+      );
 
-      if (result.successfulCards > 0) {
+      const results = await sourceIds.reduce<Promise<{ successful: number; failed: number; errors: string[] }>>(
+        async (accPromise, sourceId) => {
+          const acc = await accPromise;
+          const sourceCards = cardsBySource[sourceId];
+          const cardType = sourceCardTypes.get(sourceId);
+          if (!cardType) {
+            return {
+              ...acc,
+              failed: acc.failed + sourceCards.length,
+              errors: [...acc.errors, `Source ${sourceId} has no card type configured`]
+            };
+          }
+          const result = await this.batchAudioService.createAudioInBatch(sourceCards, cardType);
+          return {
+            successful: acc.successful + result.successfulCards,
+            failed: acc.failed + result.failedCards,
+            errors: [...acc.errors, ...result.errors]
+          };
+        },
+        Promise.resolve({ successful: 0, failed: 0, errors: [] })
+      );
+
+      if (results.successful > 0) {
         this.cards.reload();
         this.snackBar.open(
-          `Audio generated successfully for ${result.successfulCards} card${result.successfulCards === 1 ? '' : 's'}!`,
+          `Audio generated successfully for ${results.successful} card${results.successful === 1 ? '' : 's'}!`,
           'Close',
           {
             duration: 5000,
@@ -71,9 +100,9 @@ export class BatchAudioCreationFabComponent {
         );
       }
 
-      if (result.failedCards > 0) {
+      if (results.failed > 0) {
         this.snackBar.open(
-          `Failed to generate audio for ${result.failedCards} card${result.failedCards === 1 ? '' : 's'}. Check the console for details.`,
+          `Failed to generate audio for ${results.failed} card${results.failed === 1 ? '' : 's'}. Check the console for details.`,
           'Close',
           {
             duration: 8000,
@@ -93,5 +122,15 @@ export class BatchAudioCreationFabComponent {
         }
       );
     }
+  }
+
+  private groupCardsBySource(cards: Card[]): Record<string, Card[]> {
+    return cards.reduce<Record<string, Card[]>>(
+      (acc, card) => ({
+        ...acc,
+        [card.source.id]: [...(acc[card.source.id] ?? []), card]
+      }),
+      {}
+    );
   }
 }

--- a/client/src/app/batch-audio-creation-fab/batch-audio-creation-fab.component.ts
+++ b/client/src/app/batch-audio-creation-fab/batch-audio-creation-fab.component.ts
@@ -56,7 +56,7 @@ export class BatchAudioCreationFabComponent {
     });
 
     try {
-      const result = await this.batchAudioService.createAudioInBatch(cards);
+      const result = await this.batchAudioService.createAudioInBatch(cards, 'vocabulary');
 
       if (result.successfulCards > 0) {
         this.cards.reload();

--- a/client/src/app/batch-audio-creation-fab/batch-audio-creation-fab.component.ts
+++ b/client/src/app/batch-audio-creation-fab/batch-audio-creation-fab.component.ts
@@ -58,11 +58,11 @@ export class BatchAudioCreationFabComponent {
     try {
       const cardsBySource = this.groupCardsBySource(cards);
       const sourceIds = Object.keys(cardsBySource);
-      const sources = await Promise.all(
-        sourceIds.map(id => fetchJson<Source>(this.http, `/api/sources/${id}`))
-      );
+      const allSources = await fetchJson<Source[]>(this.http, '/api/sources');
       const sourceCardTypes = new Map(
-        sources.map(source => [source.id, source.cardType])
+        allSources
+          .filter(source => sourceIds.includes(String(source.id)))
+          .map(source => [source.id, source.cardType])
       );
 
       const results = await sourceIds.reduce<Promise<{ successful: number; failed: number }>>(

--- a/client/src/app/batch-audio-creation-fab/batch-audio-creation-fab.component.ts
+++ b/client/src/app/batch-audio-creation-fab/batch-audio-creation-fab.component.ts
@@ -61,7 +61,7 @@ export class BatchAudioCreationFabComponent {
       const allSources = await fetchJson<Source[]>(this.http, '/api/sources');
       const sourceCardTypes = new Map(
         allSources
-          .filter(source => sourceIds.includes(String(source.id)))
+          .filter(source => sourceIds.includes(source.id))
           .map(source => [source.id, source.cardType])
       );
 

--- a/client/src/app/batch-audio-creation.service.ts
+++ b/client/src/app/batch-audio-creation.service.ts
@@ -271,7 +271,7 @@ export class BatchAudioCreationService {
     audioList: AudioData[],
     strategy: CardTypeStrategy
   ): Promise<AudioData[]> {
-    const validAudioTexts = strategy.getValidAudioTexts(card);
+    const validAudioTexts = new Set(strategy.getAudioItems(card).map(item => item.text));
 
     const { toKeep, toDelete } = audioList.reduce<{
       toKeep: AudioData[];

--- a/client/src/app/cardTypes/vocabulary-card-type.strategy.ts
+++ b/client/src/app/cardTypes/vocabulary-card-type.strategy.ts
@@ -12,7 +12,10 @@ import {
   ExtractionRequest,
   ExtractedItem,
   WordList,
+  AudioGenerationItem,
+  Card,
 } from '../parser/types';
+import { LANGUAGE_CODES } from '../shared/types/audio-generation.types';
 
 interface WordTypeResponse {
   type: string;
@@ -209,5 +212,39 @@ export class VocabularyCardType implements CardTypeStrategy {
     } catch (error) {
       throw new Error(`Failed to prepare vocabulary card data: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
+  }
+
+  requiredAudioLanguages(): string[] {
+    return [LANGUAGE_CODES.GERMAN, LANGUAGE_CODES.HUNGARIAN];
+  }
+
+  getCardDisplayLabel(card: Card): string {
+    return card.data.word || card.id;
+  }
+
+  getAudioItems(card: Card): AudioGenerationItem[] {
+    const selectedExample = card.data.examples?.find(example => example.isSelected);
+
+    const items: (AudioGenerationItem | null)[] = [
+      card.data.word ? { text: card.data.word, language: LANGUAGE_CODES.GERMAN } : null,
+      card.data.translation?.['hu'] ? { text: card.data.translation['hu'], language: LANGUAGE_CODES.HUNGARIAN } : null,
+      selectedExample?.['de'] ? { text: selectedExample['de'], language: LANGUAGE_CODES.GERMAN } : null,
+      selectedExample?.['hu'] ? { text: selectedExample['hu'], language: LANGUAGE_CODES.HUNGARIAN } : null,
+    ];
+
+    return items.filter((item): item is AudioGenerationItem => item !== null);
+  }
+
+  getValidAudioTexts(card: Card): Set<string> {
+    const selectedExample = card.data.examples?.find(example => example.isSelected);
+
+    const texts = [
+      card.data.word,
+      card.data.translation?.['hu'],
+      selectedExample?.['de'],
+      selectedExample?.['hu'],
+    ].filter((text): text is string => text !== undefined && text !== null);
+
+    return new Set(texts);
   }
 }

--- a/client/src/app/cardTypes/vocabulary-card-type.strategy.ts
+++ b/client/src/app/cardTypes/vocabulary-card-type.strategy.ts
@@ -234,17 +234,4 @@ export class VocabularyCardType implements CardTypeStrategy {
 
     return items.filter((item): item is AudioGenerationItem => item !== null);
   }
-
-  getValidAudioTexts(card: Card): Set<string> {
-    const selectedExample = card.data.examples?.find(example => example.isSelected);
-
-    const texts = [
-      card.data.word,
-      card.data.translation?.['hu'],
-      selectedExample?.['de'],
-      selectedExample?.['hu'],
-    ].filter((text): text is string => text !== undefined && text !== null);
-
-    return new Set(texts);
-  }
 }

--- a/client/src/app/cardTypes/vocabulary-card-type.strategy.ts
+++ b/client/src/app/cardTypes/vocabulary-card-type.strategy.ts
@@ -16,6 +16,7 @@ import {
   Card,
 } from '../parser/types';
 import { LANGUAGE_CODES } from '../shared/types/audio-generation.types';
+import { nonNullable } from '../utils/type-guards';
 
 interface WordTypeResponse {
   type: string;
@@ -225,13 +226,11 @@ export class VocabularyCardType implements CardTypeStrategy {
   getAudioItems(card: Card): AudioGenerationItem[] {
     const selectedExample = card.data.examples?.find(example => example.isSelected);
 
-    const items: (AudioGenerationItem | null)[] = [
+    return [
       card.data.word ? { text: card.data.word, language: LANGUAGE_CODES.GERMAN } : null,
       card.data.translation?.['hu'] ? { text: card.data.translation['hu'], language: LANGUAGE_CODES.HUNGARIAN } : null,
       selectedExample?.['de'] ? { text: selectedExample['de'], language: LANGUAGE_CODES.GERMAN } : null,
       selectedExample?.['hu'] ? { text: selectedExample['hu'], language: LANGUAGE_CODES.HUNGARIAN } : null,
-    ];
-
-    return items.filter((item): item is AudioGenerationItem => item !== null);
+    ].filter(nonNullable);
   }
 }

--- a/client/src/app/in-review-cards/in-review-cards.component.html
+++ b/client/src/app/in-review-cards/in-review-cards.component.html
@@ -130,4 +130,4 @@
 </div>
 }
 
-<app-batch-audio-creation-fab></app-batch-audio-creation-fab>
+<app-batch-audio-creation-fab />

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -122,6 +122,11 @@ export type CardCreationResult = {
   imageGenerationInfos: ImageGenerationInfo[];
 };
 
+export type AudioGenerationItem = {
+  text: string;
+  language: string;
+};
+
 export type CardTypeStrategy = {
   cardType: CardType;
   extractItems(request: ExtractionRequest): Promise<ExtractedItem[]>;
@@ -134,6 +139,10 @@ export type CardTypeStrategy = {
     request: CardCreationRequest,
     progressCallback: (progress: number, step: string) => void
   ): Promise<CardCreationResult>;
+  requiredAudioLanguages(): string[];
+  getCardDisplayLabel(card: Card): string;
+  getAudioItems(card: Card): AudioGenerationItem[];
+  getValidAudioTexts(card: Card): Set<string>;
 };
 
 export type SourceFormatType =

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -142,7 +142,6 @@ export type CardTypeStrategy = {
   requiredAudioLanguages(): string[];
   getCardDisplayLabel(card: Card): string;
   getAudioItems(card: Card): AudioGenerationItem[];
-  getValidAudioTexts(card: Card): Set<string>;
 };
 
 export type SourceFormatType =

--- a/client/src/app/utils/type-guards.ts
+++ b/client/src/app/utils/type-guards.ts
@@ -1,0 +1,3 @@
+export function nonNullable<T>(value: T): value is NonNullable<T> {
+  return value !== null && value !== undefined;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
@@ -76,6 +76,7 @@ public class SourceController {
           .id(source.getId())
           .name(source.getName())
           .sourceType(source.getSourceType())
+          .cardType(source.getCardType())
           .startPage(source.getBookmarkedPage() != null ? source.getBookmarkedPage() : source.getStartPage())
           .pageCount(pageCount)
           .cardCount(cardCount)

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceResponse.java
@@ -9,6 +9,7 @@ public class SourceResponse {
     private String id;
     private String name;
     private SourceType sourceType;
+    private CardType cardType;
     private Integer startPage;
     private Integer pageCount;
     private Integer cardCount;

--- a/test/tests/bulk-audio-creation.spec.ts
+++ b/test/tests/bulk-audio-creation.spec.ts
@@ -651,7 +651,7 @@ test('bulk audio creation uses only enabled voice configurations', async ({ page
 
   // Should show error because Hungarian voice is disabled
   await expect(page.getByRole('dialog')).toBeVisible();
-  await expect(page.getByText('No enabled voice configurations for Hungarian language')).toBeVisible();
+  await expect(page.getByText('No enabled voice configurations for languages: hu')).toBeVisible();
 });
 
 test('bulk audio creation succeeds with all enabled voice configurations', async ({ page }) => {


### PR DESCRIPTION
Move vocabulary-specific audio generation logic to VocabularyCardType strategy, making the batch audio service card type independent. Add AudioGenerationItem type and new CardTypeStrategy methods: requiredAudioLanguages, getCardDisplayLabel, getAudioItems, and getValidAudioTexts.