### PR TITLE
Add select all functionality to cards table

### DIFF
--- a/client/src/app/cards-table/cards-table.component.html
+++ b/client/src/app/cards-table/cards-table.component.html
@@ -66,6 +66,8 @@
     [cacheBlockSize]="100"
     [maxBlocksInCache]="10"
     [rowSelection]="rowSelection"
+    [selectionColumnDef]="selectionColumnDef"
+    [context]="gridContext"
     [getRowId]="getRowId"
     (gridReady)="onGridReady($event)"
     (sortChanged)="onSortChanged($event)"

--- a/client/src/app/cards-table/select-all-header.component.ts
+++ b/client/src/app/cards-table/select-all-header.component.ts
@@ -1,0 +1,40 @@
+import { Component, type WritableSignal } from '@angular/core';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import type { IHeaderAngularComp } from 'ag-grid-angular';
+import type { GridApi, IHeaderParams } from 'ag-grid-community';
+
+export type SelectAllContext = {
+  readonly selectAllActive: WritableSignal<boolean>;
+  readonly toggleSelectAll: (active: boolean) => void;
+};
+
+@Component({
+  standalone: true,
+  imports: [MatCheckboxModule],
+  template: `<mat-checkbox
+    [checked]="params.context.selectAllActive()"
+    (change)="onToggle($event)"
+    aria-label="Select all cards"
+  />`,
+  styles: [
+    `:host { display: flex; align-items: center; justify-content: center; }`,
+  ],
+})
+export class SelectAllHeaderComponent implements IHeaderAngularComp {
+  params!: IHeaderParams & { context: SelectAllContext; api: GridApi };
+
+  agInit(params: IHeaderParams): void {
+    this.params = params as IHeaderParams & {
+      context: SelectAllContext;
+      api: GridApi;
+    };
+  }
+
+  refresh(): boolean {
+    return true;
+  }
+
+  onToggle(event: { checked: boolean }): void {
+    this.params.context.toggleSelectAll(event.checked);
+  }
+}


### PR DESCRIPTION
## Summary
Implements a "select all" feature for the cards table that allows users to select all filtered cards at once, with proper state management and UI updates.

## Key Changes
- **New SelectAllHeaderComponent**: Custom header component with a checkbox that controls selection of all visible cards
- **Selection state management**: Added `selectAllActive` and `totalFilteredCount` signals to track select-all state
- **Smart selection logic**: 
  - Automatically selects all loaded rows when header checkbox is clicked
  - Deselects the header checkbox if any individual row is deselected
  - Resets selection when filters change
  - Maintains selection state across paginated data loads
- **Bulk operations**: Updated "Mark as known" and "Delete" actions to fetch all filtered card IDs when select-all is active
- **Comprehensive test coverage**: Added 6 new tests covering:
  - Selecting all rows via header checkbox
  - Deselecting all rows
  - Header checkbox unchecking when individual rows are deselected
  - Selection reset on filter changes
  - Bulk marking cards as known
  - Bulk deletion of cards

## Implementation Details
- Uses `isAutoSelecting` flag to prevent triggering selection change events during programmatic selection updates
- Fetches complete filtered dataset when performing bulk operations with select-all active
- Integrates with existing ag-Grid infinite row model to handle large datasets
- Properly handles dialog confirmations for destructive operations

https://claude.ai/code/session_01W4putZtDMGz8HC1nnVvgEr