### PR TITLE
Add file storage cleanup service for unreferenced files

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/FileStorageCleanupController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/FileStorageCleanupController.java
@@ -1,0 +1,23 @@
+package io.github.mucsi96.learnlanguage.controller;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.github.mucsi96.learnlanguage.service.FileStorageCleanupService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@Profile("test")
+public class FileStorageCleanupController {
+
+  private final FileStorageCleanupService fileStorageCleanupService;
+
+  @PostMapping("/test/cleanup-storage")
+  public ResponseEntity<Void> triggerCleanup() {
+    fileStorageCleanupService.cleanupUnreferencedFiles();
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/DocumentRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/DocumentRepository.java
@@ -2,7 +2,9 @@ package io.github.mucsi96.learnlanguage.repository;
 
 import io.github.mucsi96.learnlanguage.entity.Document;
 import io.github.mucsi96.learnlanguage.entity.Source;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,6 +12,10 @@ import java.util.Optional;
 
 @Repository
 public interface DocumentRepository extends JpaRepository<Document, Integer> {
+    @EntityGraph(attributePaths = {"source"})
+    @Query("SELECT d FROM Document d")
+    List<Document> findAllWithSource();
+
     List<Document> findBySourceOrderByPageNumberAsc(Source source);
 
     Optional<Document> findBySourceAndPageNumber(Source source, Integer pageNumber);

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/FileStorageCleanupService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/FileStorageCleanupService.java
@@ -1,0 +1,115 @@
+package io.github.mucsi96.learnlanguage.service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+
+import io.github.mucsi96.learnlanguage.entity.Card;
+import io.github.mucsi96.learnlanguage.model.AudioData;
+import io.github.mucsi96.learnlanguage.model.ExampleImageData;
+import io.github.mucsi96.learnlanguage.repository.CardRepository;
+import io.github.mucsi96.learnlanguage.repository.DocumentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FileStorageCleanupService {
+
+  private final FileStorageService fileStorageService;
+  private final CardRepository cardRepository;
+  private final DocumentRepository documentRepository;
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void cleanupUnreferencedFiles() {
+    final var deletedAudioFiles = cleanupAudioFiles();
+    final var deletedImageFiles = cleanupImageFiles();
+    final var deletedSourceFiles = cleanupSourceDocuments();
+
+    log.info(
+        "File storage cleanup completed. Deleted {} audio files, {} image files, {} source documents",
+        deletedAudioFiles.size(), deletedImageFiles.size(), deletedSourceFiles.size());
+  }
+
+  private List<String> cleanupAudioFiles() {
+    final var allFiles = fileStorageService.listFiles("audio");
+    final var cards = cardRepository.findAll();
+
+    final Set<String> referencedPaths = cards.stream()
+        .map(Card::getData)
+        .flatMap(data -> Optional.ofNullable(data.getAudio())
+            .map(List::stream)
+            .orElse(Stream.empty()))
+        .map(AudioData::getId)
+        .map(id -> "audio/%s.mp3".formatted(id))
+        .collect(Collectors.toSet());
+
+    final var unreferenced = allFiles.stream()
+        .filter(file -> !referencedPaths.contains(file))
+        .toList();
+
+    unreferenced.forEach(file -> {
+      log.info("Deleting unreferenced audio file: {}", file);
+      fileStorageService.deleteFile(file);
+    });
+
+    return unreferenced;
+  }
+
+  private List<String> cleanupImageFiles() {
+    final var allFiles = fileStorageService.listFiles("images");
+    final var cards = cardRepository.findAll();
+
+    final Set<String> referencedPaths = cards.stream()
+        .map(Card::getData)
+        .flatMap(data -> Optional.ofNullable(data.getExamples())
+            .map(List::stream)
+            .orElse(Stream.empty()))
+        .flatMap(example -> Optional.ofNullable(example.getImages())
+            .map(List::stream)
+            .orElse(Stream.empty()))
+        .map(ExampleImageData::getId)
+        .map(id -> "images/%s.jpg".formatted(id))
+        .collect(Collectors.toSet());
+
+    final var unreferenced = allFiles.stream()
+        .filter(file -> !referencedPaths.contains(file))
+        .toList();
+
+    unreferenced.forEach(file -> {
+      log.info("Deleting unreferenced image file: {}", file);
+      fileStorageService.deleteFile(file);
+    });
+
+    return unreferenced;
+  }
+
+  private List<String> cleanupSourceDocuments() {
+    final var allFiles = fileStorageService.listFiles("sources");
+    final var documents = documentRepository.findAllWithSource();
+
+    final Set<String> referencedPaths = documents.stream()
+        .map(doc -> doc.getPageNumber() == null
+            ? "sources/%s".formatted(doc.getFileName())
+            : "sources/%s/%s".formatted(doc.getSource().getId(), doc.getFileName()))
+        .collect(Collectors.toSet());
+
+    final var unreferenced = allFiles.stream()
+        .filter(file -> !referencedPaths.contains(file))
+        .toList();
+
+    unreferenced.forEach(file -> {
+      log.info("Deleting unreferenced source document: {}", file);
+      fileStorageService.deleteFile(file);
+    });
+
+    return unreferenced;
+  }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/FileStorageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/FileStorageService.java
@@ -5,6 +5,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.stream.Stream;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -78,6 +80,26 @@ public class FileStorageService {
       Files.deleteIfExists(resolvedPath);
     } catch (IOException e) {
       throw new RuntimeException("Failed to delete file: " + filePath, e);
+    }
+  }
+
+  public List<String> listFiles(String directory) {
+    try {
+      final Path dirPath = resolveFilePath(directory);
+
+      if (!Files.exists(dirPath) || !Files.isDirectory(dirPath)) {
+        return List.of();
+      }
+
+      try (Stream<Path> stream = Files.walk(dirPath)) {
+        return stream
+            .filter(Files::isRegularFile)
+            .map(storagePath::relativize)
+            .map(Path::toString)
+            .toList();
+      }
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to list files in directory: " + directory, e);
     }
   }
 }

--- a/test/tests/file-storage-cleanup.spec.ts
+++ b/test/tests/file-storage-cleanup.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from '../fixtures';
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  STORAGE_DIR,
+  createCard,
+  yellowImage,
+  germanAudioSample,
+} from '../utils';
+
+const COMPOSE_FILE = path.join(__dirname, '..', '..', 'docker-compose.yaml');
+
+function writeStorageFile(relativePath: string, data: Buffer): void {
+  const fullPath = path.join(STORAGE_DIR, relativePath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, data);
+}
+
+function storageFileExists(relativePath: string): boolean {
+  return fs.existsSync(path.join(STORAGE_DIR, relativePath));
+}
+
+async function waitForServer(): Promise<void> {
+  const maxAttempts = 30;
+
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      const response = await fetch('http://localhost:8180/api/sources', {
+        signal: AbortSignal.timeout(2000),
+      });
+      if (response.ok) return;
+    } catch {
+      // Server not ready yet
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+
+  throw new Error('Server did not become healthy after restart');
+}
+
+async function restartServer(): Promise<void> {
+  execSync(`docker compose -f ${COMPOSE_FILE} restart server`, {
+    timeout: 60000,
+  });
+  await waitForServer();
+}
+
+test('deletes unreferenced audio files on startup', async ({ page }) => {
+  const referencedAudioId = 'ref-audio-cleanup-1';
+  const orphanAudioId = 'orphan-audio-cleanup-1';
+
+  await createCard({
+    cardId: 'cleanup-audio-card',
+    sourceId: 'goethe-a1',
+    data: {
+      word: 'Haus',
+      type: 'NOUN',
+      translation: { en: 'house', hu: 'ház' },
+      forms: [],
+      examples: [],
+      audio: [
+        {
+          id: referencedAudioId,
+          text: 'Haus',
+          language: 'de',
+          voice: 'test-voice',
+          model: 'eleven_v3',
+        },
+      ],
+    },
+  });
+
+  writeStorageFile(`audio/${referencedAudioId}.mp3`, germanAudioSample);
+  writeStorageFile(`audio/${orphanAudioId}.mp3`, germanAudioSample);
+
+  await restartServer();
+
+  expect(storageFileExists(`audio/${referencedAudioId}.mp3`)).toBe(true);
+  expect(storageFileExists(`audio/${orphanAudioId}.mp3`)).toBe(false);
+});
+
+test('deletes unreferenced image files on startup', async ({ page }) => {
+  const referencedImageId = 'ref-image-cleanup-1';
+  const orphanImageId = 'orphan-image-cleanup-1';
+
+  await createCard({
+    cardId: 'cleanup-image-card',
+    sourceId: 'goethe-a1',
+    data: {
+      word: 'Baum',
+      type: 'NOUN',
+      translation: { en: 'tree', hu: 'fa' },
+      forms: [],
+      examples: [
+        {
+          de: 'Der Baum ist groß.',
+          en: 'The tree is big.',
+          hu: 'A fa nagy.',
+          isSelected: true,
+          images: [{ id: referencedImageId }],
+        },
+      ],
+    },
+  });
+
+  writeStorageFile(`images/${referencedImageId}.jpg`, yellowImage);
+  writeStorageFile(`images/${orphanImageId}.jpg`, yellowImage);
+
+  await restartServer();
+
+  expect(storageFileExists(`images/${referencedImageId}.jpg`)).toBe(true);
+  expect(storageFileExists(`images/${orphanImageId}.jpg`)).toBe(false);
+});
+
+test('deletes unreferenced source documents on startup', async ({ page }) => {
+  writeStorageFile('sources/orphan-document.pdf', germanAudioSample);
+
+  await restartServer();
+
+  expect(storageFileExists('sources/A1_SD1_Wortliste_02.pdf')).toBe(true);
+  expect(storageFileExists('sources/Goethe-Zertifikat_A2_Wortliste.pdf')).toBe(true);
+  expect(storageFileExists('sources/Goethe-Zertifikat_B1_Wortliste.pdf')).toBe(true);
+  expect(storageFileExists('sources/orphan-document.pdf')).toBe(false);
+});


### PR DESCRIPTION
## Summary
Implement automatic cleanup of unreferenced files in storage on application startup. This service identifies and deletes audio files, images, and source documents that are no longer referenced by any entities in the database.

## Key Changes
- **New FileStorageCleanupService**: Automatically runs on application startup to clean up orphaned files
  - Scans audio files and removes those not referenced by any cards
  - Scans image files and removes those not referenced by card examples
  - Scans source documents and removes those not referenced by any documents
  - Logs all cleanup operations for audit purposes

- **Enhanced FileStorageService**: Added `listFiles()` method to recursively list all files in a directory

- **DocumentRepository**: Added `findAllWithSource()` query method with `@EntityGraph` to eagerly load source relationships, preventing N+1 queries during cleanup

## Implementation Details
- The cleanup service is triggered by Spring's `ApplicationReadyEvent`, ensuring it runs after the application is fully initialized
- Uses stream processing to efficiently match stored files against database references
- Handles missing directories gracefully by returning empty lists
- All file deletions are logged individually for traceability
- Summary statistics are logged after cleanup completes

https://claude.ai/code/session_01HFAHmeQxYrZCq5F58rkb7c