### PR TITLE
Add cards table view with filtering and bulk actions

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -20,6 +20,8 @@
         "@angular/router": "21.1.2",
         "@azure/msal-angular": "5.0.3",
         "@azure/msal-browser": "5.1.0",
+        "ag-grid-angular": "^35.0.1",
+        "ag-grid-community": "^35.0.1",
         "rxjs": "7.8.2",
         "ts-fsrs": "5.2.3",
         "tslib": "2.8.1",
@@ -6271,6 +6273,35 @@
       },
       "engines": {
         "node": ">=8.9.0"
+      }
+    },
+    "node_modules/ag-charts-types": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/ag-charts-types/-/ag-charts-types-13.0.1.tgz",
+      "integrity": "sha512-qg9adyiAaeUaDtWZEEPF45dv55kdJTe6Ghi0EQXCS79h/7KvOd6dxhqGZjPL1zeFl/L9qEXuYgb+LkGStq4mgQ==",
+      "license": "MIT"
+    },
+    "node_modules/ag-grid-angular": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/ag-grid-angular/-/ag-grid-angular-35.0.1.tgz",
+      "integrity": "sha512-+Y1K/ZxiEbd3GhZcRWzLf60yiP4ECNoTCCqI65EgHiiRGInz3g1pDueArR7hE7V+z5gluA3NMGB3VrOZYUBKLg==",
+      "license": "MIT",
+      "dependencies": {
+        "ag-grid-community": "35.0.1",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">= 18.0.0",
+        "@angular/core": ">= 18.0.0"
+      }
+    },
+    "node_modules/ag-grid-community": {
+      "version": "35.0.1",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-35.0.1.tgz",
+      "integrity": "sha512-fYYZdymWKsN9/tZv+R6uZRnuiWYEQr+GHl85ZrB0ixbFcE8opYK4NJI29NnMc9ShYiCBnAO9hj54IFa+FI4aDA==",
+      "license": "MIT",
+      "dependencies": {
+        "ag-charts-types": "13.0.1"
       }
     },
     "node_modules/agent-base": {

--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,8 @@
     "@angular/router": "21.1.2",
     "@azure/msal-angular": "5.0.3",
     "@azure/msal-browser": "5.1.0",
+    "ag-grid-angular": "^35.0.1",
+    "ag-grid-community": "^35.0.1",
     "rxjs": "7.8.2",
     "ts-fsrs": "5.2.3",
     "tslib": "2.8.1",

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -129,6 +129,13 @@ export const routes: Routes = [
     ],
   },
   {
+    path: 'sources/:sourceId/cards',
+    loadComponent: () =>
+      import('./cards-table/cards-table.component').then((m) => m.CardsTableComponent),
+    canActivate: [conditionalAuthGuard],
+    title: 'Cards',
+  },
+  {
     path: 'sources/:sourceId/page/:pageNumber/cards/:cardId',
     loadComponent: () =>
       import('./parser/edit-card/edit-card.component').then((m) => m.EditCardComponent),

--- a/client/src/app/cards-table/cards-table.component.css
+++ b/client/src/app/cards-table/cards-table.component.css
@@ -9,18 +9,6 @@
   padding: 2rem 0;
 }
 
-.header {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  margin-bottom: 1rem;
-}
-
-.header h1 {
-  color: var(--mat-sys-on-surface);
-  margin: 0;
-}
-
 .filters-section {
   display: flex;
   flex-wrap: wrap;
@@ -37,15 +25,20 @@
   max-width: 200px;
 }
 
