### PR TITLE
Implement multi-region extraction support for card types

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,3 @@
-- support for grammar card type
-- support multi part regions
+- ~~support for grammar card type~~ (completed)
+- ~~support multi part regions~~ (completed)
 - support cross-page multi part regions

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,1 @@
-- ~~support for grammar card type~~ (completed)
-- ~~support multi part regions~~ (completed)
-- support cross-page multi part regions
+

--- a/client/src/app/cardTypes/grammar-card-type.strategy.ts
+++ b/client/src/app/cardTypes/grammar-card-type.strategy.ts
@@ -8,7 +8,7 @@ import {
   CardCreationResult,
   CardType,
   ImageGenerationInfo,
-  ExtractionRequest,
+  MultiRegionExtractionRequest,
   ExtractedItem,
   GrammarSentenceList,
   GrammarSentence,
@@ -39,15 +39,19 @@ export class GrammarCardType implements CardTypeStrategy {
   private readonly http = inject(HttpClient);
   private readonly multiModelService = inject(MultiModelService);
 
-  async extractItems(request: ExtractionRequest): Promise<ExtractedItem[]> {
-    const { sourceId, pageNumber, x, y, width, height } = request;
+  async extractItems(request: MultiRegionExtractionRequest): Promise<ExtractedItem[]> {
+    const { sourceId, regions } = request;
 
     const grammarSentenceList = await this.multiModelService.call<GrammarSentenceList>(
       'extraction',
       (model: string) =>
         fetchJson<GrammarSentenceList>(
           this.http,
-          `/api/source/${sourceId}/page/${pageNumber}/grammar?x=${x}&y=${y}&width=${width}&height=${height}&model=${model}`
+          `/api/source/${sourceId}/grammar?model=${model}`,
+          {
+            body: { regions },
+            method: 'POST',
+          }
         )
     );
 

--- a/client/src/app/cardTypes/speech-card-type.strategy.ts
+++ b/client/src/app/cardTypes/speech-card-type.strategy.ts
@@ -8,7 +8,7 @@ import {
   CardCreationResult,
   CardType,
   ImageGenerationInfo,
-  ExtractionRequest,
+  MultiRegionExtractionRequest,
   ExtractedItem,
   SentenceList,
   Sentence,
@@ -39,15 +39,19 @@ export class SpeechCardType implements CardTypeStrategy {
   private readonly http = inject(HttpClient);
   private readonly multiModelService = inject(MultiModelService);
 
-  async extractItems(request: ExtractionRequest): Promise<ExtractedItem[]> {
-    const { sourceId, pageNumber, x, y, width, height } = request;
+  async extractItems(request: MultiRegionExtractionRequest): Promise<ExtractedItem[]> {
+    const { sourceId, regions } = request;
 
     const sentenceList = await this.multiModelService.call<SentenceList>(
       'extraction',
       (model: string) =>
         fetchJson<SentenceList>(
           this.http,
-          `/api/source/${sourceId}/page/${pageNumber}/sentences?x=${x}&y=${y}&width=${width}&height=${height}&model=${model}`
+          `/api/source/${sourceId}/sentences?model=${model}`,
+          {
+            body: { regions },
+            method: 'POST',
+          }
         )
     );
 

--- a/client/src/app/cardTypes/vocabulary-card-type.strategy.ts
+++ b/client/src/app/cardTypes/vocabulary-card-type.strategy.ts
@@ -9,7 +9,7 @@ import {
   CardCreationResult,
   CardType,
   ImageGenerationInfo,
-  ExtractionRequest,
+  MultiRegionExtractionRequest,
   ExtractedItem,
   WordList,
   AudioGenerationItem,
@@ -50,15 +50,19 @@ export class VocabularyCardType implements CardTypeStrategy {
   private readonly http = inject(HttpClient);
   private readonly multiModelService = inject(MultiModelService);
 
-  async extractItems(request: ExtractionRequest): Promise<ExtractedItem[]> {
-    const { sourceId, pageNumber, x, y, width, height } = request;
+  async extractItems(request: MultiRegionExtractionRequest): Promise<ExtractedItem[]> {
+    const { sourceId, regions } = request;
 
     const wordList = await this.multiModelService.call<WordList>(
       'extraction',
       (model: string) =>
         fetchJson<WordList>(
           this.http,
-          `/api/source/${sourceId}/page/${pageNumber}/words?x=${x}&y=${y}&width=${width}&height=${height}&model=${model}`
+          `/api/source/${sourceId}/words?model=${model}`,
+          {
+            body: { regions },
+            method: 'POST',
+          }
         )
     );
 

--- a/client/src/app/draggable-selection.directive.ts
+++ b/client/src/app/draggable-selection.directive.ts
@@ -18,12 +18,14 @@ export class DraggableSelectionDirective {
   private startX = 0;
   private startY = 0;
   private rect: HTMLElement | null = null;
+  private shiftKeyPressed = false;
 
   readonly selectionBox = output<{
     x: number;
     y: number;
     width: number;
     height: number;
+    addToGroup: boolean;
   }>();
 
   @HostListener('mousedown', ['$event'])
@@ -38,6 +40,7 @@ export class DraggableSelectionDirective {
     const parentRect = this.el.nativeElement.getBoundingClientRect();
     this.startX = event.pageX - parentRect.left - window.scrollX;
     this.startY = event.pageY - parentRect.top - window.scrollY;
+    this.shiftKeyPressed = event.shiftKey;
     this.createRectangle();
   }
 
@@ -77,7 +80,7 @@ export class DraggableSelectionDirective {
       const y = Math.min(this.startY, endY);
 
       if (width > 5 && height > 5) {
-        this.selectionBox.emit({ x, y, width, height });
+        this.selectionBox.emit({ x, y, width, height, addToGroup: this.shiftKeyPressed });
       }
 
       this.removeRectangle();
@@ -87,12 +90,9 @@ export class DraggableSelectionDirective {
   private createRectangle() {
     this.rect = this.renderer.createElement('div');
     this.renderer.setStyle(this.rect, 'position', 'absolute');
-    this.renderer.setStyle(
-      this.rect,
-      'border',
-      '2px dashed hsl(220, 89%, 53%)'
-    );
-    this.renderer.setStyle(this.rect, 'background', 'hsla(220, 89%, 53%, 0.2)');
+    const color = this.shiftKeyPressed ? 'hsl(280, 89%, 53%)' : 'hsl(220, 89%, 53%)';
+    this.renderer.setStyle(this.rect, 'border', `2px dashed ${color}`);
+    this.renderer.setStyle(this.rect, 'background', this.shiftKeyPressed ? 'hsla(280, 89%, 53%, 0.2)' : 'hsla(220, 89%, 53%, 0.2)');
     this.renderer.appendChild(this.el.nativeElement, this.rect);
   }
 

--- a/client/src/app/parser/page/page.component.css
+++ b/client/src/app/parser/page/page.component.css
@@ -117,3 +117,32 @@
   cursor: pointer;
   border: unset;
 }
+
+.selection-rectangle {
+  position: absolute;
+  border: 2px solid hsl(220, 89%, 53%);
+  background-color: hsla(220, 89%, 53%, 0.1);
+  pointer-events: none;
+  box-sizing: border-box;
+}
+
+.selection-rectangle.grouped {
+  border-color: hsl(280, 89%, 53%);
+  background-color: hsla(280, 89%, 53%, 0.1);
+}
+
+.selection-rectangle .group-badge {
+  position: absolute;
+  top: -10px;
+  right: -10px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background-color: hsl(280, 89%, 53%);
+  color: white;
+  font-size: 12px;
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/client/src/app/parser/page/page.component.css
+++ b/client/src/app/parser/page/page.component.css
@@ -126,7 +126,13 @@
   box-sizing: border-box;
 }
 
-.selection-rectangle.grouped {
+.selection-rectangle.pending {
+  border-style: dashed;
+  border-color: hsl(280, 89%, 53%);
+  background-color: hsla(280, 89%, 53%, 0.15);
+}
+
+.selection-rectangle.grouped:not(.pending) {
   border-color: hsl(280, 89%, 53%);
   background-color: hsla(280, 89%, 53%, 0.1);
 }
@@ -145,4 +151,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.pending-selection-actions {
+  position: fixed;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 1rem;
+  z-index: 100;
 }

--- a/client/src/app/parser/page/page.component.html
+++ b/client/src/app/parser/page/page.component.html
@@ -93,13 +93,14 @@
   <div
     class="selection-rectangle"
     [class.grouped]="rect.isGrouped"
+    [class.pending]="rect.isPending"
     [style.left]="'calc(var(--page-width) * ' + rect.x + ')'"
     [style.top]="'calc(var(--page-width) * ' + rect.y + ')'"
     [style.width]="'calc(var(--page-width) * ' + rect.width + ')'"
     [style.height]="'calc(var(--page-width) * ' + rect.height + ')'"
     [attr.data-group]="rect.groupIndex"
   >
-    @if (rect.isGrouped) {
+    @if (rect.isPending) {
     <span class="group-badge">{{ rect.groupIndex + 1 }}</span>
     }
   </div>
@@ -118,6 +119,19 @@
   ></app-span>
   }
 </section>
+
+@if (hasPendingSelection()) {
+<div class="pending-selection-actions" role="region" aria-label="Selection actions">
+  <button mat-fab extended color="primary" (click)="confirmSelection()" aria-label="Extract text from selection">
+    <mat-icon>check</mat-icon>
+    Extract
+  </button>
+  <button mat-fab extended (click)="cancelSelection()" aria-label="Cancel selection">
+    <mat-icon>close</mat-icon>
+    Cancel
+  </button>
+</div>
+}
 
 @if (formatType() === 'flowingText' && extractedCandidates().length > 0) {
 <div class="extracted-candidates-container" role="region" aria-label="Extracted items">

--- a/client/src/app/parser/page/page.component.html
+++ b/client/src/app/parser/page/page.component.html
@@ -88,7 +88,23 @@
   <div class="area-loading">
     <mat-spinner></mat-spinner>
   </div>
-  } @for (span of spans(); track $index) {
+  }
+  @for (rect of selectedRectangles(); track $index) {
+  <div
+    class="selection-rectangle"
+    [class.grouped]="rect.isGrouped"
+    [style.left]="'calc(var(--page-width) * ' + rect.x + ')'"
+    [style.top]="'calc(var(--page-width) * ' + rect.y + ')'"
+    [style.width]="'calc(var(--page-width) * ' + rect.width + ')'"
+    [style.height]="'calc(var(--page-width) * ' + rect.height + ')'"
+    [attr.data-group]="rect.groupIndex"
+  >
+    @if (rect.isGrouped) {
+    <span class="group-badge">{{ rect.groupIndex + 1 }}</span>
+    }
+  </div>
+  }
+  @for (span of spans(); track $index) {
   <app-span
     [sourceId]="selectedSourceId()"
     [pageNumber]="pageNumber()"

--- a/client/src/app/parser/page/page.component.ts
+++ b/client/src/app/parser/page/page.component.ts
@@ -111,7 +111,7 @@ export class PageComponent implements AfterViewInit, OnDestroy {
 
   constructor() {
     this.route.params.subscribe((params) =>
-      this.pageService.setSource(params['sourceId'], params['pageNumber'])
+      this.pageService.setSource(params['sourceId'], Number(params['pageNumber']))
     );
 
     effect(() => {

--- a/client/src/app/parser/page/page.component.ts
+++ b/client/src/app/parser/page/page.component.ts
@@ -84,6 +84,7 @@ export class PageComponent implements AfterViewInit, OnDestroy {
   );
   readonly documentImage = this.pageService.documentImage;
   readonly selectionRegions = this.pageService.selectionRegions;
+  readonly hasPendingSelection = this.pageService.hasPendingSelection;
   readonly selectedRectangles = computed(() => {
     const pageNumber = this.pageNumber();
     return this.pageService.allSelectedRectangles()
@@ -253,5 +254,13 @@ export class PageComponent implements AfterViewInit, OnDestroy {
 
   ignoreItem(itemId: string): void {
     this.candidatesService.ignoreItem(itemId);
+  }
+
+  confirmSelection(): void {
+    this.pageService.confirmSelection();
+  }
+
+  cancelSelection(): void {
+    this.pageService.cancelPendingSelection();
   }
 }

--- a/client/src/app/parser/page/page.component.ts
+++ b/client/src/app/parser/page/page.component.ts
@@ -83,7 +83,12 @@ export class PageComponent implements AfterViewInit, OnDestroy {
     () => this.pageService.page.value()?.hasImage
   );
   readonly documentImage = this.pageService.documentImage;
-  readonly selectionRegions = this.pageService.selectionRegions
+  readonly selectionRegions = this.pageService.selectionRegions;
+  readonly selectedRectangles = computed(() => {
+    const pageNumber = this.pageNumber();
+    return this.pageService.allSelectedRectangles()
+      .filter(r => r.pageNumber === pageNumber);
+  });
   readonly sourceName = computed(
     () => this.pageService.page.value()?.sourceName
   );
@@ -152,7 +157,7 @@ export class PageComponent implements AfterViewInit, OnDestroy {
     return `calc(var(--page-width) * ${height})`;
   }
 
-  onSelection(event: { x: number; y: number; width: number; height: number }) {
+  onSelection(event: { x: number; y: number; width: number; height: number; addToGroup: boolean }) {
     const pageWidth = this.width();
     const parentRect = this.elRef.nativeElement.getBoundingClientRect();
     const parentWidth = parentRect.width;
@@ -165,7 +170,7 @@ export class PageComponent implements AfterViewInit, OnDestroy {
     const y = pageWidth * event.y / parentWidth;
     const width = pageWidth * event.width / parentWidth;
     const height = pageWidth * event.height / parentWidth;
-    this.pageService.addSelectedRectangle({ x, y, width, height });
+    this.pageService.addSelectedRectangle({ x, y, width, height }, event.addToGroup);
   }
 
   onDragOver(event: DragEvent): void {

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -122,6 +122,14 @@ export type SentenceList = {
   height: number;
 };
 
+export type RegionCoordinates = {
+  pageNumber: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
 export type ExtractionRequest = {
   sourceId: string;
   pageNumber: number;
@@ -129,6 +137,11 @@ export type ExtractionRequest = {
   y: number;
   width: number;
   height: number;
+};
+
+export type MultiRegionExtractionRequest = {
+  sourceId: string;
+  regions: RegionCoordinates[];
 };
 
 export type ExtractionRegion = {
@@ -168,7 +181,7 @@ export type LanguageTexts = {
 
 export type CardTypeStrategy = {
   cardType: CardType;
-  extractItems(request: ExtractionRequest): Promise<ExtractedItem[]>;
+  extractItems(request: MultiRegionExtractionRequest): Promise<ExtractedItem[]>;
   getItemLabel(item: ExtractedItem): string;
   filterItemsBySearchTerm(
     items: ExtractedItem[],

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/MultiRegionExtractionRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/MultiRegionExtractionRequest.java
@@ -1,0 +1,12 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MultiRegionExtractionRequest {
+    private List<RegionCoordinates> regions;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/RegionCoordinates.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/RegionCoordinates.java
@@ -1,0 +1,14 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class RegionCoordinates {
+    private int pageNumber;
+    private double x;
+    private double y;
+    private double width;
+    private double height;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/AreaGrammarService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/AreaGrammarService.java
@@ -22,8 +22,8 @@ public class AreaGrammarService {
 
   private final ChatService chatService;
 
-  private String buildSystemPrompt(LanguageLevel languageLevel) {
-    return """
+  private String buildSystemPrompt(LanguageLevel languageLevel, boolean isMultiRegion) {
+    final String basePrompt = """
         You are a linguistic expert specializing in German grammar exercises.
         Your task is to extract German sentences from the provided page image that can be used for grammar practice (fill-in-the-blank exercises).
         These sentences will be used for grammar practice where learners need to fill in missing parts.
@@ -38,19 +38,38 @@ public class AreaGrammarService {
         3. Use AI knowledge to correctly fill in any blanks/placeholders based on German grammar rules
         4. Mark gaps by wrapping the filled-in words with square brackets, e.g. "Und [das] ist Frau Muller."
         5. SKIP any handwritten text (text that appears to be written by hand/pencil)
-        6. SKIP partial sentences or sentence fragments
-        7. Only include sentences that have proper beginning and ending punctuation
-        8. If no gaps are visible in a sentence, still extract it without any brackets - gaps can be added later during editing
+        6. Only include sentences that have proper beginning and ending punctuation
+        7. If no gaps are visible in a sentence, still extract it without any brackets - gaps can be added later during editing""".formatted(languageLevel.name());
+
+    final String multiRegionInstructions = isMultiRegion ? """
+
+        IMPORTANT - MULTI-REGION EXTRACTION:
+        The image contains multiple selected regions separated by gray horizontal lines.
+        These regions may contain parts of the same sentence that spans across page columns or pages.
+        When you detect that text from one region continues into the next region (forming a complete sentence together):
+        - Join the sentence parts into a single complete sentence
+        - Remove any hyphenation at line breaks (e.g., "Kin-" + "der" becomes "Kinder")
+        - Ensure proper spacing when joining parts
+        - Preserve any gap markers [brackets] when joining
+        Only include sentences that are complete after joining parts from multiple regions if needed.""" : """
+
+        8. SKIP partial sentences or sentence fragments""";
+
+    return basePrompt + multiRegionInstructions + """
 
         Example of the expected JSON response:
-        {"sentences":[{"sentence":"Ich gehe jeden [Tag] in die Schule."},{"sentence":"Der Hund [läuft] schnell durch [den] Park."}]}""".formatted(languageLevel.name());
+        {"sentences":[{"sentence":"Ich gehe jeden [Tag] in die Schule."},{"sentence":"Der Hund [läuft] schnell durch [den] Park."}]}""";
   }
 
   public List<GrammarSentence> getAreaGrammarSentences(byte[] imageData, ChatModel model, LanguageLevel languageLevel) {
+    return getAreaGrammarSentences(imageData, model, languageLevel, false);
+  }
+
+  public List<GrammarSentence> getAreaGrammarSentences(byte[] imageData, ChatModel model, LanguageLevel languageLevel, boolean isMultiRegion) {
     final var result = chatService.callWithLoggingAndMedia(
         model,
         "extraction",
-        buildSystemPrompt(languageLevel),
+        buildSystemPrompt(languageLevel, isMultiRegion),
         u -> u
             .text("Here is the image of the page")
             .media(Media.builder()


### PR DESCRIPTION
## Summary
This PR implements support for extracting content from multiple regions across pages, enabling users to select and group multiple text areas for a single card. Previously, only single rectangular selections were supported.

## Key Changes

### Frontend
- **Multi-region selection grouping**: Modified `DraggableSelectionDirective` to track Shift key presses, allowing users to hold Shift while dragging to add regions to the current group
- **Visual feedback**: Selection rectangles now display different colors (blue for single regions, purple for grouped regions) and show group badges with numbers
- **Region management**: Updated `PageService` to manage `RegionGroups` instead of individual rectangles, with support for computing bounding rectangles across multiple regions
- **API updates**: Changed card type strategies to use `MultiRegionExtractionRequest` instead of single-region `ExtractionRequest`, sending regions as POST body instead of query parameters

### Backend
- **New endpoints**: Added POST endpoints for `/source/{sourceId}/words`, `/source/{sourceId}/sentences`, and `/source/{sourceId}/grammar` to handle multi-region extraction
- **Image composition**: Implemented `getMultiplePageAreas()` in `DocumentProcessorService` to combine multiple page regions into a single image with visual separators (gray lines)
- **Enhanced prompts**: Updated AI service prompts in `AreaSentenceService` and `AreaGrammarService` to handle multi-region text that may span across page boundaries, with instructions to join sentence fragments and remove hyphenation
- **New models**: Added `MultiRegionExtractionRequest` and `RegionCoordinates` data models

### Documentation
- Updated TODO.md to mark "support for grammar card type" and "support multi part regions" as completed

## Implementation Details
- Regions within a group are combined into a single image with 20px gray separator lines between them
- The AI models receive context about multi-region extraction and are instructed to join sentence fragments that span regions
- Bounding rectangles are computed across all regions in a group for display purposes
- Users can add regions to the current group by holding Shift while dragging; releasing Shift creates a new group