### PR TITLE
Add cards table view with filtering and bulk actions

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -20,6 +20,8 @@
         "@angular/router": "21.1.2",
         "@azure/msal-angular": "5.0.3",
         "@azure/msal-browser": "5.1.0",
+        "ag-grid-angular": "^35.0.1",
+        "ag-grid-community": "^35.0.1",
         "rxjs": "7.8.2",
         "ts-fsrs": "5.2.3",
         "tslib": "2.8.1",
@@ -6271,6 +6273,35 @@
       },
       "engines": {
         "node": ">=8.9.0"
+      }
+    },
+    "node_modules/ag-charts-types": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/ag-charts-types/-/ag-charts-types-13.0.1.tgz",
+      "integrity": "sha512-qg9adyiAaeUaDtWZEEPF45dv55kdJTe6Ghi0EQXCS79h/7KvOd6dxhqGZjPL1zeFl/L9qEXuYgb+LkGStq4mgQ==",
+      "license": "MIT"
+    },
+    "node_modules/ag-grid-angular": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/ag-grid-angular/-/ag-grid-angular-35.0.1.tgz",
+      "integrity": "sha512-+Y1K/ZxiEbd3GhZcRWzLf60yiP4ECNoTCCqI65EgHiiRGInz3g1pDueArR7hE7V+z5gluA3NMGB3VrOZYUBKLg==",
+      "license": "MIT",
+      "dependencies": {
+        "ag-grid-community": "35.0.1",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">= 18.0.0",
+        "@angular/core": ">= 18.0.0"
+      }
+    },
+    "node_modules/ag-grid-community": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-35.0.1.tgz",
+      "integrity": "sha512-fYYZdymWKsN9/tZv+R6uZRnuiWYEQr+GHl85ZrB0ixbFcE8opYK4NJI29NnMc9ShYiCBnAO9hj54IFa+FI4aDA==",
+      "license": "MIT",
+      "dependencies": {
+        "ag-charts-types": "13.0.1"
       }
     },
     "node_modules/agent-base": {

--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,8 @@
     "@angular/router": "21.1.2",
     "@azure/msal-angular": "5.0.3",
     "@azure/msal-browser": "5.1.0",
+    "ag-grid-angular": "^35.0.1",
+    "ag-grid-community": "^35.0.1",
     "rxjs": "7.8.2",
     "ts-fsrs": "5.2.3",
     "tslib": "2.8.1",

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -32,6 +32,13 @@ export const routes: Routes = [
     title: 'Cards In Review',
   },
   {
+    path: 'cards',
+    loadComponent: () =>
+      import('./cards-table/cards-table.component').then((m) => m.CardsTableComponent),
+    canActivate: [conditionalAuthGuard],
+    title: 'All Cards',
+  },
+  {
     path: 'model-usage',
     loadComponent: () =>
       import('./model-usage-logs/model-usage-logs.component').then((m) => m.ModelUsageLogsComponent),

--- a/client/src/app/cards-table/cards-table.component.css
+++ b/client/src/app/cards-table/cards-table.component.css
@@ -1,0 +1,137 @@
+:host {
+  display: block;
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+.container {
+  padding: 2rem 0;
+}
+
+h1 {
+  color: var(--mat-sys-on-surface);
+  margin-bottom: 1.5rem;
+}
+
+.filters-section {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  padding: 1rem;
+  background: var(--mat-sys-surface-container);
+  border-radius: 8px;
+}
+
+.filter-field {
+  min-width: 140px;
+  flex: 1;
+  max-width: 200px;
+}
+
+.actions-bar {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  padding: 0.75rem 1rem;
+  background: var(--mat-sys-secondary-container);
+  border-radius: 8px;
+  align-items: center;
+}
+
+.cards-grid {
+  width: 100%;
+}
+
+.cards-grid :deep(.ag-row) {
+  cursor: pointer;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 3rem;
+  margin-top: 2rem;
+  background: var(--mat-sys-surface);
+  border: 1px solid var(--mat-sys-surface-container);
+}
+
+.empty-icon {
+  font-size: 4rem;
+  width: 4rem;
+  height: 4rem;
+  color: var(--mat-sys-primary);
+  margin-bottom: 1rem;
+}
+
+.empty-state h2 {
+  color: var(--mat-sys-on-surface);
+  margin-bottom: 0.5rem;
+}
+
+.empty-state p {
+  color: var(--mat-app-text-color);
+  margin: 0;
+}
+
+.grid-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  background: var(--mat-sys-surface-container);
+  border-radius: 8px;
+}
+
+.skeleton-row {
+  display: flex;
+  gap: 2rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--mat-sys-outline-variant);
+}
+
+.skeleton {
+  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+  background-size: 200% 100%;
+  animation: loading 1.5s infinite;
+  border-radius: 4px;
+}
+
+.skeleton-text-small {
+  height: 16px;
+  width: 60px;
+}
+
+.skeleton-text-medium {
+  height: 18px;
+  width: 120px;
+}
+
+@keyframes loading {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+@media (max-width: 768px) {
+  :host {
+    padding: 0 1rem;
+  }
+
+  .container {
+    padding: 1rem 0;
+  }
+
+  .filters-section {
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.75rem;
+  }
+
+  .filter-field {
+    max-width: 100%;
+  }
+}

--- a/client/src/app/cards-table/cards-table.component.html
+++ b/client/src/app/cards-table/cards-table.component.html
@@ -1,0 +1,106 @@
+<div class="container">
+  <h1>All Cards</h1>
+
+  @if (hasRows()) {
+  <div class="filters-section">
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>Reviews</mat-label>
+      <mat-select
+        [value]="reviewCountFilter()"
+        (selectionChange)="onReviewCountFilterChange($event.value)"
+        aria-label="Filter by review count"
+      >
+        <mat-option value="ALL">All</mat-option>
+        <mat-option value="0">0</mat-option>
+        <mat-option value="1-5">1 - 5</mat-option>
+        <mat-option value="6-10">6 - 10</mat-option>
+        <mat-option value="10+">10+</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>Last Review Date</mat-label>
+      <mat-select
+        [value]="lastReviewDateFilter()"
+        (selectionChange)="onLastReviewDateFilterChange($event.value)"
+        aria-label="Filter by last review date"
+      >
+        <mat-option value="ALL">All dates</mat-option>
+        @for (option of availableDates(); track option.value) {
+          <mat-option [value]="option.value">{{ option.label }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>Grade</mat-label>
+      <mat-select
+        [value]="lastReviewGradeFilter()"
+        (selectionChange)="onLastReviewGradeFilterChange($event.value)"
+        aria-label="Filter by last review grade"
+      >
+        <mat-option value="ALL">All grades</mat-option>
+        <mat-option value="1">Again</mat-option>
+        <mat-option value="2">Hard</mat-option>
+        <mat-option value="3">Good</mat-option>
+        <mat-option value="4">Easy</mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
+  }
+
+  @if (selectionCount() > 0) {
+  <div class="actions-bar">
+    <button
+      mat-raised-button
+      color="primary"
+      (click)="markSelectedAsKnown()"
+      aria-label="Mark selected cards as known"
+    >
+      <mat-icon>check_circle</mat-icon>
+      Mark {{ selectionCount() }} card(s) as known
+    </button>
+  </div>
+  }
+
+  @if (loading()) {
+  <div class="grid-skeleton">
+    @for (i of [1, 2, 3, 4, 5]; track i) {
+    <div class="skeleton-row">
+      <div class="skeleton skeleton-text-small"></div>
+      <div class="skeleton skeleton-text-medium"></div>
+      <div class="skeleton skeleton-text-small"></div>
+      <div class="skeleton skeleton-text-medium"></div>
+      <div class="skeleton skeleton-text-small"></div>
+      <div class="skeleton skeleton-text-medium"></div>
+      <div class="skeleton skeleton-text-small"></div>
+    </div>
+    }
+  </div>
+  } @else if (hasRows()) {
+  <ag-grid-angular
+    class="cards-grid"
+    [theme]="theme"
+    [rowData]="rows()"
+    [columnDefs]="columnDefs"
+    [defaultColDef]="defaultColDef"
+    [rowSelection]="'multiple'"
+    [suppressRowClickSelection]="true"
+    [animateRows]="true"
+    [rowHeight]="48"
+    [headerHeight]="48"
+    [domLayout]="'autoHeight'"
+    (gridReady)="onGridReady($event)"
+    (selectionChanged)="onSelectionChanged($event)"
+    (rowClicked)="onRowClicked($event)"
+  />
+  } @else {
+  <mat-card class="empty-state">
+    <mat-card-content>
+      <mat-icon class="empty-icon">style</mat-icon>
+      <h2>No cards yet</h2>
+      <p>Cards will appear here once created from source pages.</p>
+    </mat-card-content>
+  </mat-card>
+  }
+</div>

--- a/client/src/app/cards-table/cards-table.component.ts
+++ b/client/src/app/cards-table/cards-table.component.ts
@@ -1,0 +1,209 @@
+import { Component, inject, computed, signal } from '@angular/core';
+import { Router } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSelectModule } from '@angular/material/select';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatCardModule } from '@angular/material/card';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { AgGridAngular } from 'ag-grid-angular';
+import {
+  AllCommunityModule,
+  ModuleRegistry,
+  themeQuartz,
+} from 'ag-grid-community';
+import type {
+  ColDef,
+  RowClickedEvent,
+  SelectionChangedEvent,
+  GridReadyEvent,
+  GridApi,
+} from 'ag-grid-community';
+import {
+  CardsTableService,
+  CardTableRow,
+  ReviewCountRange,
+  GradeFilter,
+} from './cards-table.service';
+
+ModuleRegistry.registerModules([AllCommunityModule]);
+
+const GRADE_LABELS: Record<number, string> = {
+  1: 'Again',
+  2: 'Hard',
+  3: 'Good',
+  4: 'Easy',
+};
+
+@Component({
+  selector: 'app-cards-table',
+  standalone: true,
+  imports: [
+    AgGridAngular,
+    MatButtonModule,
+    MatIconModule,
+    MatSelectModule,
+    MatFormFieldModule,
+    MatCardModule,
+  ],
+  templateUrl: './cards-table.component.html',
+  styleUrl: './cards-table.component.css',
+})
+export class CardsTableComponent {
+  private readonly service = inject(CardsTableService);
+  private readonly router = inject(Router);
+  private readonly snackBar = inject(MatSnackBar);
+
+  private gridApi: GridApi | undefined;
+
+  readonly loading = computed(() => this.service.cards.isLoading());
+  readonly rows = this.service.filteredRows;
+  readonly selectedRows = signal<CardTableRow[]>([]);
+
+  readonly reviewCountFilter = this.service.reviewCountFilter;
+  readonly lastReviewDateFilter = this.service.lastReviewDateFilter;
+  readonly lastReviewGradeFilter = this.service.lastReviewGradeFilter;
+  readonly availableDates = this.service.availableDates;
+
+  readonly hasRows = computed(() => (this.service.cards.value() ?? []).length > 0);
+  readonly selectionCount = computed(() => this.selectedRows().length);
+
+  readonly theme = themeQuartz.withParams({
+    backgroundColor: 'var(--mat-sys-surface)',
+    foregroundColor: 'var(--mat-sys-on-surface)',
+    headerBackgroundColor: 'var(--mat-sys-surface-container)',
+    headerTextColor: 'var(--mat-sys-on-surface)',
+    rowHoverColor: 'var(--mat-sys-surface-container-highest)',
+    borderColor: 'var(--mat-sys-outline-variant)',
+    selectedRowBackgroundColor: 'var(--mat-sys-secondary-container)',
+    headerFontWeight: 500,
+  });
+
+  readonly columnDefs: ColDef<CardTableRow>[] = [
+    {
+      headerCheckboxSelection: true,
+      checkboxSelection: true,
+      maxWidth: 50,
+      sortable: false,
+      filter: false,
+      resizable: false,
+    },
+    {
+      headerName: 'Source Name',
+      field: 'sourceName',
+      flex: 1,
+      minWidth: 120,
+    },
+    {
+      headerName: 'Source Type',
+      field: 'sourceType',
+      maxWidth: 120,
+      valueFormatter: (params) => params.value ?? '-',
+    },
+    {
+      headerName: 'Card Label',
+      field: 'label',
+      flex: 2,
+      minWidth: 150,
+    },
+    {
+      headerName: 'Reviews',
+      field: 'reviewCount',
+      maxWidth: 100,
+      sort: 'desc',
+    },
+    {
+      headerName: 'Last Review',
+      field: 'lastReviewDate',
+      flex: 1,
+      minWidth: 140,
+      valueFormatter: (params) => {
+        if (!params.value) return '-';
+        return new Date(params.value).toLocaleDateString('en-US', {
+          month: 'short',
+          day: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit',
+        });
+      },
+    },
+    {
+      headerName: 'Grade',
+      field: 'lastReviewGrade',
+      maxWidth: 100,
+      valueFormatter: (params) =>
+        params.value !== null && params.value !== undefined
+          ? GRADE_LABELS[params.value] ?? String(params.value)
+          : '-',
+    },
+    {
+      headerName: 'Reviewer',
+      field: 'lastReviewPerson',
+      maxWidth: 120,
+      valueFormatter: (params) => params.value ?? '-',
+    },
+  ];
+
+  readonly defaultColDef: ColDef = {
+    sortable: true,
+    resizable: true,
+  };
+
+  onGridReady(event: GridReadyEvent): void {
+    this.gridApi = event.api;
+  }
+
+  onSelectionChanged(event: SelectionChangedEvent<CardTableRow>): void {
+    const selected = event.api.getSelectedRows();
+    this.selectedRows.set(selected);
+  }
+
+  onRowClicked(event: RowClickedEvent<CardTableRow>): void {
+    const target = event.event?.target as HTMLElement | undefined;
+    if (target?.closest('.ag-checkbox-input-wrapper')) {
+      return;
+    }
+
+    const row = event.data;
+    if (row) {
+      this.router.navigate([
+        '/sources',
+        row.sourceId,
+        'page',
+        row.sourcePageNumber,
+        'cards',
+        row.id,
+      ]);
+    }
+  }
+
+  onReviewCountFilterChange(value: ReviewCountRange): void {
+    this.service.reviewCountFilter.set(value);
+  }
+
+  onLastReviewDateFilterChange(value: string): void {
+    this.service.lastReviewDateFilter.set(value);
+  }
+
+  onLastReviewGradeFilterChange(value: GradeFilter): void {
+    this.service.lastReviewGradeFilter.set(value);
+  }
+
+  async markSelectedAsKnown(): Promise<void> {
+    const selected = this.selectedRows();
+    if (selected.length === 0) return;
+
+    const cardIds = selected.map((row) => row.id);
+    await this.service.markAsKnown(cardIds);
+
+    this.gridApi?.deselectAll();
+    this.snackBar.open(
+      `${cardIds.length} card(s) marked as known`,
+      'Close',
+      {
+        duration: 3000,
+        verticalPosition: 'top',
+      }
+    );
+  }
+}

--- a/client/src/app/cards-table/cards-table.service.ts
+++ b/client/src/app/cards-table/cards-table.service.ts
@@ -1,0 +1,106 @@
+import { Injectable, inject, resource, signal, computed } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { fetchJson } from '../utils/fetchJson';
+
+export type CardTableRow = {
+  id: string;
+  sourceName: string;
+  sourceType: string | null;
+  label: string;
+  reviewCount: number;
+  lastReviewDate: string | null;
+  lastReviewGrade: number | null;
+  lastReviewPerson: string | null;
+  readiness: string;
+  sourceId: string;
+  sourcePageNumber: number;
+};
+
+export type ReviewCountRange = 'ALL' | '0' | '1-5' | '6-10' | '10+';
+export type GradeFilter = 'ALL' | '1' | '2' | '3' | '4';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CardsTableService {
+  private readonly http = inject(HttpClient);
+
+  readonly reviewCountFilter = signal<ReviewCountRange>('ALL');
+  readonly lastReviewDateFilter = signal<string>('ALL');
+  readonly lastReviewGradeFilter = signal<GradeFilter>('ALL');
+
+  readonly cards = resource<CardTableRow[], unknown>({
+    loader: async () => {
+      return await fetchJson<CardTableRow[]>(this.http, '/api/cards/table');
+    },
+  });
+
+  readonly availableDates = computed(() => {
+    const rows = this.cards.value() ?? [];
+    const dateSet = new Set<string>();
+    rows.forEach((row) => {
+      if (row.lastReviewDate) {
+        dateSet.add(row.lastReviewDate.split('T')[0]);
+      }
+    });
+    const today = new Date().toISOString().split('T')[0];
+    const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+
+    return Array.from(dateSet)
+      .sort((a, b) => b.localeCompare(a))
+      .map((date) => ({
+        label:
+          date === today
+            ? 'Today'
+            : date === yesterday
+              ? 'Yesterday'
+              : new Date(date + 'T00:00:00').toLocaleDateString('en-US', {
+                  month: 'short',
+                  day: 'numeric',
+                }),
+        value: date,
+      }));
+  });
+
+  readonly filteredRows = computed(() => {
+    const rows = this.cards.value() ?? [];
+    const reviewCountFilter = this.reviewCountFilter();
+    const lastReviewDateFilter = this.lastReviewDateFilter();
+    const lastReviewGradeFilter = this.lastReviewGradeFilter();
+
+    return rows.filter((row) => {
+      if (reviewCountFilter !== 'ALL') {
+        if (reviewCountFilter === '0' && row.reviewCount !== 0) return false;
+        if (reviewCountFilter === '1-5' && (row.reviewCount < 1 || row.reviewCount > 5))
+          return false;
+        if (reviewCountFilter === '6-10' && (row.reviewCount < 6 || row.reviewCount > 10))
+          return false;
+        if (reviewCountFilter === '10+' && row.reviewCount <= 10) return false;
+      }
+
+      if (lastReviewDateFilter !== 'ALL') {
+        if (!row.lastReviewDate) return false;
+        if (row.lastReviewDate.split('T')[0] !== lastReviewDateFilter) return false;
+      }
+
+      if (lastReviewGradeFilter !== 'ALL') {
+        if (row.lastReviewGrade === null) return false;
+        if (row.lastReviewGrade !== Number(lastReviewGradeFilter)) return false;
+      }
+
+      return true;
+    });
+  });
+
+  async markAsKnown(cardIds: string[]): Promise<void> {
+    await fetchJson(this.http, '/api/cards/mark-known', {
+      method: 'put',
+      body: cardIds,
+    });
+    this.cards.reload();
+  }
+
+  reload(): void {
+    this.cards.reload();
+  }
+}

--- a/client/src/app/parser/page/page.component.html
+++ b/client/src/app/parser/page/page.component.html
@@ -31,6 +31,12 @@
     aria-label="Next page"
     ><mat-icon>arrow_forward_ios</mat-icon></a
   >
+  <a
+    mat-icon-button
+    routerLink="/cards"
+    aria-label="All cards"
+    ><mat-icon>table_chart</mat-icon></a
+  >
   @if (sourceType() === 'images' && hasImage()) {
   <button mat-icon-button aria-label="Delete image" (click)="deleteImage()">
     <mat-icon>delete</mat-icon>

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/CardController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/CardController.java
@@ -12,6 +12,7 @@ import io.github.mucsi96.learnlanguage.service.CardService;
 import io.github.mucsi96.learnlanguage.service.LearningPartnerService;
 import io.github.mucsi96.learnlanguage.model.AudioData;
 import io.github.mucsi96.learnlanguage.model.CardData;
+import io.github.mucsi96.learnlanguage.model.CardTableRowResponse;
 import io.github.mucsi96.learnlanguage.model.CardUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -133,6 +134,19 @@ public class CardController {
     Map<String, String> response = new HashMap<>();
     response.put("detail", "Card deleted successfully");
     return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/cards/table")
+  @PreAuthorize("hasAuthority('APPROLE_DeckReader') and hasAuthority('SCOPE_readDecks')")
+  public ResponseEntity<List<CardTableRowResponse>> getCardTableRows() {
+    return ResponseEntity.ok(cardService.getCardTableRows());
+  }
+
+  @PutMapping("/cards/mark-known")
+  @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
+  public ResponseEntity<Map<String, String>> markCardsAsKnown(@RequestBody List<String> cardIds) {
+    cardService.markCardsAsKnown(cardIds);
+    return ResponseEntity.ok(Map.of("detail", "Cards marked as known"));
   }
 
   @GetMapping("/cards/readiness/{readiness}")

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/entity/Card.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/entity/Card.java
@@ -92,4 +92,8 @@ public class Card {
     public boolean isReviewed() {
         return hasReadiness(CardReadiness.REVIEWED);
     }
+
+    public boolean isKnown() {
+        return hasReadiness(CardReadiness.KNOWN);
+    }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardReadiness.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardReadiness.java
@@ -8,6 +8,7 @@ public class CardReadiness {
     public static final String IN_REVIEW = "IN_REVIEW";
     public static final String REVIEWED = "REVIEWED";
     public static final String READY = "READY";
+    public static final String KNOWN = "KNOWN";
 
     // Private constructor to prevent instantiation
     private CardReadiness() {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardTableRowResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardTableRowResponse.java
@@ -1,0 +1,26 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CardTableRowResponse {
+    private String id;
+    private String sourceName;
+    private String sourceType;
+    private String label;
+    private Integer reviewCount;
+    private LocalDateTime lastReviewDate;
+    private Integer lastReviewGrade;
+    private String lastReviewPerson;
+    private String readiness;
+    private String sourceId;
+    private Integer sourcePageNumber;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/ReviewLogRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/ReviewLogRepository.java
@@ -19,4 +19,12 @@ public interface ReviewLogRepository extends JpaRepository<ReviewLog, Integer> {
         ORDER BY card_id, COALESCE(learning_partner_id, 0), review DESC
         """, nativeQuery = true)
     List<ReviewLog> findLatestReviewsByCardIds(@Param("cardIds") List<String> cardIds);
+
+    @Query(value = """
+        SELECT DISTINCT ON (card_id) *
+        FROM learn_language.review_logs
+        WHERE card_id IN :cardIds
+        ORDER BY card_id, review DESC
+        """, nativeQuery = true)
+    List<ReviewLog> findLatestReviewByCardIds(@Param("cardIds") List<String> cardIds);
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -1,14 +1,21 @@
 package io.github.mucsi96.learnlanguage.service;
 
 import io.github.mucsi96.learnlanguage.entity.Card;
+import io.github.mucsi96.learnlanguage.entity.ReviewLog;
+import io.github.mucsi96.learnlanguage.model.CardReadiness;
+import io.github.mucsi96.learnlanguage.model.CardTableRowResponse;
 import io.github.mucsi96.learnlanguage.model.SourceDueCardCountResponse;
 import io.github.mucsi96.learnlanguage.repository.CardRepository;
+import io.github.mucsi96.learnlanguage.repository.ReviewLogRepository;
 import io.github.mucsi96.learnlanguage.service.cardtype.CardTypeStrategyFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +25,7 @@ public class CardService {
 
   private final CardRepository cardRepository;
   private final CardTypeStrategyFactory cardTypeStrategyFactory;
+  private final ReviewLogRepository reviewLogRepository;
 
   public Optional<Card> getCardById(String id) {
     return cardRepository.findById(id);
@@ -70,6 +78,50 @@ public class CardService {
             ((Long) record[1]).intValue())
         )
         .toList();
+  }
+
+  public List<CardTableRowResponse> getCardTableRows() {
+    final List<Card> allCards = cardRepository.findAll();
+    final List<String> cardIds = allCards.stream().map(Card::getId).toList();
+
+    final Map<String, ReviewLog> latestReviewByCardId = cardIds.isEmpty()
+        ? Map.of()
+        : reviewLogRepository.findLatestReviewByCardIds(cardIds)
+            .stream()
+            .collect(Collectors.toMap(
+                rl -> rl.getCard().getId(),
+                Function.identity()
+            ));
+
+    return allCards.stream()
+        .map(card -> {
+          final var strategy = cardTypeStrategyFactory.getStrategy(card);
+          final var latestReview = latestReviewByCardId.get(card.getId());
+          final var sourceType = card.getSource().getSourceType();
+
+          return CardTableRowResponse.builder()
+              .id(card.getId())
+              .sourceName(card.getSource().getName())
+              .sourceType(sourceType != null ? sourceType.getCode() : null)
+              .label(strategy.getPrimaryText(card.getData()))
+              .reviewCount(card.getReps())
+              .lastReviewDate(card.getLastReview())
+              .lastReviewGrade(latestReview != null ? latestReview.getRating() : null)
+              .lastReviewPerson(latestReview != null && latestReview.getLearningPartner() != null
+                  ? latestReview.getLearningPartner().getName()
+                  : null)
+              .readiness(card.getReadiness())
+              .sourceId(card.getSource().getId())
+              .sourcePageNumber(card.getSourcePageNumber())
+              .build();
+        })
+        .toList();
+  }
+
+  public void markCardsAsKnown(List<String> cardIds) {
+    final List<Card> cards = cardRepository.findByIdIn(cardIds);
+    cards.forEach(card -> card.setReadiness(CardReadiness.KNOWN));
+    cardRepository.saveAll(cards);
   }
 
   private boolean isMissingAudio(Card card) {

--- a/test/tests/cards-table.spec.ts
+++ b/test/tests/cards-table.spec.ts
@@ -1,0 +1,186 @@
+import { test, expect } from '../fixtures';
+import {
+  createCard,
+  createReviewLog,
+  createLearningPartner,
+  withDbConnection,
+  getCardFromDb,
+} from '../utils';
+
+test.describe('cards table', () => {
+  test('displays cards in AG Grid table', async ({ page }) => {
+    await createCard({
+      cardId: 'card-1',
+      sourceId: 'goethe-a1',
+      data: { word: 'Haus', type: 'NOUN', translation: { en: 'house', hu: 'ház' } },
+      reps: 3,
+      lastReview: new Date('2025-06-15T10:00:00Z'),
+    });
+
+    await createCard({
+      cardId: 'card-2',
+      sourceId: 'goethe-a2',
+      data: { word: 'Katze', type: 'NOUN', translation: { en: 'cat', hu: 'macska' } },
+      reps: 0,
+    });
+
+    await page.goto('http://localhost:8180/cards');
+
+    await expect(page.getByRole('heading', { name: 'All Cards' })).toBeVisible();
+    await expect(page.getByRole('gridcell', { name: 'Haus' })).toBeVisible();
+    await expect(page.getByRole('gridcell', { name: 'Katze' })).toBeVisible();
+    await expect(page.getByRole('gridcell', { name: 'Goethe A1' }).first()).toBeVisible();
+    await expect(page.getByRole('gridcell', { name: 'Goethe A2' }).first()).toBeVisible();
+  });
+
+  test('displays review info from latest review log', async ({ page }) => {
+    const partnerId = await createLearningPartner({ name: 'Anna', isActive: true });
+
+    await createCard({
+      cardId: 'card-1',
+      sourceId: 'goethe-a1',
+      data: { word: 'Haus', type: 'NOUN', translation: { en: 'house', hu: 'ház' } },
+      reps: 3,
+      lastReview: new Date('2025-06-15T10:00:00Z'),
+    });
+
+    await createReviewLog({
+      cardId: 'card-1',
+      learningPartnerId: partnerId,
+      rating: 3,
+      review: new Date('2025-06-15T10:00:00Z'),
+    });
+
+    await page.goto('http://localhost:8180/cards');
+
+    await expect(page.getByRole('gridcell', { name: 'Good' })).toBeVisible();
+    await expect(page.getByRole('gridcell', { name: 'Anna' })).toBeVisible();
+  });
+
+  test('filters by review count', async ({ page }) => {
+    await createCard({
+      cardId: 'card-1',
+      sourceId: 'goethe-a1',
+      data: { word: 'Haus', type: 'NOUN', translation: { en: 'house', hu: 'ház' } },
+      reps: 3,
+    });
+
+    await createCard({
+      cardId: 'card-2',
+      sourceId: 'goethe-a1',
+      data: { word: 'Katze', type: 'NOUN', translation: { en: 'cat', hu: 'macska' } },
+      reps: 0,
+    });
+
+    await page.goto('http://localhost:8180/cards');
+    await expect(page.getByRole('gridcell', { name: 'Haus' })).toBeVisible();
+    await expect(page.getByRole('gridcell', { name: 'Katze' })).toBeVisible();
+
+    await page.getByLabel('Filter by review count').click();
+    await page.getByRole('option', { name: '0' }).click();
+
+    await expect(page.getByRole('gridcell', { name: 'Katze' })).toBeVisible();
+    await expect(page.getByRole('gridcell', { name: 'Haus' })).not.toBeVisible();
+  });
+
+  test('filters by last review grade', async ({ page }) => {
+    await createCard({
+      cardId: 'card-1',
+      sourceId: 'goethe-a1',
+      data: { word: 'Haus', type: 'NOUN', translation: { en: 'house', hu: 'ház' } },
+      reps: 3,
+      lastReview: new Date('2025-06-15T10:00:00Z'),
+    });
+
+    await createReviewLog({
+      cardId: 'card-1',
+      rating: 3,
+      review: new Date('2025-06-15T10:00:00Z'),
+    });
+
+    await createCard({
+      cardId: 'card-2',
+      sourceId: 'goethe-a1',
+      data: { word: 'Katze', type: 'NOUN', translation: { en: 'cat', hu: 'macska' } },
+      reps: 1,
+      lastReview: new Date('2025-06-14T10:00:00Z'),
+    });
+
+    await createReviewLog({
+      cardId: 'card-2',
+      rating: 1,
+      review: new Date('2025-06-14T10:00:00Z'),
+    });
+
+    await page.goto('http://localhost:8180/cards');
+    await expect(page.getByRole('gridcell', { name: 'Haus' })).toBeVisible();
+    await expect(page.getByRole('gridcell', { name: 'Katze' })).toBeVisible();
+
+    await page.getByLabel('Filter by last review grade').click();
+    await page.getByRole('option', { name: 'Again' }).click();
+
+    await expect(page.getByRole('gridcell', { name: 'Katze' })).toBeVisible();
+    await expect(page.getByRole('gridcell', { name: 'Haus' })).not.toBeVisible();
+  });
+
+  test('marks selected cards as known', async ({ page }) => {
+    await createCard({
+      cardId: 'card-1',
+      sourceId: 'goethe-a1',
+      data: { word: 'Haus', type: 'NOUN', translation: { en: 'house', hu: 'ház' } },
+    });
+
+    await createCard({
+      cardId: 'card-2',
+      sourceId: 'goethe-a1',
+      data: { word: 'Katze', type: 'NOUN', translation: { en: 'cat', hu: 'macska' } },
+    });
+
+    await page.goto('http://localhost:8180/cards');
+    await expect(page.getByRole('gridcell', { name: 'Haus' })).toBeVisible();
+
+    const checkboxes = page.locator('.ag-checkbox-input');
+    await checkboxes.nth(1).click();
+    await checkboxes.nth(2).click();
+
+    await page.getByRole('button', { name: /Mark .* card\(s\) as known/ }).click();
+
+    await expect(page.getByText('2 card(s) marked as known')).toBeVisible();
+
+    const card1 = await getCardFromDb('card-1');
+    const card2 = await getCardFromDb('card-2');
+    expect(card1.readiness).toBe('KNOWN');
+    expect(card2.readiness).toBe('KNOWN');
+  });
+
+  test('navigates to card editing on row click', async ({ page }) => {
+    await createCard({
+      cardId: 'card-1',
+      sourceId: 'goethe-a1',
+      sourcePageNumber: 9,
+      data: { word: 'Haus', type: 'NOUN', translation: { en: 'house', hu: 'ház' } },
+    });
+
+    await page.goto('http://localhost:8180/cards');
+    await expect(page.getByRole('gridcell', { name: 'Haus' })).toBeVisible();
+
+    await page.getByRole('gridcell', { name: 'Haus' }).click();
+
+    await page.waitForURL(/\/sources\/goethe-a1\/page\/9\/cards\/card-1/);
+  });
+
+  test('shows empty state when no cards exist', async ({ page }) => {
+    await page.goto('http://localhost:8180/cards');
+
+    await expect(page.getByRole('heading', { name: 'No cards yet' })).toBeVisible();
+  });
+
+  test('anchor button on source page navigates to cards table', async ({ page }) => {
+    await page.goto('http://localhost:8180/sources/goethe-a1/page/9');
+
+    await page.getByRole('link', { name: 'All cards' }).click();
+
+    await page.waitForURL(/\/cards/);
+    await expect(page.getByRole('heading', { name: 'All Cards' })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
This PR introduces a new "All Cards" page that displays all cards in an interactive AG Grid table with filtering capabilities and bulk actions. Users can now view, filter, and manage cards across all sources from a centralized location.

## Key Changes

### Frontend
- **New Cards Table Component** (`cards-table.component.ts/html/css`)
  - Displays all cards in an AG Grid table with columns for source name, card label, review count, last review date, grade, and reviewer
  - Supports multi-select with checkbox selection
  - Responsive design with Material Design styling
  - Loading skeleton UI while data is being fetched

- **Filtering System**
  - Filter by review count (0, 1-5, 6-10, 10+)
  - Filter by last review date (dynamically populated from available dates)
  - Filter by last review grade (Again, Hard, Good, Easy)
  - Filters are applied in real-time using computed signals

- **Bulk Actions**
  - "Mark as known" action for selected cards
  - Shows action bar only when cards are selected
  - Displays confirmation toast on completion

- **Navigation**
  - Clicking a card row navigates to the card editing page
  - New "All cards" button added to source page navigation bar
  - New route `/cards` added to app routing

### Backend
- **New API Endpoints**
  - `GET /api/cards/table` - Returns all cards with review information for table display
  - `PUT /api/cards/mark-known` - Marks selected cards as known

- **Database & Service Updates**
  - Added `CardTableRowResponse` model for table data
  - Added `KNOWN` readiness status to `CardReadiness`
  - Added `isKnown()` helper method to `Card` entity
  - New `findLatestReviewByCardIds()` query in `ReviewLogRepository`
  - New `getCardTableRows()` and `markCardsAsKnown()` methods in `CardService`

### Dependencies
- Added `ag-grid-angular` (^35.0.1) and `ag-grid-community` (^35.0.1) for the data grid

### Testing
- Comprehensive E2E tests covering:
  - Table display and data rendering
  - All filter types
  - Bulk mark as known action
  - Row click navigation
  - Empty state display
  - Navigation from source page

## Implementation Details
- Uses Angular signals and computed properties for reactive state management
- AG Grid theme customized to match Material Design system colors
- Filters are applied client-side using computed signals for better UX
- Latest review information is fetched from review logs and joined with card data
- Proper authorization checks on both endpoints (DeckReader for GET, DeckCreator for PUT)

https://claude.ai/code/session_01PgpXtZnbocEWTWbSUZqe1L