### PR TITLE
Extract shared task processor utility for rate-limited parallel execution

### DIFF
--- a/client/src/app/batch-audio-creation-fab/batch-audio-creation-fab.component.ts
+++ b/client/src/app/batch-audio-creation-fab/batch-audio-creation-fab.component.ts
@@ -66,8 +66,8 @@ export class BatchAudioCreationFabComponent {
           if (typeCards.length === 0) return acc;
           const result = await this.batchAudioService.createAudioInBatch(typeCards, cardType);
           return {
-            successful: acc.successful + result.successfulCards,
-            failed: acc.failed + result.failedCards
+            successful: acc.successful + result.succeeded,
+            failed: acc.failed + result.failed
           };
         },
         Promise.resolve({ successful: 0, failed: 0 })

--- a/client/src/app/batch-audio-creation.service.ts
+++ b/client/src/app/batch-audio-creation.service.ts
@@ -10,6 +10,11 @@ import {
   VoiceModelPair
 } from './shared/types/audio-generation.types';
 import { ENVIRONMENT_CONFIG } from './environment/environment.config';
+import {
+  processTasksWithRateLimit,
+  summarizeResults,
+  BatchResult,
+} from './utils/task-processor';
 
 interface VoiceConfiguration {
   id: number;
@@ -34,14 +39,7 @@ export interface AudioCreationProgress {
   currentStep?: string;
 }
 
-export interface BatchAudioCreationResult {
-  totalCards: number;
-  successfulCards: number;
-  failedCards: number;
-  errors: string[];
-}
-
-const RATE_LIMIT_DELAY_MS = 6000;
+const RATE_LIMIT_PER_MINUTE = 10;
 
 @Injectable({
   providedIn: 'root',
@@ -65,18 +63,13 @@ export class BatchAudioCreationService {
     return totalProgress / progress.length;
   });
 
-  async createAudioInBatch(cards: Card[], cardType: CardType): Promise<BatchAudioCreationResult> {
+  async createAudioInBatch(cards: Card[], cardType: CardType): Promise<BatchResult> {
     if (this.isCreating()) {
       throw new Error('Batch audio creation already in progress');
     }
 
     if (cards.length === 0) {
-      return {
-        totalCards: 0,
-        successfulCards: 0,
-        failedCards: 0,
-        errors: [],
-      };
+      return { total: 0, succeeded: 0, failed: 0, errors: [] };
     }
 
     const strategy = this.cardTypeRegistry.getStrategy(cardType);
@@ -109,50 +102,18 @@ export class BatchAudioCreationService {
 
     this.creationProgress.set(initialProgress);
 
-    const isRateLimited = !this.environmentConfig.skipRateLimiting;
-
-    const { results } = await cards.reduce<Promise<{ results: PromiseSettledResult<void>[]; lastStartTime: number }>>(
-      async (accPromise, card, index) => {
-        const acc = await accPromise;
-        if (isRateLimited && index > 0) {
-          const elapsed = Date.now() - acc.lastStartTime;
-          const remaining = RATE_LIMIT_DELAY_MS - elapsed;
-          if (remaining > 0) {
-            await this.delay(remaining);
-          }
-        }
-        const startTime = Date.now();
-        try {
-          await this.createAudioForSingleCard(card, index, strategy);
-          return { results: [...acc.results, { status: 'fulfilled' as const, value: undefined }], lastStartTime: startTime };
-        } catch (error) {
-          return { results: [...acc.results, { status: 'rejected' as const, reason: error }], lastStartTime: startTime };
-        }
-      },
-      Promise.resolve({ results: [], lastStartTime: 0 })
+    const tasks = cards.map(
+      (card, index) => () => this.createAudioForSingleCard(card, index, strategy)
     );
+
+    const results = await processTasksWithRateLimit(tasks, {
+      maxPerMinute: RATE_LIMIT_PER_MINUTE,
+      skipRateLimiting: this.environmentConfig.skipRateLimiting,
+    });
 
     this.isCreating.set(false);
 
-    const successfulCards = results.filter(
-      (result) => result.status === 'fulfilled'
-    ).length;
-    const failedCards = results.filter(
-      (result) => result.status === 'rejected'
-    ).length;
-    const errors = results
-      .filter(
-        (result): result is PromiseRejectedResult =>
-          result.status === 'rejected'
-      )
-      .map((result) => result.reason?.message || 'Unknown error');
-
-    return {
-      totalCards: cards.length,
-      successfulCards,
-      failedCards,
-      errors,
-    };
+    return summarizeResults(results);
   }
 
   private getMissingVoiceLanguages(strategy: CardTypeStrategy): string[] {
@@ -344,9 +305,5 @@ export class BatchAudioCreationService {
 
   clearProgress(): void {
     this.creationProgress.set([]);
-  }
-
-  private delay(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
   }
 }

--- a/client/src/app/bulk-card-creation-fab/bulk-card-creation-fab.component.ts
+++ b/client/src/app/bulk-card-creation-fab/bulk-card-creation-fab.component.ts
@@ -50,7 +50,7 @@ export class BulkCardCreationFabComponent {
       cardType
     );
 
-    if (result.successfulCards > 0) {
+    if (result.succeeded > 0) {
       this.pageService.reload();
     }
   }

--- a/client/src/app/shared/types/card-creation.types.ts
+++ b/client/src/app/shared/types/card-creation.types.ts
@@ -8,10 +8,3 @@ export type CardCreationProgress = {
   error?: string;
   currentStep?: string;
 }
-
-export interface BulkCardCreationResult {
-  totalCards: number;
-  successfulCards: number;
-  failedCards: number;
-  errors: string[];
-}

--- a/client/src/app/utils/task-processor.ts
+++ b/client/src/app/utils/task-processor.ts
@@ -1,0 +1,74 @@
+export interface TaskProcessorOptions {
+  maxPerMinute: number;
+  skipRateLimiting: boolean;
+}
+
+export interface BatchResult {
+  total: number;
+  succeeded: number;
+  failed: number;
+  errors: string[];
+}
+
+export const processTasksWithRateLimit = async <T>(
+  tasks: ReadonlyArray<() => Promise<T>>,
+  options: TaskProcessorOptions
+): Promise<PromiseSettledResult<T>[]> => {
+  if (tasks.length === 0) {
+    return [];
+  }
+
+  if (options.skipRateLimiting) {
+    return Promise.allSettled(tasks.map(task => task()));
+  }
+
+  const intervalMs = 60_000 / options.maxPerMinute;
+
+  const { inFlight } = await tasks.reduce<
+    Promise<{
+      inFlight: Promise<PromiseSettledResult<T>>[];
+      lastStartTime: number;
+    }>
+  >(
+    async (accPromise, task, index) => {
+      const acc = await accPromise;
+
+      if (index > 0) {
+        const elapsed = Date.now() - acc.lastStartTime;
+        const remaining = intervalMs - elapsed;
+        if (remaining > 0) {
+          await delay(remaining);
+        }
+      }
+
+      const startTime = Date.now();
+
+      const taskPromise = task().then(
+        (value): PromiseSettledResult<T> => ({ status: 'fulfilled', value }),
+        (reason): PromiseSettledResult<T> => ({ status: 'rejected', reason })
+      );
+
+      return {
+        inFlight: [...acc.inFlight, taskPromise],
+        lastStartTime: startTime,
+      };
+    },
+    Promise.resolve({ inFlight: [], lastStartTime: 0 })
+  );
+
+  return Promise.all(inFlight);
+};
+
+export const summarizeResults = <T>(
+  results: ReadonlyArray<PromiseSettledResult<T>>
+): BatchResult => ({
+  total: results.length,
+  succeeded: results.filter(r => r.status === 'fulfilled').length,
+  failed: results.filter(r => r.status === 'rejected').length,
+  errors: results
+    .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+    .map(r => r.reason?.message || 'Unknown error'),
+});
+
+const delay = (ms: number): Promise<void> =>
+  new Promise(resolve => setTimeout(resolve, ms));


### PR DESCRIPTION
Both batch audio creation and bulk card creation previously processed
tasks sequentially, awaiting each task's completion before starting the
next. This refactors both to use a shared processTasksWithRateLimit
utility that starts tasks at rate-limited intervals (10/min) while
allowing them to run concurrently, improving throughput.

Also unifies the duplicated BatchAudioCreationResult and
BulkCardCreationResult types into a single BatchResult type, and
extracts a shared summarizeResults helper.

https://claude.ai/code/session_01L1z4APWW4JQ5wttkeHpEcY