### PR TITLE
Add rate limiting for image generation by model

### DIFF
--- a/client/src/app/environment/environment.config.ts
+++ b/client/src/app/environment/environment.config.ts
@@ -10,7 +10,7 @@ export interface ChatModelInfo {
 export interface ImageModel {
   id: string;
   displayName: string;
-  imagesPerMinute: number;
+  provider: ModelProvider;
 }
 
 export interface AudioModel {
@@ -67,6 +67,7 @@ export interface EnvironmentConfig {
   languageLevels: LanguageLevelInfo[];
   sourceFormatTypes: SourceFormatTypeInfo[];
   sourceTypes: SourceTypeInfo[];
+  imageProviderRateLimits: Record<string, number>;
 }
 
 export const ENVIRONMENT_CONFIG = new InjectionToken<EnvironmentConfig>('ENVIRONMENT_CONFIG');

--- a/client/src/app/environment/environment.config.ts
+++ b/client/src/app/environment/environment.config.ts
@@ -10,6 +10,7 @@ export interface ChatModelInfo {
 export interface ImageModel {
   id: string;
   displayName: string;
+  imagesPerMinute: number;
 }
 
 export interface AudioModel {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/EnvironmentController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/EnvironmentController.java
@@ -18,6 +18,7 @@ import io.github.mucsi96.learnlanguage.model.LanguageLevel;
 import io.github.mucsi96.learnlanguage.model.SourceFormatType;
 import io.github.mucsi96.learnlanguage.model.SourceType;
 import io.github.mucsi96.learnlanguage.model.VoiceResponse;
+import io.github.mucsi96.learnlanguage.config.ModelPricingConfig;
 import io.github.mucsi96.learnlanguage.service.AudioService;
 import io.github.mucsi96.learnlanguage.service.ChatModelSettingService;
 import io.github.mucsi96.learnlanguage.service.ElevenLabsAudioService;
@@ -30,6 +31,7 @@ public class EnvironmentController {
   private final AudioService audioService;
   private final ElevenLabsAudioService elevenLabsAudioService;
   private final ChatModelSettingService chatModelSettingService;
+  private final ModelPricingConfig modelPricingConfig;
 
   @Value("${tenant-id:}")
   private String tenantId;
@@ -76,7 +78,10 @@ public class EnvironmentController {
             .map(model -> new ChatModelInfo(model.getModelName(), model.getProvider().getCode()))
             .toList(),
         Arrays.stream(ImageGenerationModel.values())
-            .map(model -> new ImageModelResponse(model.getModelName(), model.getDisplayName()))
+            .map(model -> new ImageModelResponse(
+                model.getModelName(),
+                model.getDisplayName(),
+                modelPricingConfig.getImageRateLimit(model.getModelName())))
             .toList(),
         audioService.getAvailableModels(),
         elevenLabsAudioService.getVoices(),

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationModel.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationModel.java
@@ -3,19 +3,22 @@ package io.github.mucsi96.learnlanguage.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 // Pricing: https://platform.openai.com/docs/pricing
 //          https://ai.google.dev/gemini-api/docs/pricing
 @RequiredArgsConstructor
+@Getter
 public enum ImageGenerationModel {
-    GPT_IMAGE_1("gpt-image-1", "GPT Image 1"),
-    GPT_IMAGE_1_5("gpt-image-1.5", "GPT Image 1.5"),
-    IMAGEN_4_ULTRA("imagen-4.0-ultra-generate-001", "Imagen 4 Ultra"),
-    GEMINI_3_PRO_IMAGE_PREVIEW("gemini-3-pro-image-preview", "Gemini 3 Pro");
+    GPT_IMAGE_1("gpt-image-1", "GPT Image 1", ModelProvider.OPENAI),
+    GPT_IMAGE_1_5("gpt-image-1.5", "GPT Image 1.5", ModelProvider.OPENAI),
+    IMAGEN_4_ULTRA("imagen-4.0-ultra-generate-001", "Imagen 4 Ultra", ModelProvider.GOOGLE),
+    GEMINI_3_PRO_IMAGE_PREVIEW("gemini-3-pro-image-preview", "Gemini 3 Pro", ModelProvider.GOOGLE);
 
     private final String modelName;
     private final String displayName;
+    private final ModelProvider provider;
 
     @JsonValue
     public String getModelName() {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageModelResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageModelResponse.java
@@ -12,4 +12,5 @@ import lombok.NoArgsConstructor;
 public class ImageModelResponse {
     private String id;
     private String displayName;
+    private int imagesPerMinute;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageModelResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageModelResponse.java
@@ -12,5 +12,5 @@ import lombok.NoArgsConstructor;
 public class ImageModelResponse {
     private String id;
     private String displayName;
-    private int imagesPerMinute;
+    private String provider;
 }


### PR DESCRIPTION
## Summary
Implement per-model rate limiting for image generation requests to respect API provider rate limits and prevent throttling errors.

## Changes
- **Rate limit configuration**: Added `imagesPerMinute` field to `ImageModelPricing` with conservative Tier 1 values:
  - OpenAI models (gpt-image-1, gpt-image-1.5): 7 images/minute
  - Google models (imagen-4.0-ultra-generate-001, gemini-3-pro-image-preview): 10 images/minute

- **Client-side rate limiting**: Refactored image generation to:
  - Group tasks by model
  - Process tasks sequentially per model with calculated delays between requests
  - Maintain minimum delay based on each model's rate limit
  - Continue processing other models in parallel while respecting individual model limits

- **API exposure**: Added `imagesPerMinute` to `ImageModel` interface and `ImageModelResponse` to expose rate limits to the frontend

- **Backend support**: Added `getImageRateLimit()` method to `ModelPricingConfig` for easy rate limit retrieval

## Implementation Details
The rate limiting uses a sequential per-model approach where:
1. Tasks are grouped by model ID
2. For each model, tasks are processed sequentially with a minimum delay between requests
3. Delay is calculated as: `minDelayMs = 60000 / imagesPerMinute`
4. If a request completes faster than the minimum delay, the remaining time is waited before the next request
5. Different models can be processed in parallel, each respecting their own rate limits

https://claude.ai/code/session_011N5PfE338rCHZrBFMagJwH