### PR TITLE
Refactor word extraction to use intermediate DTO records

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/AreaWordsService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/AreaWordsService.java
@@ -19,7 +19,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AreaWordsService {
 
-  record AreaWords(List<WordResponse> wordList) {
+  record ExtractedWord(String word, List<String> forms, List<String> examples) {
+  }
+
+  record ExtractedWordList(List<ExtractedWord> wordList) {
   }
 
   private final ObjectMapper objectMapper;
@@ -55,17 +58,10 @@ public class AreaWordsService {
           .formatted(languageLevel.name());
     };
 
-    AreaWords example = new AreaWords(List.of(
-        WordResponse.builder()
-            .word("das Haus")
-            .forms(List.of("die Häuser"))
-            .examples(List.of("Das Haus ist groß."))
-            .build(),
-        WordResponse.builder()
-            .word("gehen")
-            .forms(List.of("gehst", "geht", "ist gegangen"))
-            .examples(List.of("Ich gehe jetzt.", "Er ist nach Hause gegangen."))
-            .build()));
+    ExtractedWordList example = new ExtractedWordList(List.of(
+        new ExtractedWord("das Haus", List.of("die Häuser"), List.of("Das Haus ist groß.")),
+        new ExtractedWord("gehen", List.of("gehst", "geht", "ist gegangen"),
+            List.of("Ich gehe jetzt.", "Er ist nach Hause gegangen."))));
 
     try {
       String exampleJson = objectMapper.writeValueAsString(example);
@@ -75,7 +71,8 @@ public class AreaWordsService {
     }
   }
 
-  public List<WordResponse> getAreaWords(byte[] imageData, ChatModel model, SourceFormatType formatType, LanguageLevel languageLevel) {
+  public List<WordResponse> getAreaWords(byte[] imageData, ChatModel model, SourceFormatType formatType,
+      LanguageLevel languageLevel) {
     final var result = chatService.callWithLoggingAndMedia(
         model,
         OperationType.EXTRACTION,
@@ -87,8 +84,14 @@ public class AreaWordsService {
                 .data(imageData)
                 .mimeType(MimeTypeUtils.IMAGE_PNG)
                 .build()),
-        AreaWords.class);
+        ExtractedWordList.class);
 
-    return result.wordList;
+    return result.wordList.stream()
+        .map(extracted -> WordResponse.builder()
+            .word(extracted.word())
+            .forms(extracted.forms())
+            .examples(extracted.examples())
+            .build())
+        .toList();
   }
 }


### PR DESCRIPTION
## Summary
Refactored the word extraction logic to introduce intermediate DTO records (`ExtractedWord` and `ExtractedWordList`) that better represent the structure of data returned from the AI model, improving separation of concerns between the extraction layer and the API response layer.

## Key Changes
- Replaced the `AreaWords` record with two new records:
  - `ExtractedWord`: Represents a single word with its forms and examples
  - `ExtractedWordList`: Wraps a list of extracted words
- Updated the example JSON in `buildSystemPrompt()` to use the new `ExtractedWord` constructor instead of `WordResponse.builder()`
- Modified `getAreaWords()` to map from `ExtractedWord` objects to `WordResponse` objects using a stream transformation
- Improved code readability by simplifying the example construction (removed verbose builder pattern)

## Implementation Details
- The mapping from `ExtractedWord` to `WordResponse` is now explicit and happens at the service boundary, making the data transformation clear
- The intermediate records serve as a cleaner contract for the AI model's response format
- No functional changes to the public API or behavior; this is purely an internal refactoring

https://claude.ai/code/session_01KkfNCvzttM3zJd7egZ8xtZ