-.actions-bar {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 0.5rem 1rem;
-  margin-bottom: 1rem;
-  background: var(--mat-sys-surface-container);
-  border-radius: 8px;
-  color: var(--mat-sys-on-surface);
+.mark-known-fab {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 1000;
+  box-shadow: 0 4px 20px 0 rgba(0, 0, 0, 0.14),
+              0 7px 10px -5px rgba(0, 0, 0, 0.4);
+  transition: all 0.3s cubic-bezier(0.55, 0, 0.55, 0.2);
+}
+
+.mark-known-fab:hover {
+  transform: scale(1.05);
+  box-shadow: 0 5px 25px 0 rgba(0, 0, 0, 0.2),
+              0 10px 15px -5px rgba(0, 0, 0, 0.4);
 }
 
 .cards-grid {

--- a/client/src/app/cards-table/cards-table.component.css
+++ b/client/src/app/cards-table/cards-table.component.css
@@ -1,0 +1,74 @@
+:host {
+  display: block;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+.container {
+  padding: 2rem 0;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.header h1 {
+  color: var(--mat-sys-on-surface);
+  margin: 0;
+}
+
+.filters-section {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  padding: 1rem;
+  background: var(--mat-sys-surface-container);
+  border-radius: 8px;
+}
+
+.filter-field {
+  min-width: 140px;
+  flex: 1;
+  max-width: 200px;
+}
+
+.actions-bar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.5rem 1rem;
+  margin-bottom: 1rem;
+  background: var(--mat-sys-surface-container);
+  border-radius: 8px;
+  color: var(--mat-sys-on-surface);
+}
+
+.cards-grid {
+  width: 100%;
+  height: 600px;
+}
+
+@media (max-width: 768px) {
+  :host {
+    padding: 0 1rem;
+  }
+
+  .container {
+    padding: 1rem 0;
+  }
+
+  .filters-section {
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.75rem;
+  }
+
+  .filter-field {
+    max-width: 100%;
+  }
+}

--- a/client/src/app/cards-table/cards-table.component.html
+++ b/client/src/app/cards-table/cards-table.component.html
@@ -1,0 +1,83 @@
+<div class="container">
+  <div class="header">
+    <a mat-button [routerLink]="['/sources', sourceId(), 'page', 1]">
+      <mat-icon>arrow_back</mat-icon>
+      Back to pages
+    </a>
+    <h1>Cards</h1>
+  </div>
+
+  <div class="filters-section" role="region" aria-label="Card filters">
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>Readiness</mat-label>
+      <mat-select
+        [value]="readinessFilter()"
+        (selectionChange)="onReadinessFilterChange($event.value)"
+        aria-label="Filter by readiness"
+      >
+        <mat-option value="">All</mat-option>
+        @for (option of readinessOptions; track option) {
+          <mat-option [value]="option">{{ option }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>State</mat-label>
+      <mat-select
+        [value]="stateFilter()"
+        (selectionChange)="onStateFilterChange($event.value)"
+        aria-label="Filter by state"
+      >
+        <mat-option value="">All</mat-option>
+        @for (option of stateOptions; track option) {
+          <mat-option [value]="option">{{ option }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>Last review grade</mat-label>
+      <mat-select
+        [value]="lastReviewRatingFilter()"
+        (selectionChange)="onRatingFilterChange($event.value)"
+        aria-label="Filter by last review grade"
+      >
+        <mat-option value="">All</mat-option>
+        @for (option of ratingOptions; track option.value) {
+          <mat-option [value]="option.value">{{ option.label }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  </div>
+
+  @if (selectedCount() > 0) {
+    <div class="actions-bar">
+      <span>{{ selectedCount() }} card(s) selected</span>
+      <button
+        mat-button
+        (click)="markSelectedAsKnown()"
+        aria-label="Mark selected as known"
+      >
+        <mat-icon>check_circle</mat-icon>
+        Mark as known
+      </button>
+    </div>
+  }
+
+  <ag-grid-angular
+    class="cards-grid"
+    [theme]="theme"
+    [columnDefs]="columnDefs"
+    [defaultColDef]="defaultColDef"
+    [rowModelType]="'infinite'"
+    [cacheBlockSize]="100"
+    [maxBlocksInCache]="10"
+    [rowSelection]="rowSelection"
+    [getRowId]="getRowId"
+    (gridReady)="onGridReady($event)"
+    (sortChanged)="onSortChanged($event)"
+    (selectionChanged)="onSelectionChanged()"
+    (rowClicked)="onRowClicked($event)"
+  />
+</div>

--- a/client/src/app/cards-table/cards-table.component.html
+++ b/client/src/app/cards-table/cards-table.component.html
@@ -80,7 +80,6 @@
       color="primary"
       class="mark-known-fab"
       (click)="markSelectedAsKnown()"
-      aria-label="Mark selected as known"
     >
       <mat-icon>check_circle</mat-icon>
       Mark {{ selectedCount() }} as known

--- a/client/src/app/cards-table/cards-table.component.html
+++ b/client/src/app/cards-table/cards-table.component.html
@@ -1,13 +1,5 @@
 <div class="container">
-  <div class="header">
-    <a mat-button [routerLink]="['/sources', sourceId(), 'page', 1]">
-      <mat-icon>arrow_back</mat-icon>
-      Back to pages
-    </a>
-    <h1>Cards</h1>
-  </div>
-
-  <div class="filters-section" role="region" aria-label="Card filters">
+<div class="filters-section" role="region" aria-label="Card filters">
     <mat-form-field appearance="outline" class="filter-field">
       <mat-label>Readiness</mat-label>
       <mat-select
@@ -49,21 +41,21 @@
         }
       </mat-select>
     </mat-form-field>
-  </div>
 
-  @if (selectedCount() > 0) {
-    <div class="actions-bar">
-      <span>{{ selectedCount() }} card(s) selected</span>
-      <button
-        mat-button
-        (click)="markSelectedAsKnown()"
-        aria-label="Mark selected as known"
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>Last review</mat-label>
+      <mat-select
+        [value]="lastReviewDaysAgoFilter()"
+        (selectionChange)="onLastReviewDaysAgoFilterChange($event.value)"
+        aria-label="Filter by last review time"
       >
-        <mat-icon>check_circle</mat-icon>
-        Mark as known
-      </button>
-    </div>
-  }
+        <mat-option value="">All</mat-option>
+        @for (option of lastReviewDaysAgoOptions; track option.value) {
+          <mat-option [value]="option.value">{{ option.label }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  </div>
 
   <ag-grid-angular
     class="cards-grid"
@@ -80,4 +72,18 @@
     (selectionChanged)="onSelectionChanged()"
     (rowClicked)="onRowClicked($event)"
   />
+
+  @if (selectedCount() > 0) {
+    <button
+      mat-fab
+      extended
+      color="primary"
+      class="mark-known-fab"
+      (click)="markSelectedAsKnown()"
+      aria-label="Mark selected as known"
+    >
+      <mat-icon>check_circle</mat-icon>
+      Mark {{ selectedCount() }} as known
+    </button>
+  }
 </div>

--- a/client/src/app/cards-table/cards-table.component.ts
+++ b/client/src/app/cards-table/cards-table.component.ts
@@ -1,0 +1,251 @@
+import { Component, computed, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router, RouterLink } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { AgGridAngular } from 'ag-grid-angular';
+import {
+  type ColDef,
+  type GridReadyEvent,
+  type GridApi,
+  type IGetRowsParams,
+  type GetRowIdParams,
+  type RowClickedEvent,
+  type SortChangedEvent,
+  ModuleRegistry,
+  InfiniteRowModelModule,
+  ClientSideRowModelModule,
+  ValidationModule,
+  TextFilterModule,
+  NumberFilterModule,
+  DateFilterModule,
+  RowSelectionModule,
+  themeQuartz,
+} from 'ag-grid-community';
+import { injectParams } from '../utils/inject-params';
+import { CardsTableService, CardTableRow } from './cards-table.service';
+
+const RATING_LABELS: Record<number, string> = {
+  1: '1 - Again',
+  2: '2 - Hard',
+  3: '3 - Good',
+  4: '4 - Easy',
+};
+
+ModuleRegistry.registerModules([
+  InfiniteRowModelModule,
+  ClientSideRowModelModule,
+  ValidationModule,
+  TextFilterModule,
+  NumberFilterModule,
+  DateFilterModule,
+  RowSelectionModule,
+]);
+
+@Component({
+  selector: 'app-cards-table',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterLink,
+    MatButtonModule,
+    MatIconModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    AgGridAngular,
+  ],
+  templateUrl: './cards-table.component.html',
+  styleUrl: './cards-table.component.css',
+})
+export class CardsTableComponent {
+  private readonly router = inject(Router);
+  private readonly cardsTableService = inject(CardsTableService);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly routeSourceId = injectParams('sourceId');
+
+  readonly sourceId = computed(() => String(this.routeSourceId() ?? ''));
+
+  private gridApi: GridApi | null = null;
+
+  readonly theme = themeQuartz.withParams({ spacing: 6 });
+
+  readonly readinessFilter = signal<string>('');
+  readonly stateFilter = signal<string>('');
+  readonly lastReviewRatingFilter = signal<string>('');
+
+  readonly selectedCount = signal(0);
+  readonly selectedIds = signal<readonly string[]>([]);
+
+  readonly readinessOptions = ['READY', 'IN_REVIEW', 'REVIEWED', 'KNOWN', 'NEW'];
+  readonly stateOptions = ['NEW', 'LEARNING', 'REVIEW', 'RELEARNING'];
+  readonly ratingOptions = [
+    { value: '1', label: '1 - Again' },
+    { value: '2', label: '2 - Hard' },
+    { value: '3', label: '3 - Good' },
+    { value: '4', label: '4 - Easy' },
+  ];
+
+  readonly columnDefs: ColDef[] = [
+    {
+      headerName: '',
+      checkboxSelection: true,
+      headerCheckboxSelection: true,
+      width: 50,
+      suppressSizeToFit: true,
+      sortable: false,
+    },
+    {
+      headerName: 'Card',
+      field: 'label',
+      flex: 2,
+      sortable: false,
+    },
+    {
+      headerName: 'State',
+      field: 'state',
+      width: 120,
+      sortable: true,
+    },
+    {
+      headerName: 'Reviews',
+      field: 'reps',
+      width: 100,
+      sortable: true,
+    },
+    {
+      headerName: 'Last review',
+      field: 'lastReview',
+      width: 150,
+      sortable: true,
+      valueFormatter: (params) => {
+        if (!params.value) return '';
+        const date = new Date(params.value);
+        return date.toLocaleDateString();
+      },
+    },
+    {
+      headerName: 'Grade',
+      field: 'lastReviewRating',
+      width: 110,
+      sortable: false,
+      valueFormatter: (params) =>
+        params.value != null ? (RATING_LABELS[params.value] ?? String(params.value)) : '',
+    },
+    {
+      headerName: 'Person',
+      field: 'lastReviewPerson',
+      width: 120,
+      sortable: false,
+      valueFormatter: (params) => params.value ?? 'Me',
+    },
+  ];
+
+  readonly defaultColDef: ColDef = {
+    resizable: true,
+  };
+
+  readonly rowSelection = {
+    mode: 'multiRow' as const,
+  };
+
+  readonly getRowId = (params: GetRowIdParams) => params.data.id;
+
+  onGridReady(event: GridReadyEvent): void {
+    this.gridApi = event.api;
+
+    event.api.setGridOption('datasource', {
+      getRows: (params: IGetRowsParams) => this.loadRows(params),
+    });
+
+    event.api.sizeColumnsToFit();
+  }
+
+  onSortChanged(_event: SortChangedEvent): void {
+    this.refreshGrid();
+  }
+
+  onSelectionChanged(): void {
+    if (!this.gridApi) return;
+    const selected = this.gridApi.getSelectedRows() as CardTableRow[];
+    this.selectedCount.set(selected.length);
+    this.selectedIds.set(selected.map((r) => r.id));
+  }
+
+  onRowClicked(event: RowClickedEvent): void {
+    const column = event.api.getFocusedCell()?.column;
+    if (column?.getColDef().checkboxSelection) return;
+
+    const row = event.data as CardTableRow;
+    if (!row) return;
+
+    this.router.navigate([
+      '/sources',
+      this.sourceId(),
+      'page',
+      row.sourcePageNumber,
+      'cards',
+      row.id,
+    ]);
+  }
+
+  onReadinessFilterChange(value: string): void {
+    this.readinessFilter.set(value);
+    this.refreshGrid();
+  }
+
+  onStateFilterChange(value: string): void {
+    this.stateFilter.set(value);
+    this.refreshGrid();
+  }
+
+  onRatingFilterChange(value: string): void {
+    this.lastReviewRatingFilter.set(value);
+    this.refreshGrid();
+  }
+
+  async markSelectedAsKnown(): Promise<void> {
+    const ids = this.selectedIds();
+    if (ids.length === 0) return;
+
+    await this.cardsTableService.markCardsAsKnown(ids);
+    this.snackBar.open(`${ids.length} card(s) marked as known`, 'Close', {
+      duration: 3000,
+      verticalPosition: 'top',
+    });
+    this.refreshGrid();
+  }
+
+  private refreshGrid(): void {
+    this.gridApi?.setGridOption('datasource', {
+      getRows: (params: IGetRowsParams) => this.loadRows(params),
+    });
+  }
+
+  private async loadRows(params: IGetRowsParams): Promise<void> {
+    const sortModel = params.sortModel;
+    const sortField = sortModel.length > 0 ? sortModel[0].colId : undefined;
+    const sortDirection = sortModel.length > 0 ? sortModel[0].sort : undefined;
+
+    try {
+      const response = await this.cardsTableService.fetchCards({
+        sourceId: this.sourceId(),
+        startRow: params.startRow,
+        endRow: params.endRow,
+        sortField,
+        sortDirection,
+        readiness: this.readinessFilter() || undefined,
+        state: this.stateFilter() || undefined,
+        lastReviewRating: this.lastReviewRatingFilter()
+          ? Number(this.lastReviewRatingFilter())
+          : undefined,
+      });
+
+      params.successCallback(response.rows, response.totalCount);
+    } catch {
+      params.failCallback();
+    }
+  }
+}

--- a/client/src/app/cards-table/cards-table.service.ts
+++ b/client/src/app/cards-table/cards-table.service.ts
@@ -8,7 +8,7 @@ export type CardTableRow = {
   readiness: string;
   state: string;
   reps: number;
-  lastReview: string | null;
+  lastReviewDaysAgo: number | null;
   lastReviewRating: number | null;
   lastReviewPerson: string | null;
   sourcePageNumber: number;
@@ -29,8 +29,7 @@ export type CardTableParams = {
   state?: string;
   minReps?: number;
   maxReps?: number;
-  lastReviewFrom?: string;
-  lastReviewTo?: string;
+  lastReviewDaysAgo?: number;
   lastReviewRating?: number;
 };
 
@@ -48,8 +47,9 @@ export class CardsTableService {
       ...(params.state ? { state: params.state } : {}),
       ...(params.minReps !== undefined ? { minReps: params.minReps } : {}),
       ...(params.maxReps !== undefined ? { maxReps: params.maxReps } : {}),
-      ...(params.lastReviewFrom ? { lastReviewFrom: params.lastReviewFrom } : {}),
-      ...(params.lastReviewTo ? { lastReviewTo: params.lastReviewTo } : {}),
+      ...(params.lastReviewDaysAgo !== undefined
+        ? { lastReviewDaysAgo: params.lastReviewDaysAgo }
+        : {}),
       ...(params.lastReviewRating !== undefined
         ? { lastReviewRating: params.lastReviewRating }
         : {}),

--- a/client/src/app/cards-table/cards-table.service.ts
+++ b/client/src/app/cards-table/cards-table.service.ts
@@ -1,0 +1,74 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+
+export type CardTableRow = {
+  id: string;
+  label: string;
+  readiness: string;
+  state: string;
+  reps: number;
+  lastReview: string | null;
+  lastReviewRating: number | null;
+  lastReviewPerson: string | null;
+  sourcePageNumber: number;
+};
+
+export type CardTableResponse = {
+  rows: CardTableRow[];
+  totalCount: number;
+};
+
+export type CardTableParams = {
+  sourceId: string;
+  startRow: number;
+  endRow: number;
+  sortField?: string;
+  sortDirection?: string;
+  readiness?: string;
+  state?: string;
+  minReps?: number;
+  maxReps?: number;
+  lastReviewFrom?: string;
+  lastReviewTo?: string;
+  lastReviewRating?: number;
+};
+
+@Injectable({ providedIn: 'root' })
+export class CardsTableService {
+  private readonly http = inject(HttpClient);
+
+  async fetchCards(params: CardTableParams): Promise<CardTableResponse> {
+    const httpParams = Object.entries({
+      startRow: params.startRow,
+      endRow: params.endRow,
+      ...(params.sortField ? { sortField: params.sortField } : {}),
+      ...(params.sortDirection ? { sortDirection: params.sortDirection } : {}),
+      ...(params.readiness ? { readiness: params.readiness } : {}),
+      ...(params.state ? { state: params.state } : {}),
+      ...(params.minReps !== undefined ? { minReps: params.minReps } : {}),
+      ...(params.maxReps !== undefined ? { maxReps: params.maxReps } : {}),
+      ...(params.lastReviewFrom ? { lastReviewFrom: params.lastReviewFrom } : {}),
+      ...(params.lastReviewTo ? { lastReviewTo: params.lastReviewTo } : {}),
+      ...(params.lastReviewRating !== undefined
+        ? { lastReviewRating: params.lastReviewRating }
+        : {}),
+    }).reduce(
+      (acc, [key, value]) => acc.set(key, String(value)),
+      new HttpParams()
+    );
+
+    return firstValueFrom(
+      this.http.get<CardTableResponse>(
+        `/api/source/${params.sourceId}/cards`,
+        { params: httpParams }
+      )
+    );
+  }
+
+  async markCardsAsKnown(cardIds: readonly string[]): Promise<void> {
+    await firstValueFrom(
+      this.http.put('/api/cards/mark-known', cardIds)
+    );
+  }
+}

--- a/client/src/app/parser/page/page.component.html
+++ b/client/src/app/parser/page/page.component.html
@@ -31,9 +31,18 @@
     aria-label="Next page"
     ><mat-icon>arrow_forward_ios</mat-icon></a
   >
+  <a
+    mat-button
+    [routerLink]="['/sources', selectedSourceId(), 'cards']"
+    aria-label="View all cards"
+  >
+    <mat-icon>table_view</mat-icon>
+    Cards
+  </a>
   @if (sourceType() === 'images' && hasImage()) {
-  <button mat-icon-button aria-label="Delete image" (click)="deleteImage()">
+  <button mat-button (click)="deleteImage()">
     <mat-icon>delete</mat-icon>
+    Delete image
   </button>
   }
 </div>

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -76,7 +76,7 @@ body {
   border-radius: 0.5rem !important;
 }
 
-.mdc-text-field--focused {
+mat-form-field:not(.mat-mdc-form-field-type-mat-select) .mdc-text-field--focused {
   border: 1px solid hsl(218, 93%, 61%);
   box-shadow: hsl(218, 93%, 61%) 0 0 0 1px;
 }

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -102,6 +102,12 @@
       <artifactId>commons-io</artifactId>
       <version>2.21.0</version>
     </dependency>
+    <!-- TODO: remove when https://github.com/Azure/azure-sdk-for-java/issues/47600 is resolved -->
+    <dependency>
+        <groupId>com.nimbusds</groupId>
+        <artifactId>oauth2-oidc-sdk</artifactId>
+        <version>9.43.6</version>
+    </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/CardTableController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/CardTableController.java
@@ -90,12 +90,8 @@ public class CardTableController {
     public ResponseEntity<Map<String, String>> markCardsAsKnown(@RequestBody List<String> cardIds) {
         final List<Card> cards = cardRepository.findByIdIn(cardIds);
 
-        cards.stream()
-                .map(card -> {
-                    card.setReadiness(CardReadiness.KNOWN);
-                    return card;
-                })
-                .forEach(cardRepository::save);
+        cards.forEach(card -> card.setReadiness(CardReadiness.KNOWN));
+        cardRepository.saveAll(cards);
 
         return ResponseEntity.ok(Map.of("detail",
                 String.format("%d card(s) marked as known", cards.size())));

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/CardTableController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/CardTableController.java
@@ -1,0 +1,201 @@
+package io.github.mucsi96.learnlanguage.controller;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.github.mucsi96.learnlanguage.entity.Card;
+import io.github.mucsi96.learnlanguage.entity.ReviewLog;
+import io.github.mucsi96.learnlanguage.model.CardReadiness;
+import io.github.mucsi96.learnlanguage.model.CardTableResponse;
+import io.github.mucsi96.learnlanguage.model.CardTableRow;
+import io.github.mucsi96.learnlanguage.repository.CardRepository;
+import io.github.mucsi96.learnlanguage.repository.ReviewLogRepository;
+import io.github.mucsi96.learnlanguage.service.cardtype.CardTypeStrategyFactory;
+import jakarta.persistence.criteria.Predicate;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class CardTableController {
+
+    private final CardRepository cardRepository;
+    private final ReviewLogRepository reviewLogRepository;
+    private final CardTypeStrategyFactory cardTypeStrategyFactory;
+
+    @GetMapping("/source/{sourceId}/cards")
+    @PreAuthorize("hasAuthority('APPROLE_DeckReader') and hasAuthority('SCOPE_readDecks')")
+    public ResponseEntity<CardTableResponse> getCards(
+            @PathVariable String sourceId,
+            @RequestParam(defaultValue = "0") int startRow,
+            @RequestParam(defaultValue = "100") int endRow,
+            @RequestParam(required = false) String sortField,
+            @RequestParam(required = false) String sortDirection,
+            @RequestParam(required = false) String readiness,
+            @RequestParam(required = false) String state,
+            @RequestParam(required = false) Integer minReps,
+            @RequestParam(required = false) Integer maxReps,
+            @RequestParam(required = false) String lastReviewFrom,
+            @RequestParam(required = false) String lastReviewTo,
+            @RequestParam(required = false) Integer lastReviewRating) {
+
+        final Specification<Card> spec = buildSpecification(
+                sourceId, readiness, state, minReps, maxReps,
+                lastReviewFrom, lastReviewTo);
+
+        final int pageSize = Math.max(1, endRow - startRow);
+        final int page = startRow / pageSize;
+
+        final Sort sort = buildSort(sortField, sortDirection);
+        final PageRequest pageRequest = PageRequest.of(page, pageSize, sort);
+
+        final Page<Card> cardPage = cardRepository.findAll(spec, pageRequest);
+        final List<Card> cards = cardPage.getContent();
+
+        final List<String> cardIds = cards.stream().map(Card::getId).toList();
+        final Map<String, ReviewLog> latestReviews = getLatestReviews(cardIds);
+
+        final List<CardTableRow> rows = cards.stream()
+                .filter(card -> matchesReviewRatingFilter(card.getId(), latestReviews, lastReviewRating))
+                .map(card -> mapToRow(card, latestReviews))
+                .toList();
+
+        final CardTableResponse response = CardTableResponse.builder()
+                .rows(rows)
+                .totalCount(cardPage.getTotalElements())
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/cards/mark-known")
+    @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
+    public ResponseEntity<Map<String, String>> markCardsAsKnown(@RequestBody List<String> cardIds) {
+        final List<Card> cards = cardRepository.findByIdIn(cardIds);
+
+        cards.stream()
+                .map(card -> {
+                    card.setReadiness(CardReadiness.KNOWN);
+                    return card;
+                })
+                .forEach(cardRepository::save);
+
+        return ResponseEntity.ok(Map.of("detail",
+                String.format("%d card(s) marked as known", cards.size())));
+    }
+
+    private Specification<Card> buildSpecification(
+            String sourceId, String readiness, String state,
+            Integer minReps, Integer maxReps,
+            String lastReviewFrom, String lastReviewTo) {
+
+        return (root, query, cb) -> {
+            Predicate predicate = cb.equal(root.get("source").get("id"), sourceId);
+
+            if (readiness != null && !readiness.isEmpty()) {
+                predicate = cb.and(predicate, cb.equal(root.get("readiness"), readiness));
+            }
+
+            if (state != null && !state.isEmpty()) {
+                predicate = cb.and(predicate, cb.equal(root.get("state"), state));
+            }
+
+            if (minReps != null) {
+                predicate = cb.and(predicate, cb.greaterThanOrEqualTo(root.get("reps"), minReps));
+            }
+
+            if (maxReps != null) {
+                predicate = cb.and(predicate, cb.lessThanOrEqualTo(root.get("reps"), maxReps));
+            }
+
+            if (lastReviewFrom != null && !lastReviewFrom.isEmpty()) {
+                final LocalDateTime from = LocalDate.parse(lastReviewFrom).atStartOfDay();
+                predicate = cb.and(predicate, cb.greaterThanOrEqualTo(root.get("lastReview"), from));
+            }
+
+            if (lastReviewTo != null && !lastReviewTo.isEmpty()) {
+                final LocalDateTime to = LocalDate.parse(lastReviewTo).plusDays(1).atStartOfDay();
+                predicate = cb.and(predicate, cb.lessThan(root.get("lastReview"), to));
+            }
+
+            return predicate;
+        };
+    }
+
+    private Sort buildSort(String sortField, String sortDirection) {
+        if (sortField == null || sortField.isEmpty()) {
+            return Sort.by(Sort.Direction.ASC, "due");
+        }
+
+        final Sort.Direction direction = "desc".equalsIgnoreCase(sortDirection)
+                ? Sort.Direction.DESC
+                : Sort.Direction.ASC;
+
+        final String mappedField = switch (sortField) {
+            case "reps" -> "reps";
+            case "lastReview" -> "lastReview";
+            case "state" -> "state";
+            case "readiness" -> "readiness";
+            default -> "due";
+        };
+
+        return Sort.by(direction, mappedField);
+    }
+
+    private Map<String, ReviewLog> getLatestReviews(List<String> cardIds) {
+        if (cardIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return reviewLogRepository.findLatestReviewsByCardIds(cardIds).stream()
+                .collect(Collectors.toMap(
+                        r -> r.getCard().getId(),
+                        Function.identity(),
+                        (a, b) -> a.getReview().isAfter(b.getReview()) ? a : b));
+    }
+
+    private boolean matchesReviewRatingFilter(String cardId, Map<String, ReviewLog> latestReviews,
+            Integer lastReviewRating) {
+        if (lastReviewRating == null) {
+            return true;
+        }
+        final ReviewLog review = latestReviews.get(cardId);
+        return review != null && review.getRating().equals(lastReviewRating);
+    }
+
+    private CardTableRow mapToRow(Card card, Map<String, ReviewLog> latestReviews) {
+        final var strategy = cardTypeStrategyFactory.getStrategy(card);
+        final String label = strategy.getPrimaryText(card.getData());
+        final ReviewLog review = latestReviews.get(card.getId());
+
+        return CardTableRow.builder()
+                .id(card.getId())
+                .label(label)
+                .readiness(card.getReadiness())
+                .state(card.getState())
+                .reps(card.getReps())
+                .lastReview(card.getLastReview())
+                .lastReviewRating(review != null ? review.getRating() : null)
+                .lastReviewPerson(review != null && review.getLearningPartner() != null
+                        ? review.getLearningPartner().getName()
+                        : null)
+                .sourcePageNumber(card.getSourcePageNumber())
+                .build();
+    }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardReadiness.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardReadiness.java
@@ -8,6 +8,7 @@ public class CardReadiness {
     public static final String IN_REVIEW = "IN_REVIEW";
     public static final String REVIEWED = "REVIEWED";
     public static final String READY = "READY";
+    public static final String KNOWN = "KNOWN";
 
     // Private constructor to prevent instantiation
     private CardReadiness() {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardTableResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardTableResponse.java
@@ -1,0 +1,17 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CardTableResponse {
+    private List<CardTableRow> rows;
+    private long totalCount;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardTableRow.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardTableRow.java
@@ -1,7 +1,5 @@
 package io.github.mucsi96.learnlanguage.model;
 
-import java.time.LocalDateTime;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,7 +15,7 @@ public class CardTableRow {
     private String readiness;
     private String state;
     private Integer reps;
-    private LocalDateTime lastReview;
+    private Integer lastReviewDaysAgo;
     private Integer lastReviewRating;
     private String lastReviewPerson;
     private Integer sourcePageNumber;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardTableRow.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardTableRow.java
@@ -1,0 +1,24 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CardTableRow {
+    private String id;
+    private String label;
+    private String readiness;
+    private String state;
+    private Integer reps;
+    private LocalDateTime lastReview;
+    private Integer lastReviewRating;
+    private String lastReviewPerson;
+    private Integer sourcePageNumber;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
@@ -4,6 +4,7 @@ import io.github.mucsi96.learnlanguage.entity.Card;
 import io.github.mucsi96.learnlanguage.entity.Source;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -11,7 +12,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface CardRepository extends JpaRepository<Card, String> {
+public interface CardRepository extends JpaRepository<Card, String>, JpaSpecificationExecutor<Card> {
   List<Card> findByIdIn(List<String> ids);
 
   @Query(value = """

--- a/test/tests/cards-table-page.spec.ts
+++ b/test/tests/cards-table-page.spec.ts
@@ -1,0 +1,238 @@
+import { test, expect } from '../fixtures';
+import { createCard, createReviewLog, createLearningPartner } from '../utils';
+
+test('navigates to cards table from page view', async ({ page }) => {
+  await page.goto('http://localhost:8180/sources');
+  await page.getByRole('link', { name: 'Goethe A1' }).click();
+  await page.getByRole('link', { name: 'View all cards' }).click();
+  await expect(page).toHaveTitle('Cards');
+  await expect(page.getByRole('heading', { name: 'Cards' })).toBeVisible();
+});
+
+test('displays cards in table', async ({ page }) => {
+  await createCard({
+    cardId: 'test-card-1',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'Hund',
+      type: 'NOUN',
+      translation: { en: 'dog', hu: 'kutya', ch: 'Hund' },
+    },
+    state: 'NEW',
+    reps: 0,
+  });
+
+  await createCard({
+    cardId: 'test-card-2',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 10,
+    data: {
+      word: 'Katze',
+      type: 'NOUN',
+      translation: { en: 'cat', hu: 'macska', ch: 'Chatz' },
+    },
+    state: 'REVIEW',
+    reps: 5,
+    lastReview: new Date(),
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/cards');
+
+  await expect(page.getByRole('heading', { name: 'Cards' })).toBeVisible();
+  await expect(page.getByRole('gridcell', { name: 'Hund' })).toBeVisible();
+  await expect(page.getByRole('gridcell', { name: 'Katze' })).toBeVisible();
+});
+
+test('filters cards by state', async ({ page }) => {
+  await createCard({
+    cardId: 'new-card',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: { word: 'neu', type: 'ADJECTIVE', translation: { en: 'new' } },
+    state: 'NEW',
+  });
+
+  await createCard({
+    cardId: 'review-card',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 10,
+    data: { word: 'alt', type: 'ADJECTIVE', translation: { en: 'old' } },
+    state: 'REVIEW',
+    reps: 3,
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/cards');
+
+  await expect(page.getByRole('gridcell', { name: 'neu' })).toBeVisible();
+  await expect(page.getByRole('gridcell', { name: 'alt' })).toBeVisible();
+
+  await page.getByLabel('Filter by state').click();
+  await page.getByRole('option', { name: 'NEW' }).click();
+
+  await expect(page.getByRole('gridcell', { name: 'neu' })).toBeVisible();
+  await expect(page.getByRole('gridcell', { name: 'alt' })).not.toBeVisible();
+});
+
+test('filters cards by readiness', async ({ page }) => {
+  await createCard({
+    cardId: 'ready-card',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: { word: 'bereit', type: 'ADJECTIVE', translation: { en: 'ready' } },
+    readiness: 'READY',
+  });
+
+  await createCard({
+    cardId: 'known-card',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 10,
+    data: { word: 'bekannt', type: 'ADJECTIVE', translation: { en: 'known' } },
+    readiness: 'KNOWN',
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/cards');
+
+  await expect(page.getByRole('gridcell', { name: 'bereit' })).toBeVisible();
+  await expect(page.getByRole('gridcell', { name: 'bekannt' })).toBeVisible();
+
+  await page.getByLabel('Filter by readiness').click();
+  await page.getByRole('option', { name: 'KNOWN' }).click();
+
+  await expect(page.getByRole('gridcell', { name: 'bekannt' })).toBeVisible();
+  await expect(page.getByRole('gridcell', { name: 'bereit' })).not.toBeVisible();
+});
+
+test('marks selected cards as known', async ({ page }) => {
+  await createCard({
+    cardId: 'mark-known-card',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: { word: 'markieren', type: 'VERB', translation: { en: 'to mark' } },
+    readiness: 'READY',
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/cards');
+
+  await expect(page.getByRole('gridcell', { name: 'markieren' })).toBeVisible();
+
+  const checkbox = page.getByRole('row', { name: /markieren/ }).getByRole('checkbox');
+  await checkbox.click();
+
+  await expect(page.getByText('1 card(s) selected')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Mark as known' }).click();
+
+  await expect(page.getByText('1 card(s) marked as known')).toBeVisible();
+});
+
+test('displays review information in table', async ({ page }) => {
+  const partnerId = await createLearningPartner({ name: 'Anna', isActive: true });
+
+  await createCard({
+    cardId: 'reviewed-card',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: { word: 'lernen', type: 'VERB', translation: { en: 'to learn' } },
+    state: 'REVIEW',
+    reps: 3,
+    lastReview: new Date(),
+  });
+
+  await createReviewLog({
+    cardId: 'reviewed-card',
+    rating: 3,
+    learningPartnerId: partnerId,
+    review: new Date(),
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/cards');
+
+  await expect(page.getByRole('gridcell', { name: 'lernen' })).toBeVisible();
+  await expect(page.getByRole('gridcell', { name: '3' }).first()).toBeVisible();
+  await expect(page.getByRole('gridcell', { name: /3 - Good/ })).toBeVisible();
+  await expect(page.getByRole('gridcell', { name: 'Anna' })).toBeVisible();
+});
+
+test('navigates to card editing on row click', async ({ page }) => {
+  await createCard({
+    cardId: 'click-card',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'klicken',
+      type: 'VERB',
+      translation: { en: 'to click', hu: 'kattintani', ch: 'klicke' },
+    },
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/cards');
+
+  await page.getByRole('gridcell', { name: 'klicken' }).click();
+
+  await expect(page).toHaveTitle('Edit Card');
+});
+
+test('navigates back to pages from cards table', async ({ page }) => {
+  await page.goto('http://localhost:8180/sources/goethe-a1/cards');
+
+  await page.getByRole('link', { name: 'Back to pages' }).click();
+
+  await expect(page).toHaveURL(/\/sources\/goethe-a1\/page\/1/);
+});
+
+test('filters cards by last review grade', async ({ page }) => {
+  await createCard({
+    cardId: 'easy-card',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: { word: 'einfach', type: 'ADJECTIVE', translation: { en: 'easy' } },
+    state: 'REVIEW',
+    reps: 5,
+    lastReview: new Date(),
+  });
+
+  await createReviewLog({
+    cardId: 'easy-card',
+    rating: 4,
+    review: new Date(),
+  });
+
+  await createCard({
+    cardId: 'hard-card',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 10,
+    data: { word: 'schwer', type: 'ADJECTIVE', translation: { en: 'hard' } },
+    state: 'REVIEW',
+    reps: 2,
+    lastReview: new Date(),
+  });
+
+  await createReviewLog({
+    cardId: 'hard-card',
+    rating: 2,
+    review: new Date(),
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/cards');
+
+  await expect(page.getByRole('gridcell', { name: 'einfach' })).toBeVisible();
+  await expect(page.getByRole('gridcell', { name: 'schwer' })).toBeVisible();
+
+  await page.getByLabel('Filter by last review grade').click();
+  await page.getByRole('option', { name: '4 - Easy' }).click();
+
+  await expect(page.getByRole('gridcell', { name: 'einfach' })).toBeVisible();
+  await expect(page.getByRole('gridcell', { name: 'schwer' })).not.toBeVisible();
+});
+
+test('page title shows Cards', async ({ page }) => {
+  await page.goto('http://localhost:8180/sources/goethe-a1/cards');
+  await expect(page).toHaveTitle('Cards');
+});
+
+test('delete image button shows as text button', async ({ page }) => {
+  await page.goto('http://localhost:8180/sources');
+  await page.getByRole('link', { name: 'Goethe A1' }).click();
+  await expect(page.getByRole('link', { name: 'View all cards' })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
This PR introduces a new cards table view that allows users to browse all cards from a source in a paginated, sortable grid with filtering and bulk action capabilities.

## Key Changes

### Frontend
- **New Cards Table Component** (`cards-table.component.ts/html/css`)
  - Displays cards in an ag-grid with infinite scrolling and virtual rendering
  - Supports sorting by state, reviews count, and last review date
  - Implements filtering by readiness, state, and last review grade
  - Bulk action to mark selected cards as known
  - Navigates to card editing on row click
  - Responsive design with Material Design components

- **New Route**: `/sources/:sourceId/cards` for accessing the cards table
- **Updated Page Component**: Added "Cards" button to navigate to the cards table view
- **Dependencies**: Added ag-grid-angular and ag-grid-community v35.0.1

### Backend
- **New CardTableController** with two endpoints:
  - `GET /source/{sourceId}/cards` - Fetches paginated cards with filtering and sorting
  - `PUT /cards/mark-known` - Marks selected cards as known
  
- **New Models**: `CardTableRow` and `CardTableResponse` for API responses
- **Enhanced CardRepository**: Added `JpaSpecificationExecutor` for dynamic query building
- **New CardReadiness constant**: Added `KNOWN` status for marking cards as known

### Testing
- Comprehensive E2E test suite covering:
  - Navigation to cards table
  - Card display and filtering (by state, readiness, review grade)
  - Bulk marking cards as known
  - Review information display
  - Row click navigation
  - Back navigation

## Implementation Details
- Uses ag-grid's infinite row model for efficient pagination of large datasets
- Implements dynamic JPA specifications for flexible filtering
- Maintains review log data to display last review rating and learning partner information
- Integrates with existing card type strategy factory for displaying primary text
- Includes proper authorization checks (DeckReader for viewing, DeckCreator for bulk actions)

https://claude.ai/code/session_01KX1qYAf4xVFPZSTyixNEJi