### PR TITLE
Add batch image generation APIs for 50% cost reduction

### DIFF
--- a/client/src/app/shared/types/image-generation.types.ts
+++ b/client/src/app/shared/types/image-generation.types.ts
@@ -7,3 +7,28 @@ export interface ImageResponse {
   id: string;
   model: string;
 }
+
+export interface BatchImageRequestItem {
+  customId: string;
+  input: string;
+  model: string;
+}
+
+export interface BatchImageRequest {
+  requests: BatchImageRequestItem[];
+}
+
+export interface BatchImageJobResponse {
+  batchId: string;
+}
+
+export interface BatchImageResultItem {
+  customId: string;
+  image?: ImageResponse;
+  error?: string;
+}
+
+export interface BatchImageStatusResponse {
+  status: string;
+  results?: BatchImageResultItem[];
+}

--- a/mock_google_ai_server/src/batchHandler.ts
+++ b/mock_google_ai_server/src/batchHandler.ts
@@ -1,0 +1,78 @@
+import { ImageGenerationHandler } from './imageGeneration';
+
+interface InlinedRequest {
+  contents: Array<{
+    parts: Array<{ text?: string }>;
+  }>;
+  config?: {
+    responseModalities?: string[];
+    imageConfig?: Record<string, string>;
+  };
+  metadata?: Record<string, string>;
+}
+
+interface StoredBatch {
+  name: string;
+  state: string;
+  inlinedResponses: Array<Record<string, unknown>>;
+}
+
+export class GoogleBatchHandler {
+  private batches = new Map<string, StoredBatch>();
+  private nextBatchId = 1;
+
+  constructor(private readonly imageHandler: ImageGenerationHandler) {}
+
+  reset(): void {
+    this.batches.clear();
+    this.nextBatchId = 1;
+  }
+
+  createBatch(model: string, inlinedRequests: InlinedRequest[]): StoredBatch {
+    const batchName = `batches/batch-${this.nextBatchId++}`;
+
+    const inlinedResponses = inlinedRequests.map((req) => {
+      try {
+        const prompt = req.contents?.[0]?.parts?.[0]?.text ?? '';
+        const imageBytes = this.imageHandler.generateImage(prompt);
+        return {
+          response: {
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    {
+                      inlineData: {
+                        mimeType: 'image/png',
+                        data: imageBytes,
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          metadata: req.metadata ?? {},
+        };
+      } catch (error: any) {
+        return {
+          error: { message: error.message || 'Image generation failed' },
+          metadata: req.metadata ?? {},
+        };
+      }
+    });
+
+    const batch: StoredBatch = {
+      name: batchName,
+      state: 'JOB_STATE_SUCCEEDED',
+      inlinedResponses,
+    };
+
+    this.batches.set(batchName, batch);
+    return batch;
+  }
+
+  getBatch(name: string): StoredBatch | undefined {
+    return this.batches.get(name);
+  }
+}

--- a/mock_google_ai_server/src/index.ts
+++ b/mock_google_ai_server/src/index.ts
@@ -1,12 +1,14 @@
 import express from 'express';
 import { ImageGenerationHandler } from './imageGeneration';
 import { ChatHandler } from './chatHandler';
+import { GoogleBatchHandler } from './batchHandler';
 
 const app = express();
 const imageHandler = new ImageGenerationHandler();
 const chatHandler = new ChatHandler();
+const batchHandler = new GoogleBatchHandler(imageHandler);
 
-app.use(express.json());
+app.use(express.json({ limit: '50mb' }));
 
 // Middleware to log access details
 app.use((req, res, next) => {
@@ -19,7 +21,8 @@ app.use((req, res, next) => {
 
 app.post('/reset', (req, res) => {
   imageHandler.reset();
-  res.status(200).json({ status: 'ok', message: 'Image counter reset to 0' });
+  batchHandler.reset();
+  res.status(200).json({ status: 'ok', message: 'State reset' });
 });
 
 app.post('/v1beta/models/imagen-4.0-ultra-generate-001:predict', (req, res) => {
@@ -85,6 +88,52 @@ app.post(/\/v1beta\/models\/([^/]+):generateContent/, async (req, res) => {
   } catch (error: any) {
     console.error('Chat completion error:', error);
     res.status(400).json({ error: { message: error.message || 'Invalid request format' } });
+  }
+});
+
+// Batch API: Create batch job
+app.post('/v1beta/batches', (req, res) => {
+  try {
+    const { model, src } = req.body;
+    const inlinedRequests = src?.inlinedRequests ?? [];
+
+    console.log(`Batch create request: model=${model}, requests=${inlinedRequests.length}`);
+
+    const batch = batchHandler.createBatch(model, inlinedRequests);
+    console.log(`Batch created: ${batch.name}`);
+
+    res.status(200).json({
+      name: batch.name,
+      state: batch.state,
+      dest: {
+        inlinedResponses: batch.inlinedResponses,
+      },
+    });
+  } catch (error: any) {
+    console.error('Batch creation error:', error);
+    res.status(500).json({ error: { message: error.message || 'Batch creation failed' } });
+  }
+});
+
+// Batch API: Get batch job status
+app.get('/v1beta/batches/:batchName(*)', (req, res) => {
+  try {
+    const batchName = `batches/${req.params.batchName}`;
+    const batch = batchHandler.getBatch(batchName);
+    if (!batch) {
+      res.status(404).json({ error: { message: 'Batch not found' } });
+      return;
+    }
+    res.status(200).json({
+      name: batch.name,
+      state: batch.state,
+      dest: {
+        inlinedResponses: batch.inlinedResponses,
+      },
+    });
+  } catch (error: any) {
+    console.error('Batch retrieval error:', error);
+    res.status(500).json({ error: { message: error.message || 'Batch retrieval failed' } });
   }
 });
 

--- a/mock_openai_server/src/batchHandler.ts
+++ b/mock_openai_server/src/batchHandler.ts
@@ -1,0 +1,134 @@
+import { ImageGenerationHandler } from './imageGeneration';
+
+interface BatchRequest {
+  custom_id: string;
+  method: string;
+  url: string;
+  body: {
+    model: string;
+    input: string;
+    tools: Array<{
+      type: string;
+      model?: string;
+      size?: string;
+      quality?: string;
+      output_format?: string;
+      output_compression?: number;
+    }>;
+  };
+}
+
+interface StoredFile {
+  id: string;
+  content: string;
+  purpose: string;
+}
+
+interface StoredBatch {
+  id: string;
+  inputFileId: string;
+  status: string;
+  outputFileId: string | null;
+}
+
+export class BatchHandler {
+  private files = new Map<string, StoredFile>();
+  private batches = new Map<string, StoredBatch>();
+  private outputFiles = new Map<string, string>();
+  private nextFileId = 1;
+  private nextBatchId = 1;
+
+  constructor(private readonly imageHandler: ImageGenerationHandler) {}
+
+  reset(): void {
+    this.files.clear();
+    this.batches.clear();
+    this.outputFiles.clear();
+    this.nextFileId = 1;
+    this.nextBatchId = 1;
+  }
+
+  uploadFile(content: string, purpose: string): StoredFile {
+    const id = `file-${this.nextFileId++}`;
+    const file: StoredFile = { id, content, purpose };
+    this.files.set(id, file);
+    return file;
+  }
+
+  createBatch(inputFileId: string): StoredBatch {
+    const file = this.files.get(inputFileId);
+    if (!file) {
+      throw new Error(`File not found: ${inputFileId}`);
+    }
+
+    const batchId = `batch-${this.nextBatchId++}`;
+    const outputFileId = `file-output-${this.nextBatchId}`;
+
+    const outputLines = file.content
+      .split('\n')
+      .filter((line) => line.trim().length > 0)
+      .map((line) => this.processRequest(JSON.parse(line)));
+
+    this.outputFiles.set(outputFileId, outputLines.join('\n'));
+
+    const batch: StoredBatch = {
+      id: batchId,
+      inputFileId,
+      status: 'completed',
+      outputFileId,
+    };
+    this.batches.set(batchId, batch);
+
+    return batch;
+  }
+
+  getBatch(batchId: string): StoredBatch | undefined {
+    return this.batches.get(batchId);
+  }
+
+  getFileContent(fileId: string): string | undefined {
+    return this.outputFiles.get(fileId);
+  }
+
+  private processRequest(request: BatchRequest): string {
+    const { custom_id, body } = request;
+
+    try {
+      const imageGenTool = body.tools?.find((t) => t.type === 'image_generation');
+      if (!imageGenTool) {
+        return JSON.stringify({
+          custom_id,
+          error: { message: 'No image_generation tool found' },
+          response: null,
+        });
+      }
+
+      const prompt = body.input;
+      const model = imageGenTool.model ?? 'gpt-image-1';
+      const imageResult = this.imageHandler.generateImage({ prompt, model });
+      const b64Image = imageResult.data[0].b64_json;
+
+      return JSON.stringify({
+        custom_id,
+        error: null,
+        response: {
+          status_code: 200,
+          body: {
+            output: [
+              {
+                type: 'image_generation_call',
+                result: b64Image,
+              },
+            ],
+          },
+        },
+      });
+    } catch (error: any) {
+      return JSON.stringify({
+        custom_id,
+        error: { message: error.message || 'Processing failed' },
+        response: null,
+      });
+    }
+  }
+}

--- a/mock_openai_server/src/index.ts
+++ b/mock_openai_server/src/index.ts
@@ -2,13 +2,15 @@ import express from 'express';
 import { ImageGenerationHandler } from './imageGeneration';
 import { AudioGenerationHandler } from './audioGeneration';
 import { ChatHandler } from './chatHandler';
+import { BatchHandler } from './batchHandler';
 
 const app = express();
 const imageHandler = new ImageGenerationHandler();
 const audioHandler = new AudioGenerationHandler();
 const chatHandler = new ChatHandler();
+const batchHandler = new BatchHandler(imageHandler);
 
-app.use(express.json());
+app.use(express.json({ limit: '50mb' }));
 
 // Middleware to log access details
 app.use((req, res, next) => {
@@ -18,13 +20,12 @@ app.use((req, res, next) => {
   next();
 });
 
-// Add route to reset state for tests
 app.post('/reset', (req, res) => {
   imageHandler.reset();
-  res.status(200).json({ status: 'ok', message: 'Image counter reset to 0' });
+  batchHandler.reset();
+  res.status(200).json({ status: 'ok', message: 'State reset' });
 });
 
-// Add route for image generation mock
 app.post('/images/generations', (req, res) => {
   try {
     const result = imageHandler.generateImage(req.body);
@@ -35,7 +36,6 @@ app.post('/images/generations', (req, res) => {
   }
 });
 
-// Add route for audio generation mock
 app.post('/audio/speech', (req, res) => {
   try {
     const result = audioHandler.generateAudio(req.body);
@@ -54,6 +54,105 @@ app.post('/chat/completions', async (req, res) => {
   } catch (error) {
     console.error('Chat completion error:', error);
     res.status(400).json({ error: { message: error.message || 'Invalid request format' } });
+  }
+});
+
+app.post('/files', express.raw({ type: '*/*', limit: '200mb' }), (req, res) => {
+  try {
+    const rawBody = typeof req.body === 'string' ? req.body : req.body.toString('utf-8');
+
+    let jsonlContent = rawBody;
+    const contentType = req.headers['content-type'] ?? '';
+    const boundaryMatch = contentType.match(/boundary=([^\s;]+)/);
+    if (boundaryMatch) {
+      const boundary = boundaryMatch[1];
+      const parts = rawBody.split(`--${boundary}`);
+      for (const part of parts) {
+        if (part.includes('name="file"') || part.includes('.jsonl')) {
+          const bodyStart = part.indexOf('\r\n\r\n');
+          if (bodyStart !== -1) {
+            jsonlContent = part.substring(bodyStart + 4).replace(/\r\n$/, '').trim();
+            break;
+          }
+        }
+      }
+    }
+
+    const file = batchHandler.uploadFile(jsonlContent, 'batch');
+    console.log(`File uploaded: ${file.id}`);
+    res.status(200).json({
+      id: file.id,
+      object: 'file',
+      purpose: 'batch',
+      filename: 'batch_input.jsonl',
+      bytes: jsonlContent.length,
+      created_at: Math.floor(Date.now() / 1000),
+      status: 'processed',
+    });
+  } catch (error: any) {
+    console.error('File upload error:', error);
+    res.status(500).json({ error: { message: error.message || 'File upload failed' } });
+  }
+});
+
+app.post('/batches', (req, res) => {
+  try {
+    const { input_file_id } = req.body;
+    const batch = batchHandler.createBatch(input_file_id);
+    console.log(`Batch created: ${batch.id}`);
+    res.status(200).json({
+      id: batch.id,
+      object: 'batch',
+      endpoint: '/v1/responses',
+      input_file_id: batch.inputFileId,
+      completion_window: '24h',
+      status: batch.status,
+      output_file_id: batch.outputFileId,
+      created_at: Math.floor(Date.now() / 1000),
+      completed_at: Math.floor(Date.now() / 1000),
+    });
+  } catch (error: any) {
+    console.error('Batch creation error:', error);
+    res.status(500).json({ error: { message: error.message || 'Batch creation failed' } });
+  }
+});
+
+app.get('/batches/:batchId', (req, res) => {
+  try {
+    const batch = batchHandler.getBatch(req.params.batchId);
+    if (!batch) {
+      res.status(404).json({ error: { message: 'Batch not found' } });
+      return;
+    }
+    res.status(200).json({
+      id: batch.id,
+      object: 'batch',
+      endpoint: '/v1/responses',
+      input_file_id: batch.inputFileId,
+      completion_window: '24h',
+      status: batch.status,
+      output_file_id: batch.outputFileId,
+      created_at: Math.floor(Date.now() / 1000),
+      completed_at: batch.status === 'completed' ? Math.floor(Date.now() / 1000) : null,
+    });
+  } catch (error: any) {
+    console.error('Batch retrieval error:', error);
+    res.status(500).json({ error: { message: error.message || 'Batch retrieval failed' } });
+  }
+});
+
+app.get('/files/:fileId/content', (req, res) => {
+  try {
+    const content = batchHandler.getFileContent(req.params.fileId);
+    if (!content) {
+      res.status(404).json({ error: { message: 'File not found' } });
+      return;
+    }
+    res.setHeader('Content-Type', 'application/jsonl');
+    res.status(200).send(content);
+  } catch (error: any) {
+    console.error('File content error:', error);
+    res.status(500).json({ error: { message: error.message || 'File content retrieval failed' } });
   }
 });
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/BatchImageController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/BatchImageController.java
@@ -1,0 +1,34 @@
+package io.github.mucsi96.learnlanguage.controller;
+
+import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.github.mucsi96.learnlanguage.model.BatchImageJobResponse;
+import io.github.mucsi96.learnlanguage.model.BatchImageRequest;
+import io.github.mucsi96.learnlanguage.model.BatchImageStatusResponse;
+import io.github.mucsi96.learnlanguage.service.BatchImageService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class BatchImageController {
+
+  private final BatchImageService batchImageService;
+
+  @PostMapping("/batch-images")
+  @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
+  public BatchImageJobResponse createBatch(@Valid @RequestBody BatchImageRequest request) {
+    return batchImageService.createBatch(request);
+  }
+
+  @GetMapping("/batch-images/{batchId}")
+  @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
+  public BatchImageStatusResponse getBatchStatus(@PathVariable String batchId) {
+    return batchImageService.getBatchStatus(batchId);
+  }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/BatchImageJobResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/BatchImageJobResponse.java
@@ -1,0 +1,14 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BatchImageJobResponse {
+  private String batchId;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/BatchImageRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/BatchImageRequest.java
@@ -1,0 +1,20 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BatchImageRequest {
+  @NotEmpty
+  @Valid
+  private List<BatchImageRequestItem> requests;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/BatchImageRequestItem.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/BatchImageRequestItem.java
@@ -1,0 +1,22 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BatchImageRequestItem {
+  @NotNull
+  private String customId;
+
+  @NotNull
+  private String input;
+
+  @NotNull
+  private ImageGenerationModel model;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/BatchImageResultItem.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/BatchImageResultItem.java
@@ -1,0 +1,23 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BatchImageResultItem {
+  private String customId;
+
+  @JsonInclude(Include.NON_NULL)
+  private ExampleImageData image;
+
+  @JsonInclude(Include.NON_NULL)
+  private String error;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/BatchImageStatusResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/BatchImageStatusResponse.java
@@ -1,0 +1,22 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BatchImageStatusResponse {
+  private String status;
+
+  @JsonInclude(Include.NON_NULL)
+  private List<BatchImageResultItem> results;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/BatchImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/BatchImageService.java
@@ -1,0 +1,220 @@
+package io.github.mucsi96.learnlanguage.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.springframework.stereotype.Service;
+
+import com.azure.core.util.BinaryData;
+
+import io.github.mucsi96.learnlanguage.model.BatchImageJobResponse;
+import io.github.mucsi96.learnlanguage.model.BatchImageRequest;
+import io.github.mucsi96.learnlanguage.model.BatchImageRequestItem;
+import io.github.mucsi96.learnlanguage.model.BatchImageResultItem;
+import io.github.mucsi96.learnlanguage.model.BatchImageStatusResponse;
+import io.github.mucsi96.learnlanguage.model.ExampleImageData;
+import io.github.mucsi96.learnlanguage.model.ImageGenerationModel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BatchImageService {
+
+  private final OpenAIBatchImageService openAIBatchImageService;
+  private final GoogleBatchImageService googleBatchImageService;
+  private final GoogleImageService googleImageService;
+  private final FileStorageService fileStorageService;
+
+  private final ConcurrentHashMap<String, BatchMetadata> batchStore = new ConcurrentHashMap<>();
+
+  private record BatchMetadata(
+      String openAiBatchId,
+      String googleBatchName,
+      List<BatchImageRequestItem> openAiItems,
+      List<BatchImageRequestItem> googleGeminiItems,
+      List<BatchImageRequestItem> imagenItems,
+      List<BatchImageResultItem> completedResults) {
+  }
+
+  public BatchImageJobResponse createBatch(BatchImageRequest request) {
+    final String batchId = UUID.randomUUID().toString();
+    final List<BatchImageRequestItem> items = request.getRequests();
+
+    final Map<Boolean, List<BatchImageRequestItem>> partitioned = items.stream()
+        .collect(Collectors.partitioningBy(
+            item -> item.getModel() == ImageGenerationModel.GPT_IMAGE_1
+                || item.getModel() == ImageGenerationModel.GPT_IMAGE_1_5));
+
+    final List<BatchImageRequestItem> openAiItems = partitioned.get(true);
+    final List<BatchImageRequestItem> nonOpenAiItems = partitioned.get(false);
+
+    final List<BatchImageRequestItem> googleGeminiItems = nonOpenAiItems.stream()
+        .filter(item -> item.getModel() == ImageGenerationModel.GEMINI_3_PRO_IMAGE_PREVIEW)
+        .toList();
+
+    final List<BatchImageRequestItem> imagenItems = nonOpenAiItems.stream()
+        .filter(item -> item.getModel() == ImageGenerationModel.IMAGEN_4_ULTRA)
+        .toList();
+
+    String openAiBatchId = null;
+    String googleBatchName = null;
+    final List<BatchImageResultItem> completedResults = new ArrayList<>();
+
+    if (!openAiItems.isEmpty()) {
+      openAiBatchId = openAIBatchImageService.submitBatch(openAiItems);
+    }
+
+    if (!googleGeminiItems.isEmpty()) {
+      googleBatchName = googleBatchImageService.submitBatch(googleGeminiItems);
+    }
+
+    if (!imagenItems.isEmpty()) {
+      final List<BatchImageResultItem> imagenResults = imagenItems.stream()
+          .map(this::processImagenSynchronously)
+          .toList();
+      completedResults.addAll(imagenResults);
+    }
+
+    batchStore.put(batchId, new BatchMetadata(
+        openAiBatchId,
+        googleBatchName,
+        openAiItems,
+        googleGeminiItems,
+        imagenItems,
+        completedResults));
+
+    log.info("Batch created: id={}, openAi={}, google={}, imagen={}",
+        batchId,
+        openAiItems.size(),
+        googleGeminiItems.size(),
+        imagenItems.size());
+
+    return BatchImageJobResponse.builder().batchId(batchId).build();
+  }
+
+  public BatchImageStatusResponse getBatchStatus(String batchId) {
+    final BatchMetadata metadata = batchStore.get(batchId);
+    if (metadata == null) {
+      throw new RuntimeException("Batch not found: " + batchId);
+    }
+
+    final boolean openAiComplete = metadata.openAiBatchId == null
+        || openAIBatchImageService.isBatchComplete(metadata.openAiBatchId);
+    final boolean googleComplete = metadata.googleBatchName == null
+        || googleBatchImageService.isBatchComplete(metadata.googleBatchName);
+
+    if (!openAiComplete || !googleComplete) {
+      return BatchImageStatusResponse.builder()
+          .status("processing")
+          .build();
+    }
+
+    final List<BatchImageResultItem> allResults = collectResults(metadata);
+
+    batchStore.remove(batchId);
+
+    return BatchImageStatusResponse.builder()
+        .status("completed")
+        .results(allResults)
+        .build();
+  }
+
+  private List<BatchImageResultItem> collectResults(BatchMetadata metadata) {
+    final List<BatchImageResultItem> allResults = new ArrayList<>(metadata.completedResults);
+
+    if (metadata.openAiBatchId != null) {
+      final Map<String, BatchImageRequestItem> openAiRequestMap = metadata.openAiItems.stream()
+          .collect(Collectors.toMap(BatchImageRequestItem::getCustomId, item -> item));
+
+      final List<OpenAIBatchImageService.ProviderBatchResult> openAiResults = openAIBatchImageService
+          .getBatchResults(metadata.openAiBatchId, openAiRequestMap);
+
+      openAiResults.stream()
+          .map(this::saveAndConvert)
+          .forEach(allResults::add);
+    }
+
+    if (metadata.googleBatchName != null) {
+      final List<GoogleBatchImageService.ProviderBatchResult> googleResults = googleBatchImageService
+          .getBatchResults(metadata.googleBatchName, metadata.googleGeminiItems);
+
+      googleResults.stream()
+          .map(this::saveAndConvert)
+          .forEach(allResults::add);
+    }
+
+    return allResults;
+  }
+
+  private BatchImageResultItem saveAndConvert(OpenAIBatchImageService.ProviderBatchResult result) {
+    if (result.imageBytes() == null) {
+      return BatchImageResultItem.builder()
+          .customId(result.customId())
+          .error(result.error())
+          .build();
+    }
+
+    final String uuid = UUID.randomUUID().toString();
+    final String filePath = "images/%s.jpg".formatted(uuid);
+    fileStorageService.saveFile(BinaryData.fromBytes(result.imageBytes()), filePath);
+
+    return BatchImageResultItem.builder()
+        .customId(result.customId())
+        .image(ExampleImageData.builder()
+            .id(uuid)
+            .model(result.modelDisplayName())
+            .build())
+        .build();
+  }
+
+  private BatchImageResultItem saveAndConvert(GoogleBatchImageService.ProviderBatchResult result) {
+    if (result.imageBytes() == null) {
+      return BatchImageResultItem.builder()
+          .customId(result.customId())
+          .error(result.error())
+          .build();
+    }
+
+    final String uuid = UUID.randomUUID().toString();
+    final String filePath = "images/%s.jpg".formatted(uuid);
+    fileStorageService.saveFile(BinaryData.fromBytes(result.imageBytes()), filePath);
+
+    return BatchImageResultItem.builder()
+        .customId(result.customId())
+        .image(ExampleImageData.builder()
+            .id(uuid)
+            .model(result.modelDisplayName())
+            .build())
+        .build();
+  }
+
+  private BatchImageResultItem processImagenSynchronously(BatchImageRequestItem item) {
+    try {
+      final byte[] imageBytes = googleImageService.generateImageWithImagen(item.getInput());
+      final String uuid = UUID.randomUUID().toString();
+      final String filePath = "images/%s.jpg".formatted(uuid);
+      fileStorageService.saveFile(BinaryData.fromBytes(imageBytes), filePath);
+
+      return BatchImageResultItem.builder()
+          .customId(item.getCustomId())
+          .image(ExampleImageData.builder()
+              .id(uuid)
+              .model(item.getModel().getDisplayName())
+              .build())
+          .build();
+    } catch (Exception e) {
+      log.error("Failed to generate Imagen image for customId={}", item.getCustomId(), e);
+      return BatchImageResultItem.builder()
+          .customId(item.getCustomId())
+          .error("Imagen generation failed: " + e.getMessage())
+          .build();
+    }
+  }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/GoogleBatchImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/GoogleBatchImageService.java
@@ -1,0 +1,187 @@
+package io.github.mucsi96.learnlanguage.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import org.springframework.stereotype.Service;
+
+import com.google.genai.Client;
+import com.google.genai.types.BatchJob;
+import com.google.genai.types.BatchJobSource;
+import com.google.genai.types.Content;
+import com.google.genai.types.CreateBatchJobConfig;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.ImageConfig;
+import com.google.genai.types.InlinedRequest;
+import com.google.genai.types.InlinedResponse;
+import com.google.genai.types.JobState;
+import com.google.genai.types.Part;
+
+import io.github.mucsi96.learnlanguage.model.BatchImageRequestItem;
+import io.github.mucsi96.learnlanguage.model.OperationType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GoogleBatchImageService {
+
+  private static final String GEMINI_MODEL = "gemini-3-pro-image-preview";
+
+  private final Client googleAiClient;
+  private final ModelUsageLoggingService usageLoggingService;
+
+  public record ProviderBatchResult(String customId, byte[] imageBytes, String modelDisplayName, String error) {
+  }
+
+  public String submitBatch(List<BatchImageRequestItem> items) {
+    final long startTime = System.currentTimeMillis();
+    try {
+      final List<InlinedRequest> inlinedRequests = items.stream()
+          .map(this::buildInlinedRequest)
+          .toList();
+
+      final BatchJobSource source = BatchJobSource.builder()
+          .inlinedRequests(inlinedRequests)
+          .build();
+
+      final BatchJob batchJob = googleAiClient.batches.create(
+          GEMINI_MODEL,
+          source,
+          CreateBatchJobConfig.builder()
+              .displayName("image-generation-batch")
+              .build());
+
+      final String batchName = batchJob.name().orElseThrow(
+          () -> new RuntimeException("Batch job has no name"));
+
+      final long processingTime = System.currentTimeMillis() - startTime;
+      log.info("Google batch submitted: name={}, items={}, time={}ms",
+          batchName, items.size(), processingTime);
+
+      return batchName;
+    } catch (Exception e) {
+      log.error("Failed to submit Google batch", e);
+      throw new RuntimeException("Failed to submit Google batch: " + e.getMessage(), e);
+    }
+  }
+
+  public boolean isBatchComplete(String batchName) {
+    try {
+      final BatchJob job = googleAiClient.batches.get(batchName, null);
+      final JobState state = job.state().orElse(null);
+      if (state == null) {
+        return false;
+      }
+      final String stateName = state.toString();
+      return "JOB_STATE_SUCCEEDED".equals(stateName)
+          || "JOB_STATE_FAILED".equals(stateName)
+          || "JOB_STATE_CANCELLED".equals(stateName)
+          || "JOB_STATE_PARTIALLY_SUCCEEDED".equals(stateName);
+    } catch (Exception e) {
+      log.error("Failed to get Google batch status", e);
+      return false;
+    }
+  }
+
+  public String getBatchStatus(String batchName) {
+    try {
+      final BatchJob job = googleAiClient.batches.get(batchName, null);
+      return job.state().map(JobState::toString).orElse("UNKNOWN");
+    } catch (Exception e) {
+      log.error("Failed to get Google batch status", e);
+      return "UNKNOWN";
+    }
+  }
+
+  public List<ProviderBatchResult> getBatchResults(String batchName,
+      List<BatchImageRequestItem> originalItems) {
+    final long startTime = System.currentTimeMillis();
+    try {
+      final BatchJob job = googleAiClient.batches.get(batchName, null);
+      final List<InlinedResponse> responses = job.dest()
+          .flatMap(dest -> dest.inlinedResponses())
+          .orElseThrow(() -> new RuntimeException("No inlined responses in batch job"));
+
+      final long processingTime = System.currentTimeMillis() - startTime;
+
+      return IntStream.range(0, Math.min(responses.size(), originalItems.size()))
+          .mapToObj(i -> parseInlinedResponse(responses.get(i), originalItems.get(i), processingTime))
+          .toList();
+    } catch (Exception e) {
+      log.error("Failed to get Google batch results", e);
+      throw new RuntimeException("Failed to get Google batch results: " + e.getMessage(), e);
+    }
+  }
+
+  private InlinedRequest buildInlinedRequest(BatchImageRequestItem item) {
+    final Content content = Content.builder()
+        .parts(List.of(
+            Part.builder()
+                .text(item.getInput() + ". Avoid using text.")
+                .build()))
+        .build();
+
+    final GenerateContentConfig config = GenerateContentConfig.builder()
+        .responseModalities("TEXT", "IMAGE")
+        .imageConfig(ImageConfig.builder()
+            .aspectRatio("1:1")
+            .imageSize("1K")
+            .build())
+        .build();
+
+    return InlinedRequest.builder()
+        .contents(content)
+        .config(config)
+        .metadata(Map.of("customId", item.getCustomId()))
+        .build();
+  }
+
+  private ProviderBatchResult parseInlinedResponse(InlinedResponse inlinedResponse,
+      BatchImageRequestItem originalItem, long processingTime) {
+    final String customId = originalItem.getCustomId();
+    try {
+      if (inlinedResponse.error().isPresent()) {
+        return new ProviderBatchResult(customId, null, null,
+            inlinedResponse.error().get().toString());
+      }
+
+      final var generateResponse = inlinedResponse.response().orElseThrow(
+          () -> new RuntimeException("No response in inlined response"));
+
+      final var candidates = generateResponse.candidates()
+          .orElseThrow(() -> new RuntimeException("No candidates"));
+
+      if (candidates.isEmpty()) {
+        return new ProviderBatchResult(customId, null, null, "No candidates in response");
+      }
+
+      final var parts = candidates.get(0).content()
+          .flatMap(c -> c.parts())
+          .orElseThrow(() -> new RuntimeException("No parts in response"));
+
+      for (final Part part : parts) {
+        if (part.inlineData().isPresent()) {
+          final byte[] imageBytes = part.inlineData().get().data()
+              .orElseThrow(() -> new RuntimeException("No data in inline data"));
+
+          usageLoggingService.logImageUsage(
+              GEMINI_MODEL,
+              OperationType.IMAGE_GENERATION,
+              1,
+              processingTime);
+
+          return new ProviderBatchResult(customId, imageBytes,
+              originalItem.getModel().getDisplayName(), null);
+        }
+      }
+
+      return new ProviderBatchResult(customId, null, null, "No image found in response");
+    } catch (Exception e) {
+      log.error("Failed to parse Google batch result for customId={}", customId, e);
+      return new ProviderBatchResult(customId, null, null, "Parse error: " + e.getMessage());
+    }
+  }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/OpenAIBatchImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/OpenAIBatchImageService.java
@@ -1,0 +1,179 @@
+package io.github.mucsi96.learnlanguage.service;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.openai.client.OpenAIClient;
+import com.openai.core.http.HttpResponse;
+import com.openai.models.batches.BatchCreateParams;
+import com.openai.models.batches.Batch;
+import com.openai.models.files.FileCreateParams;
+import com.openai.models.files.FileObject;
+import com.openai.models.files.FilePurpose;
+
+import io.github.mucsi96.learnlanguage.model.BatchImageRequestItem;
+import io.github.mucsi96.learnlanguage.model.OperationType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OpenAIBatchImageService {
+
+  private final OpenAIClient openAIClient;
+  private final ModelUsageLoggingService usageLoggingService;
+  private final ObjectMapper objectMapper;
+
+  public record ProviderBatchResult(String customId, byte[] imageBytes, String modelDisplayName, String error) {
+  }
+
+  public String submitBatch(List<BatchImageRequestItem> items) {
+    final long startTime = System.currentTimeMillis();
+    try {
+      final String jsonlContent = items.stream()
+          .map(this::buildJsonlLine)
+          .collect(Collectors.joining("\n"));
+
+      final FileObject file = openAIClient.files().create(
+          FileCreateParams.builder()
+              .purpose(FilePurpose.BATCH)
+              .file(jsonlContent.getBytes(StandardCharsets.UTF_8))
+              .build());
+
+      final Batch batch = openAIClient.batches().create(
+          BatchCreateParams.builder()
+              .inputFileId(file.id())
+              .endpoint(BatchCreateParams.Endpoint.V1_RESPONSES)
+              .completionWindow(BatchCreateParams.CompletionWindow._24H)
+              .build());
+
+      final long processingTime = System.currentTimeMillis() - startTime;
+      log.info("OpenAI batch submitted: id={}, items={}, time={}ms",
+          batch.id(), items.size(), processingTime);
+
+      return batch.id();
+    } catch (Exception e) {
+      log.error("Failed to submit OpenAI batch", e);
+      throw new RuntimeException("Failed to submit OpenAI batch: " + e.getMessage(), e);
+    }
+  }
+
+  public boolean isBatchComplete(String batchId) {
+    final Batch batch = openAIClient.batches().retrieve(batchId);
+    final String status = batch.status().toString();
+    return "completed".equals(status) || "failed".equals(status) || "expired".equals(status)
+        || "cancelled".equals(status);
+  }
+
+  public String getBatchStatus(String batchId) {
+    return openAIClient.batches().retrieve(batchId).status().toString();
+  }
+
+  public List<ProviderBatchResult> getBatchResults(String batchId,
+      Map<String, BatchImageRequestItem> requestMap) {
+    final long startTime = System.currentTimeMillis();
+    try {
+      final Batch batch = openAIClient.batches().retrieve(batchId);
+      final String outputFileId = batch.outputFileId().orElseThrow(
+          () -> new RuntimeException("Batch has no output file"));
+
+      final HttpResponse response = openAIClient.files().content(outputFileId);
+      final String content = new BufferedReader(
+          new InputStreamReader(response.body(), StandardCharsets.UTF_8))
+          .lines()
+          .collect(Collectors.joining("\n"));
+      response.close();
+
+      final long processingTime = System.currentTimeMillis() - startTime;
+
+      return new BufferedReader(new StringReader(content)).lines()
+          .map(line -> parseResultLine(line, requestMap, processingTime))
+          .toList();
+    } catch (Exception e) {
+      log.error("Failed to get OpenAI batch results", e);
+      throw new RuntimeException("Failed to get OpenAI batch results: " + e.getMessage(), e);
+    }
+  }
+
+  private String buildJsonlLine(BatchImageRequestItem item) {
+    try {
+      final String modelName = item.getModel().getModelName();
+      final Map<String, Object> toolConfig = Map.of(
+          "type", "image_generation",
+          "model", modelName,
+          "size", "1024x1024",
+          "quality", "high",
+          "output_format", "jpeg",
+          "output_compression", 75);
+
+      final Map<String, Object> body = Map.of(
+          "model", "gpt-4.1-mini",
+          "input",
+          "Create a photorealistic image for the following context: " + item.getInput() + ". Avoid using text.",
+          "tools", List.of(toolConfig));
+
+      final Map<String, Object> request = Map.of(
+          "custom_id", item.getCustomId(),
+          "method", "POST",
+          "url", "/v1/responses",
+          "body", body);
+
+      return objectMapper.writeValueAsString(request);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to build JSONL line", e);
+    }
+  }
+
+  private ProviderBatchResult parseResultLine(String line, Map<String, BatchImageRequestItem> requestMap,
+      long processingTime) {
+    try {
+      final JsonNode root = objectMapper.readTree(line);
+      final String customId = root.get("custom_id").asText();
+      final BatchImageRequestItem originalRequest = requestMap.get(customId);
+
+      final JsonNode error = root.get("error");
+      if (error != null && !error.isNull()) {
+        return new ProviderBatchResult(customId, null, null, error.toString());
+      }
+
+      final JsonNode responseBody = root.get("response").get("body");
+      final JsonNode output = responseBody.get("output");
+
+      for (final JsonNode outputItem : output) {
+        if ("image_generation_call".equals(outputItem.get("type").asText())) {
+          final String b64Image = outputItem.get("result").asText();
+          final byte[] imageBytes = Base64.getDecoder().decode(b64Image);
+          final String modelDisplayName = originalRequest != null
+              ? originalRequest.getModel().getDisplayName()
+              : null;
+
+          if (originalRequest != null) {
+            usageLoggingService.logImageUsage(
+                originalRequest.getModel().getModelName(),
+                OperationType.IMAGE_GENERATION,
+                1,
+                processingTime);
+          }
+
+          return new ProviderBatchResult(customId, imageBytes, modelDisplayName, null);
+        }
+      }
+
+      return new ProviderBatchResult(customId, null, null, "No image found in response");
+    } catch (Exception e) {
+      log.error("Failed to parse result line", e);
+      return new ProviderBatchResult("unknown", null, null, "Parse error: " + e.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
Switch image generation from sequential per-image API calls to batch
mode using native OpenAI and Google Gemini batch APIs, which offer 50%
cost reduction for asynchronous processing.

Backend:
- Add OpenAIBatchImageService using Responses API batch endpoint with
  image_generation tool, JSONL file upload, and result polling
- Add GoogleBatchImageService using Gemini batch API with inline
  requests and batchGenerateContent for gemini-3-pro-image-preview
- Add BatchImageService orchestrator that groups requests by provider,
  falls back to synchronous for Imagen 4 Ultra (no batch support)
- Add POST /api/batch-images and GET /api/batch-images/{batchId}
  endpoints with in-memory job tracking

Frontend:
- Update BulkCardCreationService to collect all image generation tasks
  across all cards and submit them as a single batch request
- Add batch polling with 2s interval until completion
- Add batch image request/response types

Mock servers:
- Add OpenAI batch endpoints (files upload, batch create/retrieve,
  file content download) with immediate processing
- Add Google AI batch endpoints (batch create/get) with inline
  response generation

https://claude.ai/code/session_01SapZTdCtwXhSFG3zrKe2rM