### PR TITLE
Group model summary by operation type

### DIFF
--- a/client/src/app/model-usage-logs/model-usage-logs.component.css
+++ b/client/src/app/model-usage-logs/model-usage-logs.component.css
@@ -334,8 +334,21 @@ p {
 }
 
 /* Summary table */
+.operation-type-heading {
+  margin: 1.5rem 0 0.5rem 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: capitalize;
+  color: var(--mat-sys-primary);
+}
+
+.operation-type-heading:first-child {
+  margin-top: 0;
+}
+
 .summary-table {
   width: 100%;
+  margin-bottom: 1rem;
 }
 
 .avg-rating {

--- a/client/src/app/model-usage-logs/model-usage-logs.component.html
+++ b/client/src/app/model-usage-logs/model-usage-logs.component.html
@@ -84,7 +84,6 @@
   <p>Track AI model usage and costs across chat, image, and audio services.</p>
 
   @let logsList = logs() || [];
-  @let summaryList = summary() || [];
   @let dateOptions = availableDates();
   @let modelTypes = availableModelTypes();
   @let operationTypes = availableOperationTypes();

--- a/client/src/app/model-usage-logs/model-usage-logs.component.html
+++ b/client/src/app/model-usage-logs/model-usage-logs.component.html
@@ -325,49 +325,53 @@
 
     <mat-tab label="Model Summary">
       <div class="tab-content">
-        @if (summaryList.length > 0) {
-        <table mat-table [dataSource]="summaryList" class="summary-table">
-          <ng-container matColumnDef="modelName">
-            <th mat-header-cell *matHeaderCellDef>Model</th>
-            <td mat-cell *matCellDef="let row">
-              <span class="model-name">{{ row.modelName }}</span>
-            </td>
-          </ng-container>
+        @let groups = groupedSummary();
+        @if (groups.length > 0) {
+          @for (group of groups; track group.operationType) {
+            <h3 class="operation-type-heading">{{ group.operationType }}</h3>
+            <table mat-table [dataSource]="group.summaries" class="summary-table" [attr.aria-label]="group.operationType + ' summary'">
+              <ng-container matColumnDef="modelName">
+                <th mat-header-cell *matHeaderCellDef>Model</th>
+                <td mat-cell *matCellDef="let row">
+                  <span class="model-name">{{ row.modelName }}</span>
+                </td>
+              </ng-container>
 
-          <ng-container matColumnDef="totalCalls">
-            <th mat-header-cell *matHeaderCellDef>Total Calls</th>
-            <td mat-cell *matCellDef="let row">{{ row.totalCalls }}</td>
-          </ng-container>
+              <ng-container matColumnDef="totalCalls">
+                <th mat-header-cell *matHeaderCellDef>Total Calls</th>
+                <td mat-cell *matCellDef="let row">{{ row.totalCalls }}</td>
+              </ng-container>
 
-          <ng-container matColumnDef="ratedCalls">
-            <th mat-header-cell *matHeaderCellDef>Rated Calls</th>
-            <td mat-cell *matCellDef="let row">{{ row.ratedCalls }}</td>
-          </ng-container>
+              <ng-container matColumnDef="ratedCalls">
+                <th mat-header-cell *matHeaderCellDef>Rated Calls</th>
+                <td mat-cell *matCellDef="let row">{{ row.ratedCalls }}</td>
+              </ng-container>
 
-          <ng-container matColumnDef="averageRating">
-            <th mat-header-cell *matHeaderCellDef>Avg Rating</th>
-            <td mat-cell *matCellDef="let row">
-              @if (row.ratedCalls > 0) {
-                <div class="avg-rating">
-                  <mat-icon class="star-filled">star</mat-icon>
-                  <span>{{ row.averageRating | number: '1.2-2' }}</span>
-                </div>
-              } @else {
-                <span class="no-rating">-</span>
-              }
-            </td>
-          </ng-container>
+              <ng-container matColumnDef="averageRating">
+                <th mat-header-cell *matHeaderCellDef>Avg Rating</th>
+                <td mat-cell *matCellDef="let row">
+                  @if (row.ratedCalls > 0) {
+                    <div class="avg-rating">
+                      <mat-icon class="star-filled">star</mat-icon>
+                      <span>{{ row.averageRating | number: '1.2-2' }}</span>
+                    </div>
+                  } @else {
+                    <span class="no-rating">-</span>
+                  }
+                </td>
+              </ng-container>
 
-          <ng-container matColumnDef="totalCost">
-            <th mat-header-cell *matHeaderCellDef>Total Cost</th>
-            <td mat-cell *matCellDef="let row">
-              <span class="cost-value">${{ row.totalCost | number: '1.4-4' }}</span>
-            </td>
-          </ng-container>
+              <ng-container matColumnDef="totalCost">
+                <th mat-header-cell *matHeaderCellDef>Total Cost</th>
+                <td mat-cell *matCellDef="let row">
+                  <span class="cost-value">${{ row.totalCost | number: '1.4-4' }}</span>
+                </td>
+              </ng-container>
 
-          <tr mat-header-row *matHeaderRowDef="summaryColumns"></tr>
-          <tr mat-row *matRowDef="let row; columns: summaryColumns"></tr>
-        </table>
+              <tr mat-header-row *matHeaderRowDef="summaryColumns"></tr>
+              <tr mat-row *matRowDef="let row; columns: summaryColumns"></tr>
+            </table>
+          }
         } @else {
         <mat-card class="empty-state">
           <mat-card-content>

--- a/client/src/app/model-usage-logs/model-usage-logs.component.ts
+++ b/client/src/app/model-usage-logs/model-usage-logs.component.ts
@@ -9,7 +9,7 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { MatSelectModule } from '@angular/material/select';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { ModelUsageLogsService, ModelUsageLog, ModelType, OperationGroup, DiffLine } from './model-usage-logs.service';
+import { ModelUsageLogsService, ModelUsageLog, ModelType, OperationGroup, DiffLine, OperationTypeSummaryGroup } from './model-usage-logs.service';
 
 @Component({
   selector: 'app-model-usage-logs',
@@ -37,6 +37,7 @@ export class ModelUsageLogsComponent {
   readonly logs = this.service.filteredAndSortedLogs;
   readonly groups = this.service.groupedLogs;
   readonly summary = this.service.summary.value;
+  readonly groupedSummary = this.service.groupedSummary;
   readonly loading = computed(() => this.service.logs.isLoading());
   readonly expandedLogId = signal<number | null>(null);
   readonly ratingStars = [1, 2, 3, 4, 5];

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ModelUsageLogController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ModelUsageLogController.java
@@ -32,8 +32,8 @@ public class ModelUsageLogController {
 
     public record RatingRequest(Integer rating) {}
 
-    public record ModelSummary(String modelName, long totalCalls, long ratedCalls,
-            BigDecimal averageRating, BigDecimal totalCost) {}
+    public record ModelSummary(OperationType operationType, String modelName, long totalCalls,
+            long ratedCalls, BigDecimal averageRating, BigDecimal totalCost) {}
 
     @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
     @GetMapping("/model-usage-logs")
@@ -60,11 +60,12 @@ public class ModelUsageLogController {
     public List<ModelSummary> getModelSummary() {
         return repository.getModelSummary().stream()
             .map(row -> new ModelSummary(
-                (String) row[0],
-                (Long) row[1],
+                (OperationType) row[0],
+                (String) row[1],
                 (Long) row[2],
-                BigDecimal.valueOf((Double) row[3]).setScale(2, RoundingMode.HALF_UP),
-                (BigDecimal) row[4]
+                (Long) row[3],
+                BigDecimal.valueOf((Double) row[4]).setScale(2, RoundingMode.HALF_UP),
+                (BigDecimal) row[5]
             ))
             .toList();
     }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/ModelUsageLogRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/ModelUsageLogRepository.java
@@ -26,11 +26,11 @@ public interface ModelUsageLogRepository extends JpaRepository<ModelUsageLog, Lo
             @Param("id") Long id,
             @Param("rating") Integer rating);
 
-    @Query("SELECT m.modelName, COUNT(m), COUNT(m.rating), "
+    @Query("SELECT m.operationType, m.modelName, COUNT(m), COUNT(m.rating), "
             + "COALESCE(AVG(m.rating), 0.0), "
             + "COALESCE(SUM(m.costUsd), 0) "
-            + "FROM ModelUsageLog m GROUP BY m.modelName "
-            + "ORDER BY COALESCE(AVG(m.rating), 0.0) DESC")
+            + "FROM ModelUsageLog m GROUP BY m.operationType, m.modelName "
+            + "ORDER BY m.operationType, COALESCE(AVG(m.rating), 0.0) DESC")
     List<Object[]> getModelSummary();
 
     @Modifying

--- a/test/tests/model-usage-page.spec.ts
+++ b/test/tests/model-usage-page.spec.ts
@@ -28,6 +28,11 @@ type ModelSummaryRow = {
   'Total Cost': string;
 };
 
+type ModelSummaryGroup = {
+  operationType: string;
+  rows: ModelSummaryRow[];
+};
+
 async function setupVoiceConfigurations() {
   await createVoiceConfiguration({
     voiceId: 'test-voice-de',
@@ -236,9 +241,11 @@ test('allows rating usage logs', async ({ page }) => {
 
   await page.getByRole('tab', { name: 'Model Summary' }).click();
 
+  const summaryPanel = page.getByRole('tabpanel', { name: 'Model Summary' });
+
   await expect(async () => {
     const summaryData = await getTableData<ModelSummaryRow>(
-      page.getByRole('tabpanel', { name: 'Model Summary' }).getByRole('table')
+      summaryPanel.getByRole('table', { name: 'translation summary' })
     );
 
     expect(summaryData).toEqual([
@@ -298,9 +305,11 @@ test('auto-rates duplicate logs with same response content', async ({ page }) =>
 
   await page.getByRole('tab', { name: 'Model Summary' }).click();
 
+  const summaryPanel = page.getByRole('tabpanel', { name: 'Model Summary' });
+
   await expect(async () => {
     const summaryData = await getTableData<ModelSummaryRow>(
-      page.getByRole('tabpanel', { name: 'Model Summary' }).getByRole('table')
+      summaryPanel.getByRole('table', { name: 'translation summary' })
     );
 
     expect(summaryData).toEqual([
@@ -335,9 +344,11 @@ test('allows clearing rating by clicking the same star', async ({ page }) => {
 
   await page.getByRole('tab', { name: 'Model Summary' }).click();
 
+  const summaryPanel = page.getByRole('tabpanel', { name: 'Model Summary' });
+
   await expect(async () => {
     const summaryData = await getTableData<ModelSummaryRow>(
-      page.getByRole('tabpanel', { name: 'Model Summary' }).getByRole('table')
+      summaryPanel.getByRole('table', { name: 'translation summary' })
     );
 
     expect(summaryData).toEqual([
@@ -430,10 +441,12 @@ test('displays model summary tab', async ({ page }) => {
 
   await page.getByRole('tab', { name: 'Model Summary' }).click();
 
-  const table = page.getByRole('tabpanel', { name: 'Model Summary' }).getByRole('table');
+  const summaryPanel = page.getByRole('tabpanel', { name: 'Model Summary' });
 
   await expect(async () => {
-    const summaryData = await getTableData<ModelSummaryRow>(table);
+    const summaryData = await getTableData<ModelSummaryRow>(
+      summaryPanel.getByRole('table', { name: 'translation summary' })
+    );
 
     expect(summaryData).toEqual([
       {


### PR DESCRIPTION
## Summary
This PR reorganizes the model usage summary display to group results by operation type (e.g., translation, image generation), making it easier to compare model performance across different operation categories.

## Key Changes

**Backend (Java)**
- Updated `ModelSummary` record to include `operationType` as the first field
- Modified `ModelUsageLogRepository.getModelSummary()` query to:
  - Select `operationType` from the model
  - Group by both `operationType` and `modelName`
  - Order by `operationType` first, then by average rating
- Updated `ModelUsageLogController.getModelSummary()` to map the new query result structure

**Frontend (Angular)**
- Added `OperationTypeSummaryGroup` interface to represent grouped summaries
- Created `groupedSummary` computed signal in `ModelUsageLogsService` that groups `ModelSummary` items by operation type
- Updated component template to:
  - Display a heading for each operation type group
  - Render a separate summary table for each operation type
  - Add `aria-label` attributes to tables for accessibility
- Added new CSS styles for operation type headings with proper spacing and typography

**Tests**
- Updated E2E tests to query tables by their `aria-label` attribute (`'translation summary'`) instead of selecting the first table
- Tests now properly target specific operation type tables

## Implementation Details
- The grouping is performed client-side using a computed signal, reducing backend complexity
- Tables are now semantically grouped with headings, improving accessibility and readability
- The first operation type heading has no top margin to maintain proper spacing
- Each summary table has consistent bottom margin for visual separation

https://claude.ai/code/session_01XdTCcQSd26U6pcoTxNuJHb