### PR TITLE
claude/refactor-learn-card-generic-1dlom

### DIFF
--- a/client/src/app/cardTypes/vocabulary-card-type.strategy.ts
+++ b/client/src/app/cardTypes/vocabulary-card-type.strategy.ts
@@ -16,6 +16,7 @@ import {
   Card,
   CardData,
   ImagesByIndex,
+  LanguageTexts,
 } from '../parser/types';
 import { LANGUAGE_CODES } from '../shared/types/audio-generation.types';
 import { nonNullable } from '../utils/type-guards';
@@ -251,5 +252,24 @@ export class VocabularyCardType implements CardTypeStrategy {
     });
 
     return { ...cardData, examples: updatedExamples };
+  }
+
+  getLanguageTexts(card: Card): LanguageTexts[] {
+    const selectedExample = card.data.examples?.find(ex => ex.isSelected);
+
+    const germanTexts = [
+      card.data.word,
+      selectedExample?.['de']
+    ].filter(nonNullable);
+
+    const hungarianTexts = [
+      card.data.translation?.['hu'],
+      selectedExample?.['hu']
+    ].filter(nonNullable);
+
+    return [
+      ...(germanTexts.length > 0 ? [{ language: 'de', texts: germanTexts }] : []),
+      ...(hungarianTexts.length > 0 ? [{ language: 'hu', texts: hungarianTexts }] : [])
+    ];
   }
 }

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -129,6 +129,11 @@ export type AudioGenerationItem = {
 
 export type ImagesByIndex = Map<number, ExampleImage[]>;
 
+export type LanguageTexts = {
+  language: string;
+  texts: string[];
+};
+
 export type CardTypeStrategy = {
   cardType: CardType;
   extractItems(request: ExtractionRequest): Promise<ExtractedItem[]>;
@@ -145,6 +150,7 @@ export type CardTypeStrategy = {
   getCardDisplayLabel(card: Card): string;
   getAudioItems(card: Card): AudioGenerationItem[];
   updateCardDataWithImages(cardData: CardData, images: ImagesByIndex): CardData;
+  getLanguageTexts(card: Card): LanguageTexts[];
 };
 
 export type SourceFormatType =

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -54,6 +54,7 @@ export type Card = {
     id: string;
     name?: string;
     startPage?: number;
+    cardType?: CardType;
   };
   sourcePageNumber: number;
   data: CardData;

--- a/client/src/app/shared/card-actions/card-actions.component.ts
+++ b/client/src/app/shared/card-actions/card-actions.component.ts
@@ -7,7 +7,8 @@ import { HttpClient } from '@angular/common/http';
 import { MatDialog } from '@angular/material/dialog';
 import { fetchJson } from '../../utils/fetchJson';
 import { AudioData } from '../types/audio-generation.types';
-import { VoiceSelectionDialogComponent, LanguageTexts } from '../voice-selection-dialog/voice-selection-dialog.component';
+import { VoiceSelectionDialogComponent } from '../voice-selection-dialog/voice-selection-dialog.component';
+import { LanguageTexts } from '../../parser/types';
 import { CardResourceLike } from '../types/card-resource.types';
 
 @Component({

--- a/client/src/app/shared/voice-selection-dialog/voice-selection-dialog.component.ts
+++ b/client/src/app/shared/voice-selection-dialog/voice-selection-dialog.component.ts
@@ -22,6 +22,8 @@ import { MatCardModule } from '@angular/material/card';
 import { fetchJson } from '../../utils/fetchJson';
 import { AudioData, AudioResponse } from '../types/audio-generation.types';
 import { AudioPlaybackService } from '../services/audio-playback.service';
+import { LanguageTexts } from '../../parser/types';
+export { LanguageTexts } from '../../parser/types';
 
 interface VoiceConfiguration {
   id: number;
@@ -39,11 +41,6 @@ interface VoiceCardData {
   audioData?: AudioData;
   isGenerating?: boolean;
   isPlaying?: boolean;
-}
-
-export interface LanguageTexts {
-  language: string;
-  texts: string[];
 }
 
 export interface VoiceSelectionDialogData {

--- a/client/src/app/study/learn-card/learn-card.component.html
+++ b/client/src/app/study/learn-card/learn-card.component.html
@@ -41,12 +41,15 @@
       </app-card-actions>
     </div>
 
-    <app-learn-vocabulary-card
-      [card]="cardResource"
-      [isRevealed]="isRevealed()"
-      [onPlayAudio]="playAudioForContent.bind(this)"
-      (languageTextsReady)="onLanguageTextsReady($event)">
-    </app-learn-vocabulary-card>
+    @switch (currentCardType()) {
+      @case ('vocabulary') {
+        <app-learn-vocabulary-card
+          [card]="cardResource"
+          [isRevealed]="isRevealed()"
+          [onPlayAudio]="playAudioForContent.bind(this)">
+        </app-learn-vocabulary-card>
+      }
+    }
   </div>
 
   @if (isRevealed()) {

--- a/client/src/app/study/learn-card/learn-card.component.ts
+++ b/client/src/app/study/learn-card/learn-card.component.ts
@@ -17,9 +17,8 @@ import { CardActionsComponent } from '../../shared/card-actions/card-actions.com
 import { LearnVocabularyCardComponent } from '../learn-vocabulary-card/learn-vocabulary-card.component';
 import { LearnCardSkeletonComponent } from '../learn-card-skeleton/learn-card-skeleton.component';
 import { AudioPlaybackService } from '../../shared/services/audio-playback.service';
-import { Card, LanguageTexts, CardType } from '../../parser/types';
+import { Card, LanguageTexts } from '../../parser/types';
 import { CardResourceLike } from '../../shared/types/card-resource.types';
-import { SourcesService } from '../../sources.service';
 import { CardTypeRegistry } from '../../cardTypes/card-type.registry';
 
 @Component({
@@ -44,7 +43,6 @@ export class LearnCardComponent implements OnDestroy {
   private readonly studySessionService = inject(StudySessionService);
   private readonly http = inject(HttpClient);
   private readonly audioPlaybackService = inject(AudioPlaybackService);
-  private readonly sourcesService = inject(SourcesService);
   private readonly cardTypeRegistry = inject(CardTypeRegistry);
 
   readonly currentCardData = this.studySessionService.currentCard;
@@ -63,13 +61,7 @@ export class LearnCardComponent implements OnDestroy {
   private lastPlayedTexts: string[] = [];
   private currentSourceId: string | null = null;
 
-  readonly currentCardType = computed<CardType | undefined>(() => {
-    const card = this.card();
-    if (!card) return undefined;
-    const sources = this.sourcesService.sources.value();
-    const source = sources?.find(s => s.id === card.source.id);
-    return source?.cardType;
-  });
+  readonly currentCardType = computed(() => this.card()?.source.cardType);
 
   readonly languageTexts = computed<LanguageTexts[]>(() => {
     const card = this.card();

--- a/client/src/app/study/learn-vocabulary-card/learn-vocabulary-card.component.ts
+++ b/client/src/app/study/learn-vocabulary-card/learn-vocabulary-card.component.ts
@@ -3,7 +3,6 @@ import {
   computed,
   inject,
   input,
-  output,
   Injector,
   resource,
   linkedSignal,
@@ -18,7 +17,6 @@ import { ExampleImage } from '../../parser/types';
 import { StateComponent } from '../../shared/state/state.component';
 import { getWordTypeInfo } from '../../shared/word-type-translations';
 import { getGenderInfo } from '../../shared/gender-translations';
-import { LanguageTexts } from '../../shared/voice-selection-dialog/voice-selection-dialog.component';
 import { CardResourceLike } from '../../shared/types/card-resource.types';
 
 type ImageResource = ExampleImage & { url: string };
@@ -39,7 +37,6 @@ export class LearnVocabularyCardComponent {
   card = input<CardResourceLike | null>(null);
   isRevealed = input<boolean>(false);
   onPlayAudio = input<((texts: string[]) => void) | null>(null);
-  languageTextsReady = output<LanguageTexts[]>();
 
   private readonly http = inject(HttpClient);
   private readonly injector = inject(Injector);
@@ -96,7 +93,6 @@ export class LearnVocabularyCardComponent {
   });
 
   constructor() {
-    // Play audio based on what text is currently displayed
     effect(() => {
       const currentWord = this.word();
       const currentExample = this.example();
@@ -107,39 +103,5 @@ export class LearnVocabularyCardComponent {
         playAudioFn(texts);
       }
     });
-
-    // Emit language texts when card changes
-    effect(() => {
-      const card = this.card();
-      if (card?.value()) {
-        this.languageTextsReady.emit(this.getLanguageTextsForVoiceDialog());
-      }
-    });
-  }
-
-  getLanguageTextsForVoiceDialog(): LanguageTexts[] {
-    const card = this.card()?.value();
-    if (!card?.data) return [];
-
-    const selectedExample = card.data.examples?.find(ex => ex.isSelected);
-    const result: LanguageTexts[] = [];
-
-    // German texts
-    const germanTexts: string[] = [];
-    if (card.data.word) germanTexts.push(card.data.word);
-    if (selectedExample?.['de']) germanTexts.push(selectedExample['de']);
-    if (germanTexts.length > 0) {
-      result.push({ language: 'de', texts: germanTexts });
-    }
-
-    // Hungarian texts
-    const hungarianTexts: string[] = [];
-    if (card.data.translation?.['hu']) hungarianTexts.push(card.data.translation['hu']);
-    if (selectedExample?.['hu']) hungarianTexts.push(selectedExample['hu']);
-    if (hungarianTexts.length > 0) {
-      result.push({ language: 'hu', texts: hungarianTexts });
-    }
-
-    return result;
   }
 }


### PR DESCRIPTION
- Add getLanguageTexts method to CardTypeStrategy interface
- Implement getLanguageTexts in VocabularyCardType strategy
- Move LanguageTexts type to parser/types.ts for shared access
- Update learn-card component to use strategy for language texts
- Use @switch in template to dynamically render card type component
- Remove language texts logic from learn-vocabulary-card component