### PR TITLE
Track AI model selection for translations and classifications

### DIFF
--- a/client/src/app/cardTypes/grammar-card-type.strategy.ts
+++ b/client/src/app/cardTypes/grammar-card-type.strategy.ts
@@ -97,8 +97,8 @@ export class GrammarCardType implements CardTypeStrategy {
 
     try {
       progressCallback(30, 'Translating to English...');
-      const englishTranslation =
-        await this.multiModelService.call<SentenceTranslationResponse>(
+      const englishResult =
+        await this.multiModelService.callWithModel<SentenceTranslationResponse>(
           'translation',
           (model: string) =>
             fetchJson<SentenceTranslationResponse>(
@@ -113,12 +113,12 @@ export class GrammarCardType implements CardTypeStrategy {
 
       progressCallback(80, 'Preparing grammar card data...');
 
-      const imageGenerationInfos: ImageGenerationInfo[] = englishTranslation.translation
+      const imageGenerationInfos: ImageGenerationInfo[] = englishResult.response.translation
         ? [
             {
               cardId: sentence.id,
               exampleIndex: 0,
-              englishTranslation: englishTranslation.translation,
+              englishTranslation: englishResult.response.translation,
             },
           ]
         : [];
@@ -127,11 +127,12 @@ export class GrammarCardType implements CardTypeStrategy {
         examples: [
           {
             de: sentence.sentence,
-            en: englishTranslation.translation,
+            en: englishResult.response.translation,
             isSelected: true,
             images: [],
           },
         ],
+        translationModel: englishResult.model,
       };
 
       return { cardData, imageGenerationInfos };

--- a/client/src/app/cardTypes/speech-card-type.strategy.ts
+++ b/client/src/app/cardTypes/speech-card-type.strategy.ts
@@ -96,8 +96,8 @@ export class SpeechCardType implements CardTypeStrategy {
 
     try {
       progressCallback(20, 'Translating to Hungarian...');
-      const hungarianTranslation =
-        await this.multiModelService.call<SentenceTranslationResponse>(
+      const hungarianResult =
+        await this.multiModelService.callWithModel<SentenceTranslationResponse>(
           'translation',
           (model: string) =>
             fetchJson<SentenceTranslationResponse>(
@@ -111,8 +111,8 @@ export class SpeechCardType implements CardTypeStrategy {
         );
 
       progressCallback(50, 'Translating to English...');
-      const englishTranslation =
-        await this.multiModelService.call<SentenceTranslationResponse>(
+      const englishResult =
+        await this.multiModelService.callWithModel<SentenceTranslationResponse>(
           'translation',
           (model: string) =>
             fetchJson<SentenceTranslationResponse>(
@@ -127,12 +127,12 @@ export class SpeechCardType implements CardTypeStrategy {
 
       progressCallback(80, 'Preparing speech card data...');
 
-      const imageGenerationInfos: ImageGenerationInfo[] = englishTranslation.translation
+      const imageGenerationInfos: ImageGenerationInfo[] = englishResult.response.translation
         ? [
             {
               cardId: sentence.id,
               exampleIndex: 0,
-              englishTranslation: englishTranslation.translation,
+              englishTranslation: englishResult.response.translation,
             },
           ]
         : [];
@@ -141,12 +141,13 @@ export class SpeechCardType implements CardTypeStrategy {
         examples: [
           {
             de: sentence.sentence,
-            hu: hungarianTranslation.translation,
-            en: englishTranslation.translation,
+            hu: hungarianResult.response.translation,
+            en: englishResult.response.translation,
             isSelected: true,
             images: [],
           },
         ],
+        translationModel: hungarianResult.model,
       };
 
       return { cardData, imageGenerationInfos };

--- a/client/src/app/cardTypes/vocabulary-card-type.strategy.ts
+++ b/client/src/app/cardTypes/vocabulary-card-type.strategy.ts
@@ -122,7 +122,7 @@ export class VocabularyCardType implements CardTypeStrategy {
 
     try {
       progressCallback(10, 'Detecting word type...');
-      const wordType = await this.multiModelService.call<WordTypeResponse>(
+      const wordTypeResult = await this.multiModelService.callWithModel<WordTypeResponse>(
         'classification',
         (model: string) => fetchJson<WordTypeResponse>(
           this.http,
@@ -133,9 +133,10 @@ export class VocabularyCardType implements CardTypeStrategy {
           }
         )
       );
+      const classificationModel = wordTypeResult.model;
 
       let gender: string | undefined;
-      if (wordType.type === 'NOUN') {
+      if (wordTypeResult.response.type === 'NOUN') {
         progressCallback(30, 'Detecting gender...');
         const genderResponse = await this.multiModelService.call<GenderResponse>(
           'classification',
@@ -152,9 +153,9 @@ export class VocabularyCardType implements CardTypeStrategy {
       }
 
       progressCallback(50, 'Translating to multiple languages...');
-      const translations = await Promise.all(
+      const translationResults = await Promise.all(
         languages.map(async (languageCode) => {
-          const translation = await this.multiModelService.call<TranslationResponse>(
+          const result = await this.multiModelService.callWithModel<TranslationResponse>(
             'translation',
             (model: string) => fetchJson<TranslationResponse>(
               this.http,
@@ -165,18 +166,19 @@ export class VocabularyCardType implements CardTypeStrategy {
               }
             )
           );
-          return { languageCode, translation };
+          return { languageCode, translation: result.response, model: result.model };
         })
       );
 
+      const translationModel = translationResults[0]?.model;
       const translationMap = Object.fromEntries(
-        translations.map(({ languageCode, translation }) => [
+        translationResults.map(({ languageCode, translation }) => [
           languageCode,
           translation.translation
         ])
       );
       const exampleTranslations = Object.fromEntries(
-        translations.map(({ languageCode, translation }) => [
+        translationResults.map(({ languageCode, translation }) => [
           languageCode,
           translation.examples || []
         ])
@@ -200,7 +202,7 @@ export class VocabularyCardType implements CardTypeStrategy {
 
       const cardData = {
         word: word.word,
-        type: wordType.type,
+        type: wordTypeResult.response.type,
         gender: gender,
         translation: translationMap,
         forms: word.forms,
@@ -214,7 +216,9 @@ export class VocabularyCardType implements CardTypeStrategy {
           ]),
           isSelected: index === 0,
           images: []
-        }))
+        })),
+        translationModel,
+        classificationModel,
       };
 
       return { cardData, imageGenerationInfos };

--- a/client/src/app/multi-model.service.ts
+++ b/client/src/app/multi-model.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { ENVIRONMENT_CONFIG } from './environment/environment.config';
 
-interface ModelResponse<T> {
+export interface ModelResponse<T> {
   model: string;
   response: T;
 }
@@ -16,6 +16,14 @@ export class MultiModelService {
     operationType: string,
     apiCall: (model: string) => Promise<T>
   ): Promise<T> {
+    const result = await this.callWithModel(operationType, apiCall);
+    return result.response;
+  }
+
+  async callWithModel<T>(
+    operationType: string,
+    apiCall: (model: string) => Promise<T>
+  ): Promise<ModelResponse<T>> {
     const enabledModelNames = this.environmentConfig.enabledModelsByOperation[operationType] ?? [];
     const modelsToUse = this.environmentConfig.chatModels.filter(m =>
       enabledModelNames.includes(m.modelName)
@@ -43,11 +51,11 @@ export class MultiModelService {
 
     if (!primaryResponse) {
       if (successfulResponses.length > 0) {
-        return successfulResponses[0].response;
+        return successfulResponses[0];
       }
       throw new Error(`Primary model ${primaryModelName} failed and no other models succeeded`);
     }
 
-    return primaryResponse.response;
+    return primaryResponse;
   }
 }

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -54,6 +54,7 @@ export type CardData = {
   audioVoice?: string;
   translationModel?: string;
   classificationModel?: string;
+  extractionModel?: string;
 };
 
 export type Card = {
@@ -98,6 +99,7 @@ export type CardType = 'vocabulary' | 'speech' | 'grammar';
 export type ExtractedItem = {
   id: string;
   exists: boolean;
+  extractionModel?: string;
 };
 
 export type Sentence = ExtractedItem & {

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -52,6 +52,8 @@ export type CardData = {
   examples?: Example[];
   audio?: AudioData[];
   audioVoice?: string;
+  translationModel?: string;
+  classificationModel?: string;
 };
 
 export type Card = {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardData.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardData.java
@@ -32,4 +32,7 @@ public class CardData {
 
     @JsonInclude(Include.NON_NULL)
     private String classificationModel;
+
+    @JsonInclude(Include.NON_NULL)
+    private String extractionModel;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardData.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardData.java
@@ -26,4 +26,10 @@ public class CardData {
 
     @JsonInclude(Include.NON_NULL)
     private List<AudioData> audio;
+
+    @JsonInclude(Include.NON_NULL)
+    private String translationModel;
+
+    @JsonInclude(Include.NON_NULL)
+    private String classificationModel;
 }

--- a/test/tests/bulk-card-creation.spec.ts
+++ b/test/tests/bulk-card-creation.spec.ts
@@ -373,6 +373,7 @@ test('bulk card creation includes word data', async ({ page }) => {
 
     expect(cardData.translationModel).toBe('gemini-3-pro-preview');
     expect(cardData.classificationModel).toBe('gemini-3-pro-preview');
+    expect(cardData.extractionModel).toBe('gemini-3-pro-preview');
 
     const result2 = await client.query("SELECT data FROM learn_language.cards WHERE id = 'abfahrt-indulas'");
     expect(result2.rows.length).toBe(1);
@@ -385,6 +386,7 @@ test('bulk card creation includes word data', async ({ page }) => {
     expect(cardData2.forms).toEqual(['die Abfahrten']);
     expect(cardData2.translationModel).toBe('gemini-3-pro-preview');
     expect(cardData2.classificationModel).toBe('gemini-3-pro-preview');
+    expect(cardData2.extractionModel).toBe('gemini-3-pro-preview');
   });
 });
 
@@ -599,12 +601,14 @@ test('bulk speech card creation includes sentence data', async ({ page }) => {
     expect(card1?.data.examples[0].hu).toBe('Hogy hívják a dalt?');
     expect(card1?.data.examples[0].en).toBe('What is the name of the song?');
     expect(card1?.data.translationModel).toBe('gemini-3-pro-preview');
+    expect(card1?.data.extractionModel).toBe('gemini-3-pro-preview');
 
     const card2 = result.rows.find((row) => row.data.examples?.[0]?.de === 'Hören Sie.');
     expect(card2).toBeDefined();
     expect(card2?.data.examples[0].hu).toBe('Hallgasson.');
     expect(card2?.data.examples[0].en).toBe('Listen.');
     expect(card2?.data.translationModel).toBe('gemini-3-pro-preview');
+    expect(card2?.data.extractionModel).toBe('gemini-3-pro-preview');
   });
 });
 
@@ -662,10 +666,12 @@ test('bulk grammar card creation extracts sentences with gaps', async ({ page })
     expect(card1?.data.examples[0].de).toContain('[ist]');
 
     expect(card1?.data.translationModel).toBe('gemini-3-pro-preview');
+    expect(card1?.data.extractionModel).toBe('gemini-3-pro-preview');
 
     const card2 = result.rows.find((row) => row.data.examples?.[0]?.de === 'Und [das] ist Frau Wachter.');
     expect(card2).toBeDefined();
     expect(card2?.data.examples[0].de).toContain('[das]');
     expect(card2?.data.translationModel).toBe('gemini-3-pro-preview');
+    expect(card2?.data.extractionModel).toBe('gemini-3-pro-preview');
   });
 });

--- a/test/tests/bulk-card-creation.spec.ts
+++ b/test/tests/bulk-card-creation.spec.ts
@@ -371,6 +371,9 @@ test('bulk card creation includes word data', async ({ page }) => {
     expect(cardData.examples[0].images[3].model).toBe('Gemini 3 Pro');
     expect(cardData.examples[1].images[0].model).toBe('GPT Image 1');
 
+    expect(cardData.translationModel).toBe('gemini-3-pro-preview');
+    expect(cardData.classificationModel).toBe('gemini-3-pro-preview');
+
     const result2 = await client.query("SELECT data FROM learn_language.cards WHERE id = 'abfahrt-indulas'");
     expect(result2.rows.length).toBe(1);
     const cardData2 = result2.rows[0].data;
@@ -380,6 +383,8 @@ test('bulk card creation includes word data', async ({ page }) => {
     expect(cardData2.type).toBe('NOUN');
     expect(cardData2.gender).toBe('FEMININE');
     expect(cardData2.forms).toEqual(['die Abfahrten']);
+    expect(cardData2.translationModel).toBe('gemini-3-pro-preview');
+    expect(cardData2.classificationModel).toBe('gemini-3-pro-preview');
   });
 });
 
@@ -593,10 +598,13 @@ test('bulk speech card creation includes sentence data', async ({ page }) => {
     expect(card1?.data.examples[0].de).toBe('Wie heißt das Lied?');
     expect(card1?.data.examples[0].hu).toBe('Hogy hívják a dalt?');
     expect(card1?.data.examples[0].en).toBe('What is the name of the song?');
+    expect(card1?.data.translationModel).toBe('gemini-3-pro-preview');
+
     const card2 = result.rows.find((row) => row.data.examples?.[0]?.de === 'Hören Sie.');
     expect(card2).toBeDefined();
     expect(card2?.data.examples[0].hu).toBe('Hallgasson.');
     expect(card2?.data.examples[0].en).toBe('Listen.');
+    expect(card2?.data.translationModel).toBe('gemini-3-pro-preview');
   });
 });
 
@@ -653,8 +661,11 @@ test('bulk grammar card creation extracts sentences with gaps', async ({ page })
     expect(card1?.data.examples[0].en).toBe('This is Paco.');
     expect(card1?.data.examples[0].de).toContain('[ist]');
 
+    expect(card1?.data.translationModel).toBe('gemini-3-pro-preview');
+
     const card2 = result.rows.find((row) => row.data.examples?.[0]?.de === 'Und [das] ist Frau Wachter.');
     expect(card2).toBeDefined();
     expect(card2?.data.examples[0].de).toContain('[das]');
+    expect(card2?.data.translationModel).toBe('gemini-3-pro-preview');
   });
 });


### PR DESCRIPTION
## Summary
This PR adds tracking of which AI model was used for translation and classification operations during card creation. The selected model information is now captured and stored with the card data for transparency and debugging purposes.

## Key Changes

- **MultiModelService refactoring**: 
  - Renamed `call()` method to `callWithModel()` to better reflect its behavior of returning both the response and the model used
  - Created new `call()` method that wraps `callWithModel()` and returns only the response for backward compatibility
  - Exported `ModelResponse<T>` interface for type safety

- **Card type strategies updated**:
  - Grammar card type: Now captures and stores the translation model used
  - Speech card type: Now captures and stores the translation model used
  - Vocabulary card type: Now captures both translation and classification models used

- **Data model updates**:
  - Added `translationModel` and `classificationModel` optional fields to `CardData` type in both client and server
  - Updated server-side `CardData.java` entity to include these new fields with `@JsonInclude(NON_NULL)` annotation

- **Test coverage**:
  - Updated bulk card creation tests to verify that model information is correctly stored in card data
  - Tests now assert that the expected model names are present in the created cards

## Implementation Details

The changes maintain backward compatibility by keeping the original `call()` method signature while introducing `callWithModel()` for cases where model tracking is needed. This allows gradual migration of code to use model tracking where appropriate.

The model information is stored at the card level, enabling future features like model performance tracking, A/B testing, or model-specific card handling.

https://claude.ai/code/session_019vBWEjUaZHwxw6Ks3cCnWz