### PR TITLE
Add cards table view with filtering and bulk operations

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -20,6 +20,8 @@
         "@angular/router": "21.1.2",
         "@azure/msal-angular": "5.0.3",
         "@azure/msal-browser": "5.1.0",
+        "ag-grid-angular": "^35.0.1",
+        "ag-grid-community": "^35.0.1",
         "rxjs": "7.8.2",
         "ts-fsrs": "5.2.3",
         "tslib": "2.8.1",
@@ -6271,6 +6273,35 @@
       },
       "engines": {
         "node": ">=8.9.0"
+      }
+    },
+    "node_modules/ag-charts-types": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/ag-charts-types/-/ag-charts-types-13.0.1.tgz",
+      "integrity": "sha512-qg9adyiAaeUaDtWZEEPF45dv55kdJTe6Ghi0EQXCS79h/7KvOd6dxhqGZjPL1zeFl/L9qEXuYgb+LkGStq4mgQ==",
+      "license": "MIT"
+    },
+    "node_modules/ag-grid-angular": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/ag-grid-angular/-/ag-grid-angular-35.0.1.tgz",
+      "integrity": "sha512-+Y1K/ZxiEbd3GhZcRWzLf60yiP4ECNoTCCqI65EgHiiRGInz3g1pDueArR7hE7V+z5gluA3NMGB3VrOZYUBKLg==",
+      "license": "MIT",
+      "dependencies": {
+        "ag-grid-community": "35.0.1",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">= 18.0.0",
+        "@angular/core": ">= 18.0.0"
+      }
+    },
+    "node_modules/ag-grid-community": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-35.0.1.tgz",
+      "integrity": "sha512-fYYZdymWKsN9/tZv+R6uZRnuiWYEQr+GHl85ZrB0ixbFcE8opYK4NJI29NnMc9ShYiCBnAO9hj54IFa+FI4aDA==",
+      "license": "MIT",
+      "dependencies": {
+        "ag-charts-types": "13.0.1"
       }
     },
     "node_modules/agent-base": {

--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,8 @@
     "@angular/router": "21.1.2",
     "@azure/msal-angular": "5.0.3",
     "@azure/msal-browser": "5.1.0",
+    "ag-grid-angular": "^35.0.1",
+    "ag-grid-community": "^35.0.1",
     "rxjs": "7.8.2",
     "ts-fsrs": "5.2.3",
     "tslib": "2.8.1",

--- a/client/src/app/admin/admin.component.css
+++ b/client/src/app/admin/admin.component.css
@@ -69,6 +69,7 @@ p {
 .action-button {
   background: var(--mat-sys-surface);
   border: 1px solid var(--mat-sys-surface-container);
+  font-size: 0.8rem;
 }
 
 .action-button:hover {
@@ -77,6 +78,11 @@ p {
 
 .delete-button:hover {
   color: var(--mat-sys-error);
+}
+
+.action-button a {
+  text-decoration: none;
+  color: inherit;
 }
 
 .sources mat-card {

--- a/client/src/app/admin/admin.component.html
+++ b/client/src/app/admin/admin.component.html
@@ -7,7 +7,7 @@
     <p>Select a source to edit or create a new one:</p>
   </div>
   <button
-    mat-flat-button
+    mat-button
     (click)="openAddSourceDialog()"
     class="add-button"
   >
@@ -38,21 +38,33 @@
       </mat-card>
     </a>
     <div class="card-actions">
+      <a
+        mat-button
+        [routerLink]="['/sources', source.id, 'cards']"
+        (click)="$event.stopPropagation()"
+        aria-label="View cards"
+        class="action-button"
+      >
+        <mat-icon>table_chart</mat-icon>
+        Cards
+      </a>
       <button
-        mat-icon-button
+        mat-button
         (click)="openEditSourceDialog(source, $event)"
         aria-label="Edit source"
         class="action-button"
       >
         <mat-icon>edit</mat-icon>
+        Edit
       </button>
       <button
-        mat-icon-button
+        mat-button
         (click)="openDeleteConfirmDialog(source, $event)"
         aria-label="Delete source"
         class="action-button delete-button"
       >
         <mat-icon>delete</mat-icon>
+        Delete
       </button>
     </div>
   </article>

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -105,6 +105,13 @@ export const routes: Routes = [
     title: 'Sources',
   },
   {
+    path: 'sources/:sourceId/cards',
+    loadComponent: () =>
+      import('./source-cards/source-cards.component').then((m) => m.SourceCardsComponent),
+    canActivate: [conditionalAuthGuard],
+    title: 'Source Cards',
+  },
+  {
     path: 'sources/:sourceId/page/:pageNumber',
     canActivate: [conditionalAuthGuard],
     title: (route) => {

--- a/client/src/app/shared/state/card-state.ts
+++ b/client/src/app/shared/state/card-state.ts
@@ -1,6 +1,6 @@
 import { State } from 'ts-fsrs';
 
-export type CardState = 'NEW' | 'LEARNING' | 'REVIEW' | 'RELEARNING';
+export type CardState = 'NEW' | 'LEARNING' | 'REVIEW' | 'RELEARNING' | 'KNOWN';
 
 export function mapTsfsrsStateToCardState(state: State): CardState {
   switch (state) {
@@ -22,6 +22,7 @@ export function mapCardStateToTsfsrsState(state: CardState): State {
     case 'LEARNING':
       return State.Learning;
     case 'REVIEW':
+    case 'KNOWN':
       return State.Review;
     case 'RELEARNING':
       return State.Relearning;

--- a/client/src/app/shared/state/state.component.ts
+++ b/client/src/app/shared/state/state.component.ts
@@ -18,14 +18,16 @@ export class StateComponent {
     'NEW': 'New',
     'LEARNING': 'Learning',
     'REVIEW': 'Review',
-    'RELEARNING': 'Relearning'
+    'RELEARNING': 'Relearning',
+    'KNOWN': 'Known',
   };
 
   private readonly stateColorMap: Record<CardState, string> = {
-    'NEW': '#2196F3', // Blue
-    'LEARNING': '#4CAF50', // Green
-    'REVIEW': '#FFC107', // Amber
-    'RELEARNING': '#F44336', // Red
+    'NEW': '#2196F3',
+    'LEARNING': '#4CAF50',
+    'REVIEW': '#FFC107',
+    'RELEARNING': '#F44336',
+    'KNOWN': '#9E9E9E',
   };
 
   stateStyle = computed(() => {

--- a/client/src/app/source-cards/source-cards.component.css
+++ b/client/src/app/source-cards/source-cards.component.css
@@ -1,0 +1,98 @@
+:host {
+  display: block;
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+.container {
+  padding: 2rem 0;
+}
+
+h1 {
+  color: var(--mat-sys-on-surface);
+  margin-bottom: 0.5rem;
+}
+
+p {
+  color: var(--mat-app-text-color);
+  margin-bottom: 0;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+  gap: 1rem;
+}
+
+.breadcrumb-link {
+  color: var(--mat-sys-primary);
+  text-decoration: none;
+}
+
+.breadcrumb-link:hover {
+  text-decoration: underline;
+}
+
+.breadcrumb-separator {
+  margin: 0 0.5rem;
+  color: var(--mat-app-text-color);
+}
+
+.filters-section {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  padding: 1rem;
+  background: var(--mat-sys-surface-container);
+  border-radius: 8px;
+}
+
+.filter-field {
+  min-width: 140px;
+  flex: 1;
+  max-width: 200px;
+}
+
+.actions-bar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  background: var(--mat-sys-secondary-container);
+  border-radius: 8px;
+}
+
+.selection-count {
+  color: var(--mat-sys-on-secondary-container);
+  font-weight: 500;
+}
+
+.grid-container {
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+@media (max-width: 768px) {
+  :host {
+    padding: 0 1rem;
+  }
+
+  .container {
+    padding: 1rem 0;
+  }
+
+  .filters-section {
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.75rem;
+  }
+
+  .filter-field {
+    max-width: 100%;
+  }
+}

--- a/client/src/app/source-cards/source-cards.component.html
+++ b/client/src/app/source-cards/source-cards.component.html
@@ -1,0 +1,101 @@
+<div class="container">
+  <div class="header">
+    <div>
+      <h1>Cards</h1>
+      <p>
+        <a [routerLink]="['/sources']" class="breadcrumb-link">Sources</a>
+        <span class="breadcrumb-separator">/</span>
+        <span>{{ sourceId() }}</span>
+      </p>
+    </div>
+    <a mat-button [routerLink]="['/sources']">
+      <mat-icon>arrow_back</mat-icon>
+      Back to Sources
+    </a>
+  </div>
+
+  <div class="filters-section" role="search" aria-label="Card filters">
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>State</mat-label>
+      <mat-select
+        [value]="stateFilter()"
+        (selectionChange)="stateFilter.set($event.value); onFilterChange()"
+        aria-label="Filter by state"
+      >
+        @for (option of stateOptions; track option) {
+          <mat-option [value]="option">{{ getStateLabel(option) }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>Reviews</mat-label>
+      <mat-select
+        [value]="reviewCountFilter()"
+        (selectionChange)="reviewCountFilter.set($event.value); onFilterChange()"
+        aria-label="Filter by review count"
+      >
+        @for (option of reviewCountOptions; track option.value) {
+          <mat-option [value]="option.value">{{ option.label }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>Last Review</mat-label>
+      <mat-select
+        [value]="reviewDateFilter()"
+        (selectionChange)="reviewDateFilter.set($event.value); onFilterChange()"
+        aria-label="Filter by last review date"
+      >
+        @for (option of reviewDateOptions; track option.value) {
+          <mat-option [value]="option.value">{{ option.label }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>Grade</mat-label>
+      <mat-select
+        [value]="gradeFilter()"
+        (selectionChange)="gradeFilter.set($event.value); onFilterChange()"
+        aria-label="Filter by last review grade"
+      >
+        @for (option of gradeOptions; track option) {
+          <mat-option [value]="option">{{ getGradeLabel(option) }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  </div>
+
+  @if (hasSelection()) {
+    <div class="actions-bar">
+      <span class="selection-count">{{ selectedCount() }} selected</span>
+      <button mat-button (click)="markAsKnown()" aria-label="Mark selected cards as known">
+        <mat-icon>check_circle</mat-icon>
+        Mark as Known
+      </button>
+      <button mat-button (click)="markAsReady()" aria-label="Mark selected cards as ready">
+        <mat-icon>replay</mat-icon>
+        Mark as Ready
+      </button>
+    </div>
+  }
+
+  <div class="grid-container">
+    <ag-grid-angular
+      [theme]="theme"
+      style="width: 100%; height: 600px;"
+      [columnDefs]="columnDefs"
+      [defaultColDef]="defaultColDef"
+      [rowModelType]="'infinite'"
+      [cacheBlockSize]="100"
+      [maxBlocksInCache]="10"
+      [rowSelection]="{ mode: 'multiRow', checkboxes: true, headerCheckbox: true }"
+      [getRowId]="getRowId"
+      (gridReady)="onGridReady($event)"
+      (selectionChanged)="onSelectionChanged()"
+      (rowClicked)="onRowClicked($event)"
+    />
+  </div>
+</div>

--- a/client/src/app/source-cards/source-cards.component.ts
+++ b/client/src/app/source-cards/source-cards.component.ts
@@ -1,0 +1,301 @@
+import { Component, computed, inject, signal, OnInit, OnDestroy } from '@angular/core';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { AgGridAngular } from 'ag-grid-angular';
+import {
+  AllCommunityModule,
+  ModuleRegistry,
+  type ColDef,
+  type GetRowIdParams,
+  type GridApi,
+  type GridReadyEvent,
+  type IDatasource,
+  type IGetRowsParams,
+  type RowClickedEvent,
+  type SortModelItem,
+  themeQuartz,
+} from 'ag-grid-community';
+import { SourceCardsService, type CardTableRow } from './source-cards.service';
+
+ModuleRegistry.registerModules([AllCommunityModule]);
+
+const GRADE_LABELS: Record<number, string> = {
+  1: 'Again',
+  2: 'Hard',
+  3: 'Good',
+  4: 'Easy',
+};
+
+const REVIEW_COUNT_OPTIONS = [
+  { label: 'All', value: '' },
+  { label: 'Never reviewed', value: '0-0' },
+  { label: '1-5', value: '1-5' },
+  { label: '6-10', value: '6-10' },
+  { label: '11+', value: '11-' },
+];
+
+const REVIEW_DATE_OPTIONS = [
+  { label: 'All', value: '' },
+  { label: 'Today', value: 'today' },
+  { label: 'Last 7 days', value: 'last7days' },
+  { label: 'Last 30 days', value: 'last30days' },
+  { label: 'Over 30 days ago', value: 'over30days' },
+  { label: 'Never', value: 'never' },
+];
+
+@Component({
+  selector: 'app-source-cards',
+  standalone: true,
+  imports: [
+    RouterModule,
+    MatButtonModule,
+    MatIconModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    AgGridAngular,
+  ],
+  templateUrl: './source-cards.component.html',
+  styleUrl: './source-cards.component.css',
+})
+export class SourceCardsComponent implements OnInit, OnDestroy {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly sourceCardsService = inject(SourceCardsService);
+
+  readonly sourceId = signal('');
+  readonly sourceName = signal('');
+  readonly selectedCount = signal(0);
+
+  readonly stateFilter = signal('');
+  readonly gradeFilter = signal<string>('');
+  readonly reviewCountFilter = signal('');
+  readonly reviewDateFilter = signal('');
+
+  readonly stateOptions = ['', 'NEW', 'LEARNING', 'REVIEW', 'RELEARNING', 'KNOWN'];
+  readonly gradeOptions = ['', '1', '2', '3', '4'];
+  readonly reviewCountOptions = REVIEW_COUNT_OPTIONS;
+  readonly reviewDateOptions = REVIEW_DATE_OPTIONS;
+
+  readonly theme = themeQuartz.withParams({
+    backgroundColor: 'var(--mat-sys-surface)',
+    foregroundColor: 'var(--mat-sys-on-surface)',
+    headerBackgroundColor: 'var(--mat-sys-surface-container)',
+    borderColor: 'var(--mat-sys-outline-variant)',
+    rowHoverColor: 'var(--mat-sys-surface-container-highest)',
+    selectedRowBackgroundColor: 'var(--mat-sys-secondary-container)',
+  });
+
+  readonly hasSelection = computed(() => this.selectedCount() > 0);
+
+  private gridApi: GridApi | null = null;
+  private routeSubscription: any;
+
+  readonly columnDefs: ColDef<CardTableRow>[] = [
+    {
+      headerCheckboxSelection: true,
+      checkboxSelection: true,
+      width: 50,
+      sortable: false,
+      suppressHeaderMenuButton: true,
+    },
+    {
+      headerName: 'Card',
+      field: 'label',
+      sortable: true,
+      flex: 2,
+    },
+    {
+      headerName: 'State',
+      field: 'state',
+      sortable: true,
+      width: 120,
+      cellRenderer: (params: { value: string }) => {
+        if (!params.value) return '';
+        const colors: Record<string, string> = {
+          NEW: '#2196F3',
+          LEARNING: '#4CAF50',
+          REVIEW: '#FFC107',
+          RELEARNING: '#F44336',
+          KNOWN: '#9E9E9E',
+        };
+        const names: Record<string, string> = {
+          NEW: 'New',
+          LEARNING: 'Learning',
+          REVIEW: 'Review',
+          RELEARNING: 'Relearning',
+          KNOWN: 'Known',
+        };
+        const bg = colors[params.value] ?? '#000';
+        const name = names[params.value] ?? params.value;
+        return `<span style="background:${bg};color:white;padding:2px 8px;border-radius:12px;font-size:0.75rem;">${name}</span>`;
+      },
+    },
+    {
+      headerName: 'Reviews',
+      field: 'reviewCount',
+      sortable: true,
+      width: 100,
+    },
+    {
+      headerName: 'Last Review',
+      field: 'lastReviewDate',
+      sortable: true,
+      width: 150,
+      cellRenderer: (params: { value: string | null }) => {
+        if (!params.value) return '';
+        const date = new Date(params.value);
+        return date.toLocaleDateString();
+      },
+    },
+    {
+      headerName: 'Grade',
+      field: 'lastReviewGrade',
+      sortable: true,
+      width: 100,
+      cellRenderer: (params: { value: number | null }) => {
+        if (params.value == null) return '';
+        return GRADE_LABELS[params.value] ?? String(params.value);
+      },
+    },
+    {
+      headerName: 'Reviewer',
+      field: 'lastReviewPerson',
+      sortable: true,
+      width: 120,
+      cellRenderer: (params: { value: string | null }) =>
+        params.value ?? 'Me',
+    },
+  ];
+
+  readonly defaultColDef: ColDef = {
+    resizable: true,
+  };
+
+  getRowId = (params: GetRowIdParams<CardTableRow>) => params.data.id;
+
+  ngOnInit(): void {
+    this.routeSubscription = this.route.paramMap.subscribe((params) => {
+      this.sourceId.set(params.get('sourceId') ?? '');
+    });
+    this.route.data.subscribe((data) => {
+      this.sourceName.set(data['sourceName'] ?? '');
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.routeSubscription?.unsubscribe();
+  }
+
+  onGridReady(event: GridReadyEvent): void {
+    this.gridApi = event.api;
+    this.gridApi.setGridOption('datasource', this.createDatasource());
+  }
+
+  onSelectionChanged(): void {
+    const selected = this.gridApi?.getSelectedRows() ?? [];
+    this.selectedCount.set(selected.length);
+  }
+
+  onRowClicked(event: RowClickedEvent<CardTableRow>): void {
+    const target = event.event?.target as HTMLElement;
+    if (target?.closest('.ag-checkbox-input-wrapper')) return;
+
+    const row = event.data;
+    if (row) {
+      this.router.navigate([
+        '/sources', this.sourceId(), 'page', row.sourcePageNumber, 'cards', row.id,
+      ]);
+    }
+  }
+
+  onFilterChange(): void {
+    this.gridApi?.setGridOption('datasource', this.createDatasource());
+  }
+
+  getStateLabel(value: string): string {
+    const labels: Record<string, string> = {
+      '': 'All',
+      NEW: 'New',
+      LEARNING: 'Learning',
+      REVIEW: 'Review',
+      RELEARNING: 'Relearning',
+      KNOWN: 'Known',
+    };
+    return labels[value] ?? value;
+  }
+
+  getGradeLabel(value: string): string {
+    if (!value) return 'All';
+    return GRADE_LABELS[Number(value)] ?? value;
+  }
+
+  async markAsKnown(): Promise<void> {
+    const selected: CardTableRow[] = this.gridApi?.getSelectedRows() ?? [];
+    const cardIds = selected.map((row) => row.id);
+    if (cardIds.length === 0) return;
+
+    await this.sourceCardsService.updateCardsReadiness(cardIds, 'KNOWN');
+    this.gridApi?.deselectAll();
+    this.gridApi?.setGridOption('datasource', this.createDatasource());
+  }
+
+  async markAsReady(): Promise<void> {
+    const selected: CardTableRow[] = this.gridApi?.getSelectedRows() ?? [];
+    const cardIds = selected.map((row) => row.id);
+    if (cardIds.length === 0) return;
+
+    await this.sourceCardsService.updateCardsReadiness(cardIds, 'READY');
+    this.gridApi?.deselectAll();
+    this.gridApi?.setGridOption('datasource', this.createDatasource());
+  }
+
+  private createDatasource(): IDatasource {
+    const sourceId = this.sourceId();
+    const stateFilter = this.stateFilter();
+    const gradeFilter = this.gradeFilter();
+    const reviewCountFilter = this.reviewCountFilter();
+    const reviewDateFilter = this.reviewDateFilter();
+
+    return {
+      getRows: (params: IGetRowsParams) => {
+        const sortModel: SortModelItem[] = params.sortModel;
+        const sortField = sortModel.length > 0 ? sortModel[0].colId : undefined;
+        const sortDir = sortModel.length > 0 ? sortModel[0].sort : undefined;
+
+        const reviewRange = this.parseReviewCountRange(reviewCountFilter);
+
+        this.sourceCardsService
+          .fetchCards({
+            sourceId,
+            startRow: params.startRow,
+            endRow: params.endRow,
+            sortField,
+            sortDir,
+            state: stateFilter || undefined,
+            lastReviewGrade: gradeFilter ? Number(gradeFilter) : undefined,
+            minReviews: reviewRange.min,
+            maxReviews: reviewRange.max,
+            lastReviewDate: reviewDateFilter || undefined,
+          })
+          .then((response) => {
+            params.successCallback(response.rows, response.totalCount);
+          })
+          .catch(() => {
+            params.failCallback();
+          });
+      },
+    };
+  }
+
+  private parseReviewCountRange(value: string): { min?: number; max?: number } {
+    if (!value) return {};
+    const parts = value.split('-');
+    return {
+      min: parts[0] ? Number(parts[0]) : undefined,
+      max: parts[1] ? Number(parts[1]) : undefined,
+    };
+  }
+}

--- a/client/src/app/source-cards/source-cards.service.ts
+++ b/client/src/app/source-cards/source-cards.service.ts
@@ -1,0 +1,63 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { fetchJson } from '../utils/fetchJson';
+
+export type CardTableRow = {
+  id: string;
+  label: string;
+  reviewCount: number;
+  state: string;
+  sourcePageNumber: number;
+  lastReviewGrade: number | null;
+  lastReviewDate: string | null;
+  lastReviewPerson: string | null;
+};
+
+export type CardTableResponse = {
+  rows: CardTableRow[];
+  totalCount: number;
+};
+
+export type CardTableParams = {
+  sourceId: string;
+  startRow: number;
+  endRow: number;
+  sortField?: string;
+  sortDir?: string;
+  state?: string;
+  lastReviewGrade?: number;
+  minReviews?: number;
+  maxReviews?: number;
+  lastReviewDate?: string;
+};
+
+@Injectable({ providedIn: 'root' })
+export class SourceCardsService {
+  private readonly http = inject(HttpClient);
+
+  async fetchCards(params: CardTableParams): Promise<CardTableResponse> {
+    const searchParams = new URLSearchParams();
+    searchParams.set('startRow', String(params.startRow));
+    searchParams.set('endRow', String(params.endRow));
+
+    if (params.sortField) searchParams.set('sortField', params.sortField);
+    if (params.sortDir) searchParams.set('sortDir', params.sortDir);
+    if (params.state) searchParams.set('state', params.state);
+    if (params.lastReviewGrade != null) searchParams.set('lastReviewGrade', String(params.lastReviewGrade));
+    if (params.minReviews != null) searchParams.set('minReviews', String(params.minReviews));
+    if (params.maxReviews != null) searchParams.set('maxReviews', String(params.maxReviews));
+    if (params.lastReviewDate) searchParams.set('lastReviewDate', params.lastReviewDate);
+
+    return fetchJson<CardTableResponse>(
+      this.http,
+      `/api/source/${params.sourceId}/cards?${searchParams.toString()}`
+    );
+  }
+
+  async updateCardsReadiness(cardIds: string[], readiness: string): Promise<void> {
+    await fetchJson(this.http, '/api/cards/readiness', {
+      method: 'put',
+      body: { cardIds, readiness },
+    });
+  }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/CardController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/CardController.java
@@ -11,7 +11,9 @@ import io.github.mucsi96.learnlanguage.repository.SourceRepository;
 import io.github.mucsi96.learnlanguage.service.CardService;
 import io.github.mucsi96.learnlanguage.service.LearningPartnerService;
 import io.github.mucsi96.learnlanguage.model.AudioData;
+import io.github.mucsi96.learnlanguage.model.BulkReadinessUpdateRequest;
 import io.github.mucsi96.learnlanguage.model.CardData;
+import io.github.mucsi96.learnlanguage.model.CardTableResponse;
 import io.github.mucsi96.learnlanguage.model.CardUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -202,6 +204,42 @@ public class CardController {
 
     Map<String, String> response = new HashMap<>();
     response.put("detail", "Audio added successfully");
+    return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/source/{sourceId}/cards")
+  @PreAuthorize("hasAuthority('APPROLE_DeckReader') and hasAuthority('SCOPE_readDecks')")
+  public ResponseEntity<CardTableResponse> getCardsForSource(
+      @PathVariable String sourceId,
+      @RequestParam(defaultValue = "0") int startRow,
+      @RequestParam(defaultValue = "100") int endRow,
+      @RequestParam(required = false) String sortField,
+      @RequestParam(required = false, defaultValue = "asc") String sortDir,
+      @RequestParam(required = false) String state,
+      @RequestParam(required = false) Integer lastReviewGrade,
+      @RequestParam(required = false) Integer minReviews,
+      @RequestParam(required = false) Integer maxReviews,
+      @RequestParam(required = false) String lastReviewDate) {
+
+    CardTableResponse response = cardService.getCardsForTable(
+        sourceId, startRow, endRow,
+        sortField, sortDir,
+        state, lastReviewGrade,
+        minReviews, maxReviews,
+        lastReviewDate);
+
+    return ResponseEntity.ok(response);
+  }
+
+  @PutMapping("/cards/readiness")
+  @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
+  public ResponseEntity<Map<String, String>> updateCardsReadiness(
+      @RequestBody BulkReadinessUpdateRequest request) {
+
+    cardService.updateReadinessForCards(request.getCardIds(), request.getReadiness());
+
+    Map<String, String> response = new HashMap<>();
+    response.put("detail", "Cards readiness updated successfully");
     return ResponseEntity.ok(response);
   }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/BulkReadinessUpdateRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/BulkReadinessUpdateRequest.java
@@ -1,0 +1,15 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BulkReadinessUpdateRequest {
+    private List<String> cardIds;
+    private String readiness;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardReadiness.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardReadiness.java
@@ -8,6 +8,7 @@ public class CardReadiness {
     public static final String IN_REVIEW = "IN_REVIEW";
     public static final String REVIEWED = "REVIEWED";
     public static final String READY = "READY";
+    public static final String KNOWN = "KNOWN";
 
     // Private constructor to prevent instantiation
     private CardReadiness() {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardTableResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardTableResponse.java
@@ -1,0 +1,17 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CardTableResponse {
+    private List<CardTableRow> rows;
+    private long totalCount;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardTableRow.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardTableRow.java
@@ -1,0 +1,23 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CardTableRow {
+    private String id;
+    private String label;
+    private int reviewCount;
+    private String state;
+    private int sourcePageNumber;
+    private Integer lastReviewGrade;
+    private LocalDateTime lastReviewDate;
+    private String lastReviewPerson;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -1,13 +1,22 @@
 package io.github.mucsi96.learnlanguage.service;
 
 import io.github.mucsi96.learnlanguage.entity.Card;
+import io.github.mucsi96.learnlanguage.model.CardTableResponse;
+import io.github.mucsi96.learnlanguage.model.CardTableRow;
 import io.github.mucsi96.learnlanguage.model.SourceDueCardCountResponse;
 import io.github.mucsi96.learnlanguage.repository.CardRepository;
 import io.github.mucsi96.learnlanguage.service.cardtype.CardTypeStrategyFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.Timestamp;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -16,8 +25,20 @@ public class CardService {
 
   public static record SourceCardCount(String sourceId, Integer count) {}
 
+  private static final Map<String, String> SORT_FIELD_MAP = Map.of(
+      "label", "label",
+      "reviewCount", "c.reps",
+      "lastReviewDate", "last_review_date",
+      "lastReviewGrade", "last_review_grade",
+      "lastReviewPerson", "last_review_person",
+      "state", "display_state"
+  );
+
   private final CardRepository cardRepository;
   private final CardTypeStrategyFactory cardTypeStrategyFactory;
+
+  @PersistenceContext
+  private EntityManager entityManager;
 
   public Optional<Card> getCardById(String id) {
     return cardRepository.findById(id);
@@ -70,6 +91,122 @@ public class CardService {
             ((Long) record[1]).intValue())
         )
         .toList();
+  }
+
+  @Transactional
+  public void updateReadinessForCards(List<String> cardIds, String readiness) {
+    final List<Card> cards = cardRepository.findByIdIn(cardIds);
+    cards.forEach(card -> card.setReadiness(readiness));
+    cardRepository.saveAll(cards);
+  }
+
+  @Transactional(readOnly = true)
+  @SuppressWarnings("unchecked")
+  public CardTableResponse getCardsForTable(
+      String sourceId, int startRow, int endRow,
+      String sortField, String sortDir,
+      String stateFilter, Integer lastReviewGradeFilter,
+      Integer minReviews, Integer maxReviews,
+      String lastReviewDateRange) {
+
+    final String safeSortColumn = SORT_FIELD_MAP.getOrDefault(sortField, "label");
+    final String safeSortDir = "desc".equalsIgnoreCase(sortDir) ? "DESC" : "ASC";
+
+    final String cte = """
+        WITH latest_reviews AS (
+            SELECT DISTINCT ON (card_id) card_id, rating, review, learning_partner_id
+            FROM learn_language.review_logs
+            ORDER BY card_id, review DESC
+        )
+        """;
+
+    final StringBuilder whereClause = new StringBuilder("WHERE c.source_id = :sourceId");
+    final Map<String, Object> params = new HashMap<>();
+    params.put("sourceId", sourceId);
+
+    if (stateFilter != null && !stateFilter.isEmpty()) {
+      if ("KNOWN".equals(stateFilter)) {
+        whereClause.append(" AND c.readiness = 'KNOWN'");
+      } else {
+        whereClause.append(" AND c.state = :stateFilter AND c.readiness != 'KNOWN'");
+        params.put("stateFilter", stateFilter);
+      }
+    }
+
+    if (lastReviewGradeFilter != null) {
+      whereClause.append(" AND lr.rating = :lastReviewGrade");
+      params.put("lastReviewGrade", lastReviewGradeFilter);
+    }
+
+    if (minReviews != null) {
+      whereClause.append(" AND c.reps >= :minReviews");
+      params.put("minReviews", minReviews);
+    }
+
+    if (maxReviews != null) {
+      whereClause.append(" AND c.reps <= :maxReviews");
+      params.put("maxReviews", maxReviews);
+    }
+
+    if (lastReviewDateRange != null && !lastReviewDateRange.isEmpty()) {
+      switch (lastReviewDateRange) {
+        case "today" -> whereClause.append(" AND lr.review::date = CURRENT_DATE");
+        case "last7days" -> whereClause.append(" AND lr.review >= NOW() - INTERVAL '7 days'");
+        case "last30days" -> whereClause.append(" AND lr.review >= NOW() - INTERVAL '30 days'");
+        case "over30days" -> whereClause.append(" AND lr.review < NOW() - INTERVAL '30 days'");
+        case "never" -> whereClause.append(" AND lr.review IS NULL");
+        default -> { }
+      }
+    }
+
+    final String selectFields = """
+        SELECT c.id, c.data->>'word' as label, c.reps as review_count,
+               CASE WHEN c.readiness = 'KNOWN' THEN 'KNOWN' ELSE c.state END as display_state,
+               c.source_page_number,
+               lr.rating as last_review_grade,
+               lr.review as last_review_date,
+               lp.name as last_review_person
+        FROM learn_language.cards c
+        LEFT JOIN latest_reviews lr ON c.id = lr.card_id
+        LEFT JOIN learn_language.learning_partners lp ON lr.learning_partner_id = lp.id
+        """;
+
+    final String fullSelect = selectFields + whereClause;
+    final String countSql = cte + "SELECT COUNT(*) FROM (" + fullSelect + ") as filtered";
+    final String dataSql = cte + fullSelect
+        + " ORDER BY " + safeSortColumn + " " + safeSortDir + " NULLS LAST";
+
+    final Query countQuery = entityManager.createNativeQuery(countSql);
+    final Query dataQuery = entityManager.createNativeQuery(dataSql);
+
+    params.forEach((key, value) -> {
+      countQuery.setParameter(key, value);
+      dataQuery.setParameter(key, value);
+    });
+
+    dataQuery.setFirstResult(startRow);
+    dataQuery.setMaxResults(endRow - startRow);
+
+    final long totalCount = ((Number) countQuery.getSingleResult()).longValue();
+    final List<Object[]> rows = dataQuery.getResultList();
+
+    final List<CardTableRow> tableRows = rows.stream()
+        .map(row -> CardTableRow.builder()
+            .id((String) row[0])
+            .label((String) row[1])
+            .reviewCount(((Number) row[2]).intValue())
+            .state((String) row[3])
+            .sourcePageNumber(((Number) row[4]).intValue())
+            .lastReviewGrade(row[5] != null ? ((Number) row[5]).intValue() : null)
+            .lastReviewDate(row[6] != null ? ((Timestamp) row[6]).toLocalDateTime() : null)
+            .lastReviewPerson(row[7] != null ? (String) row[7] : null)
+            .build())
+        .toList();
+
+    return CardTableResponse.builder()
+        .rows(tableRows)
+        .totalCount(totalCount)
+        .build();
   }
 
   private boolean isMissingAudio(Card card) {

--- a/test/tests/source-cards.spec.ts
+++ b/test/tests/source-cards.spec.ts
@@ -1,0 +1,222 @@
+import { test, expect } from '../fixtures';
+import { createCard, createReviewLog, createLearningPartner } from '../utils';
+
+test('navigates to cards table from sources page', async ({ page }) => {
+  await page.goto('http://localhost:8180/sources');
+
+  const sourceCard = page.getByRole('article', { name: 'Goethe A1' });
+  await sourceCard.hover();
+  await sourceCard.getByRole('link', { name: 'Cards' }).click();
+
+  await expect(page).toHaveURL(/\/sources\/goethe-a1\/cards/);
+  await expect(page.getByRole('heading', { level: 1, name: 'Cards' })).toBeVisible();
+});
+
+test('displays cards in table', async ({ page }) => {
+  await createCard({
+    cardId: 'table-card-1',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: { word: 'Apfel', type: 'NOUN', translation: { en: 'apple' } },
+    state: 'NEW',
+    reps: 0,
+  });
+  await createCard({
+    cardId: 'table-card-2',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 10,
+    data: { word: 'Birne', type: 'NOUN', translation: { en: 'pear' } },
+    state: 'REVIEW',
+    reps: 5,
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/cards');
+
+  await expect(page.getByRole('gridcell', { name: 'Apfel' })).toBeVisible();
+  await expect(page.getByRole('gridcell', { name: 'Birne' })).toBeVisible();
+});
+
+test('filters cards by state', async ({ page }) => {
+  await createCard({
+    cardId: 'filter-new',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: { word: 'Tisch', type: 'NOUN', translation: { en: 'table' } },
+    state: 'NEW',
+  });
+  await createCard({
+    cardId: 'filter-review',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 10,
+    data: { word: 'Stuhl', type: 'NOUN', translation: { en: 'chair' } },
+    state: 'REVIEW',
+    reps: 3,
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/cards');
+
+  await expect(page.getByRole('gridcell', { name: 'Tisch' })).toBeVisible();
+  await expect(page.getByRole('gridcell', { name: 'Stuhl' })).toBeVisible();
+
+  await page.getByLabel('Filter by state').click();
+  await page.getByRole('option', { name: 'New' }).click();
+
+  await expect(page.getByRole('gridcell', { name: 'Tisch' })).toBeVisible();
+  await expect(page.getByRole('gridcell', { name: 'Stuhl' })).not.toBeVisible();
+});
+
+test('marks cards as known', async ({ page }) => {
+  await createCard({
+    cardId: 'known-card-1',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: { word: 'Haus', type: 'NOUN', translation: { en: 'house' } },
+    state: 'NEW',
+  });
+  await createCard({
+    cardId: 'known-card-2',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 10,
+    data: { word: 'Auto', type: 'NOUN', translation: { en: 'car' } },
+    state: 'NEW',
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/cards');
+
+  await expect(page.getByRole('gridcell', { name: 'Haus' })).toBeVisible();
+
+  const hausRow = page.getByRole('row').filter({ hasText: 'Haus' });
+  await hausRow.getByRole('checkbox').check();
+
+  await expect(page.getByText('1 selected')).toBeVisible();
+  await page.getByRole('button', { name: 'Mark selected cards as known' }).click();
+
+  await page.getByLabel('Filter by state').click();
+  await page.getByRole('option', { name: 'Known' }).click();
+
+  await expect(page.getByRole('gridcell', { name: 'Haus' })).toBeVisible();
+  await expect(page.getByRole('gridcell', { name: 'Auto' })).not.toBeVisible();
+});
+
+test('marks known cards back as ready', async ({ page }) => {
+  await createCard({
+    cardId: 'ready-card-1',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: { word: 'Buch', type: 'NOUN', translation: { en: 'book' } },
+    readiness: 'KNOWN',
+    state: 'REVIEW',
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/cards');
+
+  await page.getByLabel('Filter by state').click();
+  await page.getByRole('option', { name: 'Known' }).click();
+
+  await expect(page.getByRole('gridcell', { name: 'Buch' })).toBeVisible();
+
+  const buchRow = page.getByRole('row').filter({ hasText: 'Buch' });
+  await buchRow.getByRole('checkbox').check();
+
+  await page.getByRole('button', { name: 'Mark selected cards as ready' }).click();
+
+  await expect(page.getByRole('gridcell', { name: 'Buch' })).not.toBeVisible();
+});
+
+test('displays review information in table', async ({ page }) => {
+  const partnerId = await createLearningPartner({ name: 'Anna', isActive: true });
+
+  await createCard({
+    cardId: 'review-info-card',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: { word: 'Katze', type: 'NOUN', translation: { en: 'cat' } },
+    state: 'REVIEW',
+    reps: 3,
+    lastReview: new Date(),
+  });
+
+  await createReviewLog({
+    cardId: 'review-info-card',
+    rating: 3,
+    learningPartnerId: partnerId,
+    review: new Date(),
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/cards');
+
+  await expect(page.getByRole('gridcell', { name: 'Katze' })).toBeVisible();
+  const row = page.getByRole('row').filter({ hasText: 'Katze' });
+  await expect(row.getByRole('gridcell', { name: '3' }).first()).toBeVisible();
+  await expect(row.getByRole('gridcell', { name: 'Good' })).toBeVisible();
+  await expect(row.getByRole('gridcell', { name: 'Anna' })).toBeVisible();
+});
+
+test('filters by review grade', async ({ page }) => {
+  await createCard({
+    cardId: 'grade-card-good',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: { word: 'Hund', type: 'NOUN', translation: { en: 'dog' } },
+    state: 'REVIEW',
+    reps: 2,
+  });
+  await createReviewLog({
+    cardId: 'grade-card-good',
+    rating: 3,
+    review: new Date(),
+  });
+
+  await createCard({
+    cardId: 'grade-card-hard',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 10,
+    data: { word: 'Vogel', type: 'NOUN', translation: { en: 'bird' } },
+    state: 'LEARNING',
+    reps: 1,
+  });
+  await createReviewLog({
+    cardId: 'grade-card-hard',
+    rating: 2,
+    review: new Date(),
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/cards');
+
+  await expect(page.getByRole('gridcell', { name: 'Hund' })).toBeVisible();
+  await expect(page.getByRole('gridcell', { name: 'Vogel' })).toBeVisible();
+
+  await page.getByLabel('Filter by last review grade').click();
+  await page.getByRole('option', { name: 'Good' }).click();
+
+  await expect(page.getByRole('gridcell', { name: 'Hund' })).toBeVisible();
+  await expect(page.getByRole('gridcell', { name: 'Vogel' })).not.toBeVisible();
+});
+
+test('source page shows text buttons for edit and delete', async ({ page }) => {
+  await page.goto('http://localhost:8180/sources');
+
+  const sourceCard = page.getByRole('article', { name: 'Goethe A1' });
+  await sourceCard.hover();
+
+  await expect(sourceCard.getByRole('button', { name: 'Edit source' })).toBeVisible();
+  await expect(sourceCard.getByRole('button', { name: 'Edit source' })).toContainText('Edit');
+  await expect(sourceCard.getByRole('button', { name: 'Delete source' })).toBeVisible();
+  await expect(sourceCard.getByRole('button', { name: 'Delete source' })).toContainText('Delete');
+});
+
+test('navigates to card editing page on row click', async ({ page }) => {
+  await createCard({
+    cardId: 'nav-card-1',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: { word: 'Fenster', type: 'NOUN', translation: { en: 'window' } },
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/cards');
+
+  await expect(page.getByRole('gridcell', { name: 'Fenster' })).toBeVisible();
+  await page.getByRole('gridcell', { name: 'Fenster' }).click();
+
+  await expect(page).toHaveURL(/\/sources\/goethe-a1\/page\/9\/cards\/nav-card-1/);
+});


### PR DESCRIPTION
## Summary
This PR adds a new cards table view for sources, allowing users to browse, filter, and perform bulk operations on cards. The implementation includes a new Angular component using ag-Grid for data display and a corresponding backend API endpoint.

## Key Changes

### Frontend
- **New Component**: `SourceCardsComponent` with ag-Grid integration for displaying cards in a table format
- **Dependencies**: Added `ag-grid-angular` (v35.0.1) and `ag-grid-community` (v35.0.1)
- **Routing**: Added new route `/sources/:sourceId/cards` to access the cards table
- **Filtering**: Implemented multi-field filtering by:
  - Card state (NEW, LEARNING, REVIEW, RELEARNING, KNOWN)
  - Review count ranges
  - Last review date ranges
  - Last review grade
- **Bulk Operations**: Added ability to mark selected cards as "Known" or "Ready"
- **UI Updates**: Enhanced admin component buttons with text labels and improved styling
- **New State**: Added "KNOWN" card state to the state management system

### Backend
- **New Endpoints**:
  - `GET /api/source/{sourceId}/cards` - Fetch paginated, filtered, and sorted cards for a source
  - `PUT /api/cards/readiness` - Bulk update card readiness status
- **New Models**: 
  - `CardTableRow` - Data transfer object for table rows
  - `CardTableResponse` - Paginated response wrapper
  - `BulkReadinessUpdateRequest` - Request body for bulk updates
- **Database Query**: Implemented efficient SQL query with CTE for fetching latest review information
- **New Constant**: Added `KNOWN` readiness constant to `CardReadiness`

### Testing
- Added comprehensive E2E tests covering:
  - Navigation to cards table
  - Card display and filtering
  - Bulk operations (mark as known/ready)
  - Review information display
  - Row click navigation to card editing

## Implementation Details
- The cards table uses ag-Grid's infinite row model for efficient pagination of large datasets
- Filtering is performed server-side to minimize data transfer
- The "KNOWN" state is a special readiness status that overrides the card's learning state
- Material Design theming is applied to the ag-Grid using CSS variables
- Responsive design with mobile-friendly filter layout

https://claude.ai/code/session_01MwiDqGG2VR7hmfhQ6o5Hxt