### PR TITLE
Add bulk delete functionality for cards with confirmation dialog

### DIFF
--- a/client/src/app/cards-table/cards-table.component.css
+++ b/client/src/app/cards-table/cards-table.component.css
@@ -25,17 +25,22 @@
   max-width: 200px;
 }
 
-.mark-known-fab {
+.selection-actions {
   position: fixed;
   bottom: 24px;
   right: 24px;
   z-index: 1000;
+  display: flex;
+  gap: 12px;
+}
+
+.action-fab {
   box-shadow: 0 4px 20px 0 rgba(0, 0, 0, 0.14),
               0 7px 10px -5px rgba(0, 0, 0, 0.4);
   transition: all 0.3s cubic-bezier(0.55, 0, 0.55, 0.2);
 }
 
-.mark-known-fab:hover {
+.action-fab:hover {
   transform: scale(1.05);
   box-shadow: 0 5px 25px 0 rgba(0, 0, 0, 0.2),
               0 10px 15px -5px rgba(0, 0, 0, 0.4);

--- a/client/src/app/cards-table/cards-table.component.css
+++ b/client/src/app/cards-table/cards-table.component.css
@@ -46,6 +46,14 @@
               0 10px 15px -5px rgba(0, 0, 0, 0.4);
 }
 
+.delete-fab {
+  background-color: red;
+}
+
+.delete-fab:hover {
+  background-color: darkred;
+}
+
 .cards-grid {
   width: 100%;
   height: 600px;

--- a/client/src/app/cards-table/cards-table.component.html
+++ b/client/src/app/cards-table/cards-table.component.html
@@ -78,8 +78,7 @@
       <button
         mat-fab
         extended
-        color="warn"
-        class="action-fab"
+        class="action-fab delete-fab"
         (click)="deleteSelected()"
       >
         <mat-icon>delete</mat-icon>

--- a/client/src/app/cards-table/cards-table.component.html
+++ b/client/src/app/cards-table/cards-table.component.html
@@ -74,15 +74,28 @@
   />
 
   @if (selectedCount() > 0) {
-    <button
-      mat-fab
-      extended
-      color="primary"
-      class="mark-known-fab"
-      (click)="markSelectedAsKnown()"
-    >
-      <mat-icon>check_circle</mat-icon>
-      Mark {{ selectedCount() }} as known
-    </button>
+    <div class="selection-actions">
+      <button
+        mat-fab
+        extended
+        color="warn"
+        class="action-fab"
+        (click)="deleteSelected()"
+        aria-label="Delete selected cards"
+      >
+        <mat-icon>delete</mat-icon>
+        Delete {{ selectedCount() }}
+      </button>
+      <button
+        mat-fab
+        extended
+        color="primary"
+        class="action-fab"
+        (click)="markSelectedAsKnown()"
+      >
+        <mat-icon>check_circle</mat-icon>
+        Mark {{ selectedCount() }} as known
+      </button>
+    </div>
   }
 </div>

--- a/client/src/app/cards-table/cards-table.component.html
+++ b/client/src/app/cards-table/cards-table.component.html
@@ -81,7 +81,6 @@
         color="warn"
         class="action-fab"
         (click)="deleteSelected()"
-        aria-label="Delete selected cards"
       >
         <mat-icon>delete</mat-icon>
         Delete {{ selectedCount() }}

--- a/client/src/app/cards-table/cards-table.component.ts
+++ b/client/src/app/cards-table/cards-table.component.ts
@@ -302,6 +302,9 @@ export class CardsTableComponent {
     if (!result) return;
 
     await this.cardsTableService.deleteCards(ids);
+    this.selectedCount.set(0);
+    this.selectedIds.set([]);
+    this.gridApi?.deselectAll();
     this.snackBar.open(`${ids.length} card(s) deleted`, 'Close', {
       duration: 3000,
       verticalPosition: 'top',

--- a/client/src/app/cards-table/cards-table.service.ts
+++ b/client/src/app/cards-table/cards-table.service.ts
@@ -74,4 +74,10 @@ export class CardsTableService {
       this.http.put('/api/cards/mark-known', cardIds)
     );
   }
+
+  async deleteCards(cardIds: readonly string[]): Promise<void> {
+    await firstValueFrom(
+      this.http.delete('/api/cards', { body: cardIds })
+    );
+  }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/CardController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/CardController.java
@@ -74,6 +74,15 @@ public class CardController {
         String.format("%d card(s) marked as known", cardIds.size())));
   }
 
+  @DeleteMapping("/cards")
+  @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
+  public ResponseEntity<Map<String, String>> deleteCards(@RequestBody List<String> cardIds) {
+    cardService.deleteCardsByIds(cardIds);
+
+    return ResponseEntity.ok(Map.of("detail",
+        String.format("%d card(s) deleted", cardIds.size())));
+  }
+
   @PostMapping("/card")
   @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
   public ResponseEntity<Map<String, String>> createCard(@RequestBody Card request) throws Exception {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/ReviewLogRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/ReviewLogRepository.java
@@ -3,6 +3,7 @@ package io.github.mucsi96.learnlanguage.repository;
 import io.github.mucsi96.learnlanguage.entity.ReviewLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -13,6 +14,9 @@ import java.util.List;
 public interface ReviewLogRepository
         extends JpaRepository<ReviewLog, Integer>, JpaSpecificationExecutor<ReviewLog> {
     List<ReviewLog> findByCardId(String cardId);
+
+    @Modifying
+    void deleteByCardIdIn(List<String> cardIds);
 
     @Query(value = """
         SELECT card_id,

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -128,6 +128,12 @@ public class CardService {
     cardRepository.updateReadinessByIds(cardIds, CardReadiness.KNOWN);
   }
 
+  @Transactional
+  public void deleteCardsByIds(List<String> cardIds) {
+    reviewLogRepository.deleteByCardIdIn(cardIds);
+    cardRepository.deleteAllById(cardIds);
+  }
+
   private Specification<Card> buildCardTableSpec(
       String sourceId, String readiness, String state,
       Integer minReps, Integer maxReps,

--- a/test/tests/cards-table-page.spec.ts
+++ b/test/tests/cards-table-page.spec.ts
@@ -4,6 +4,7 @@ import {
   createReviewLog,
   createLearningPartner,
   getGridData,
+  withDbConnection,
 } from '../utils';
 
 test('navigates to cards table from page view', async ({ page }) => {
@@ -436,4 +437,97 @@ test('delete image button shows as text button', async ({ page }) => {
   await page.goto('http://localhost:8180/sources');
   await page.getByRole('link', { name: 'Goethe A1' }).click();
   await expect(page.getByRole('link', { name: 'View all cards' })).toBeVisible();
+});
+
+test('deletes selected cards with confirmation', async ({ page }) => {
+  await createCard({
+    cardId: 'delete-card-1',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: { word: 'löschen', type: 'VERB', translation: { en: 'to delete' } },
+  });
+
+  await createCard({
+    cardId: 'delete-card-2',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: { word: 'entfernen', type: 'VERB', translation: { en: 'to remove' } },
+  });
+
+  await createCard({
+    cardId: 'keep-card',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: { word: 'behalten', type: 'VERB', translation: { en: 'to keep' } },
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/cards');
+
+  const grid = page.getByRole('grid');
+  await expect(async () => {
+    const rows = await getGridData(grid);
+    expect(rows.map((r) => r.Card)).toEqual(
+      expect.arrayContaining(['löschen', 'entfernen', 'behalten'])
+    );
+  }).toPass();
+
+  await page.getByRole('row', { name: /löschen/ }).getByRole('checkbox').click();
+  await page.getByRole('row', { name: /entfernen/ }).getByRole('checkbox').click();
+
+  await page.getByRole('button', { name: /Delete 2/ }).click();
+
+  await expect(
+    page.getByText('Are you sure you want to delete 2 card(s)?')
+  ).toBeVisible();
+  await page.getByRole('button', { name: 'Yes' }).click();
+
+  await expect(page.getByText('2 card(s) deleted')).toBeVisible();
+
+  await expect(async () => {
+    const rows = await getGridData(grid);
+    expect(rows.map((r) => r.Card)).toEqual(['behalten']);
+  }).toPass();
+
+  await withDbConnection(async (client) => {
+    const result = await client.query(
+      "SELECT id FROM learn_language.cards WHERE id IN ('delete-card-1', 'delete-card-2')"
+    );
+    expect(result.rows.length).toBe(0);
+  });
+});
+
+test('cancels card deletion on dialog dismissal', async ({ page }) => {
+  await createCard({
+    cardId: 'cancel-delete-card',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: { word: 'abbrechen', type: 'VERB', translation: { en: 'to cancel' } },
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/cards');
+
+  await expect(async () => {
+    const rows = await getGridData(page.getByRole('grid'));
+    expect(rows[0]).toEqual(expect.objectContaining({ Card: 'abbrechen' }));
+  }).toPass();
+
+  await page.getByRole('row', { name: /abbrechen/ }).getByRole('checkbox').click();
+  await page.getByRole('button', { name: /Delete 1/ }).click();
+
+  await expect(
+    page.getByText('Are you sure you want to delete 1 card(s)?')
+  ).toBeVisible();
+  await page.getByRole('button', { name: 'No' }).click();
+
+  await expect(async () => {
+    const rows = await getGridData(page.getByRole('grid'));
+    expect(rows[0]).toEqual(expect.objectContaining({ Card: 'abbrechen' }));
+  }).toPass();
+
+  await withDbConnection(async (client) => {
+    const result = await client.query(
+      "SELECT id FROM learn_language.cards WHERE id = 'cancel-delete-card'"
+    );
+    expect(result.rows.length).toBe(1);
+  });
 });

--- a/test/tests/cards-table-page.spec.ts
+++ b/test/tests/cards-table-page.spec.ts
@@ -476,10 +476,12 @@ test('deletes selected cards with confirmation', async ({ page }) => {
 
   await page.getByRole('button', { name: /Delete 2/ }).click();
 
+  const dialog = page.getByRole('dialog', { name: 'Confirmation' });
+
   await expect(
-    page.getByText('Are you sure you want to delete 2 card(s)?')
+    dialog.getByText('Are you sure you want to delete 2 card(s)?')
   ).toBeVisible();
-  await page.getByRole('button', { name: 'Yes' }).click();
+  await dialog.getByRole('button', { name: 'Yes' }).click();
 
   await expect(page.getByText('2 card(s) deleted')).toBeVisible();
 
@@ -514,10 +516,12 @@ test('cancels card deletion on dialog dismissal', async ({ page }) => {
   await page.getByRole('row', { name: /abbrechen/ }).getByRole('checkbox').click();
   await page.getByRole('button', { name: /Delete 1/ }).click();
 
+  const dialog = page.getByRole('dialog', { name: 'Confirmation' });
+
   await expect(
-    page.getByText('Are you sure you want to delete 1 card(s)?')
+    dialog.getByText('Are you sure you want to delete 1 card(s)?')
   ).toBeVisible();
-  await page.getByRole('button', { name: 'No' }).click();
+  await dialog.getByRole('button', { name: 'No' }).click();
 
   await expect(async () => {
     const rows = await getGridData(page.getByRole('grid'));


### PR DESCRIPTION
## Summary
This PR adds the ability to delete multiple selected cards from the cards table with a confirmation dialog, complementing the existing "mark as known" bulk action.

## Key Changes
- **Frontend UI**: 
  - Refactored FAB button layout to support multiple action buttons using flexbox
  - Added "Delete" button alongside "Mark as known" button in a new `.selection-actions` container
  - Integrated confirmation dialog before deletion
  
- **Frontend Logic**:
  - Implemented `deleteSelected()` method in `CardsTableComponent` that prompts user confirmation before deletion
  - Added `deleteCards()` service method in `CardsTableService` to call the backend API
  
- **Backend API**:
  - Added `DELETE /api/cards` endpoint in `CardController` with proper authorization checks
  - Implemented `deleteCardsByIds()` service method in `CardService` with transactional support
  
- **Database**:
  - Added `deleteByCardIdIn()` method to `ReviewLogRepository` to cascade delete review logs before card deletion
  
- **Tests**:
  - Added comprehensive E2E tests covering successful deletion with confirmation
  - Added test for cancellation of deletion operation
  - Tests verify both UI feedback and database state

## Implementation Details
- Deletion is transactional: review logs are deleted first, then cards (maintaining referential integrity)
- Uses Angular Material dialog component for user confirmation
- Displays snackbar notification with count of deleted cards
- Grid automatically refreshes after successful deletion
- Maintains consistent styling and behavior with existing "mark as known" action

https://claude.ai/code/session_018p4NzhiA2XFJXMMDKSrYaH