### PR TITLE
Replace GPT Image 1 and Imagen 4 with batch GPT Image 1.5 (n=4) and Gemini 3 Pro

### DIFF
--- a/client/src/app/bulk-card-creation.service.ts
+++ b/client/src/app/bulk-card-creation.service.ts
@@ -190,7 +190,7 @@ export class BulkCardCreationService {
       async (accPromise, task, index) => {
         const acc = await accPromise;
         try {
-          const response = await fetchJson<ImageResponse>(
+          const responses = await fetchJson<ImageResponse[]>(
             this.http,
             `/api/image`,
             {
@@ -212,7 +212,7 @@ export class BulkCardCreationService {
             `Generating images (${index + 1}/${totalTasks})...`
           );
 
-          return [...acc, { exampleIndex: task.exampleIndex, image: response }];
+          return [...acc, ...responses.map(response => ({ exampleIndex: task.exampleIndex, image: response }))];
         } catch {
           this.imageGenerationProgress.update(p => ({ ...p, completed: p.completed + 1 }));
           return acc;

--- a/client/src/app/parser/edit-card/edit-grammar-card/edit-grammar-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-grammar-card/edit-grammar-card.component.ts
@@ -269,7 +269,7 @@ export class EditGrammarCardComponent {
           return;
         }
 
-        const response = await fetchJson<ExampleImage>(
+        const responses = await fetchJson<ExampleImage[]>(
           this.http,
           `/api/image`,
           {
@@ -281,9 +281,22 @@ export class EditGrammarCardComponent {
           }
         );
 
+        if (responses.length > 1) {
+          const additionalResources = responses.slice(1).map((img) =>
+            resource({
+              injector: this.injector,
+              loader: async () => ({
+                ...img,
+                url: await this.getExampleImageUrl(img.id),
+              }),
+            })
+          );
+          this.images.update((imgs) => [...imgs, ...additionalResources]);
+        }
+
         return {
-          ...response,
-          url: await this.getExampleImageUrl(response.id),
+          ...responses[0],
+          url: await this.getExampleImageUrl(responses[0].id),
         };
       },
     });

--- a/client/src/app/parser/edit-card/edit-speech-card/edit-speech-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-speech-card/edit-speech-card.component.ts
@@ -214,7 +214,7 @@ export class EditSpeechCardComponent {
           return;
         }
 
-        const response = await fetchJson<ExampleImage>(
+        const responses = await fetchJson<ExampleImage[]>(
           this.http,
           `/api/image`,
           {
@@ -226,9 +226,22 @@ export class EditSpeechCardComponent {
           }
         );
 
+        if (responses.length > 1) {
+          const additionalResources = responses.slice(1).map((img) =>
+            resource({
+              injector: this.injector,
+              loader: async () => ({
+                ...img,
+                url: await this.getExampleImageUrl(img.id),
+              }),
+            })
+          );
+          this.images.update((imgs) => [...imgs, ...additionalResources]);
+        }
+
         return {
-          ...response,
-          url: await this.getExampleImageUrl(response.id),
+          ...responses[0],
+          url: await this.getExampleImageUrl(responses[0].id),
         };
       },
     });

--- a/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.ts
@@ -280,7 +280,7 @@ export class EditVocabularyCardComponent {
           return;
         }
 
-        const response = await fetchJson<ExampleImage>(
+        const responses = await fetchJson<ExampleImage[]>(
           this.http,
           `/api/image`,
           {
@@ -292,9 +292,26 @@ export class EditVocabularyCardComponent {
           }
         );
 
+        if (responses.length > 1) {
+          const additionalResources = responses.slice(1).map((img) =>
+            resource({
+              injector: this.injector,
+              loader: async () => ({
+                ...img,
+                url: await this.getExampleImageUrl(img.id),
+              }),
+            })
+          );
+          this.exampleImages.update((images) => {
+            const updated = [...images];
+            updated[index] = [...updated[index], ...additionalResources];
+            return updated;
+          });
+        }
+
         return {
-          ...response,
-          url: await this.getExampleImageUrl(response.id),
+          ...responses[0],
+          url: await this.getExampleImageUrl(responses[0].id),
         };
       },
     });

--- a/mock_google_ai_server/src/index.ts
+++ b/mock_google_ai_server/src/index.ts
@@ -22,26 +22,6 @@ app.post('/reset', (req, res) => {
   res.status(200).json({ status: 'ok', message: 'Image counter reset to 0' });
 });
 
-app.post('/v1beta/models/imagen-4.0-ultra-generate-001:predict', (req, res) => {
-  try {
-    const prompt = req.body.instances[0].prompt;
-    console.log({ prompt });
-    const imageBytes = imageHandler.generateImage(prompt);
-    res.status(200).json({
-      predictions: [
-        {
-          mimeType: 'image/jpeg',
-          bytesBase64Encoded: imageBytes,
-        },
-      ],
-    });
-    console.log({ imageBytes });
-  } catch (error) {
-    console.error('Image generation error:', error);
-    res.status(500).json({ error: { message: 'Image generation failed' } });
-  }
-});
-
 app.post(
   '/v1beta/models/gemini-3-pro-image-preview:generateContent',
   (req, res) => {

--- a/mock_openai_server/src/imageGeneration.ts
+++ b/mock_openai_server/src/imageGeneration.ts
@@ -35,9 +35,9 @@ export class ImageGenerationHandler {
   }
 
   generateImage(request: ImageGenerationRequest): ImageGenerationResponse {
-    const { prompt, model } = request;
+    const { prompt, model, n = 1 } = request;
 
-    console.log('Received image generation request with prompt:', prompt);
+    console.log('Received image generation request with prompt:', prompt, 'n:', n);
 
     let b64_json = IMAGES.yellow;
 
@@ -53,13 +53,11 @@ export class ImageGenerationHandler {
 
     return {
       created: Date.now(),
-      data: [
-        {
-          b64_json,
-          revised_prompt: prompt,
-          url: null,
-        },
-      ],
+      data: Array.from({ length: n }, () => ({
+        b64_json,
+        revised_prompt: prompt,
+        url: null,
+      })),
     };
   }
 }

--- a/mock_openai_server/src/types.ts
+++ b/mock_openai_server/src/types.ts
@@ -30,6 +30,7 @@ export interface ChatMessage {
 export interface ImageGenerationRequest {
   prompt: string;
   model: string;
+  n?: number;
 }
 
 export interface ImageGenerationResponse {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/config/ModelPricingConfig.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/config/ModelPricingConfig.java
@@ -40,10 +40,8 @@ public class ModelPricingConfig {
 
     private static final Map<String, ImageModelPricing> IMAGE_MODEL_PRICING = Map.of(
         // OpenAI image models (1024x1024 high quality)
-        "gpt-image-1", new ImageModelPricing(new BigDecimal("0.25")),
         "gpt-image-1.5", new ImageModelPricing(new BigDecimal("0.20")),
         // Google image models
-        "imagen-4.0-ultra-generate-001", new ImageModelPricing(new BigDecimal("0.06")),
         "gemini-3-pro-image-preview", new ImageModelPricing(new BigDecimal("0.134"))
     );
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ImageController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ImageController.java
@@ -1,5 +1,6 @@
 package io.github.mucsi96.learnlanguage.controller;
 
+import java.util.List;
 import java.util.UUID;
 
 import jakarta.validation.Valid;
@@ -32,17 +33,21 @@ public class ImageController {
 
   @PostMapping("/image")
   @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
-  public ExampleImageData createImage(@Valid @RequestBody ImageSourceRequest imageSource) {
-    String uuid = UUID.randomUUID().toString();
-    String filePath = "images/%s.jpg".formatted(uuid);
+  public List<ExampleImageData> createImages(@Valid @RequestBody ImageSourceRequest imageSource) {
+    List<byte[]> images = imageService.generateImages(imageSource.getInput(), imageSource.getModel());
+    final String displayName = imageSource.getModel().getDisplayName();
 
-    byte[] data = imageService.generateImage(imageSource.getInput(), imageSource.getModel());
-    fileStorageService.saveFile(BinaryData.fromBytes(data), filePath);
-
-    return ExampleImageData.builder()
-        .id(uuid)
-        .model(imageSource.getModel().getDisplayName())
-        .build();
+    return images.stream()
+        .map(data -> {
+          String uuid = UUID.randomUUID().toString();
+          String filePath = "images/%s.jpg".formatted(uuid);
+          fileStorageService.saveFile(BinaryData.fromBytes(data), filePath);
+          return ExampleImageData.builder()
+              .id(uuid)
+              .model(displayName)
+              .build();
+        })
+        .toList();
   }
 
   @GetMapping(value = "/image/{id}", produces = MediaType.IMAGE_JPEG_VALUE)

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationModel.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationModel.java
@@ -9,9 +9,7 @@ import lombok.RequiredArgsConstructor;
 //          https://ai.google.dev/gemini-api/docs/pricing
 @RequiredArgsConstructor
 public enum ImageGenerationModel {
-    GPT_IMAGE_1("gpt-image-1", "GPT Image 1"),
     GPT_IMAGE_1_5("gpt-image-1.5", "GPT Image 1.5"),
-    IMAGEN_4_ULTRA("imagen-4.0-ultra-generate-001", "Imagen 4 Ultra"),
     GEMINI_3_PRO_IMAGE_PREVIEW("gemini-3-pro-image-preview", "Gemini 3 Pro");
 
     private final String modelName;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
@@ -1,5 +1,7 @@
 package io.github.mucsi96.learnlanguage.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import io.github.mucsi96.learnlanguage.model.ImageGenerationModel;
@@ -13,12 +15,10 @@ public class ImageService {
   private final OpenAIImageService openAIImageService;
   private final GoogleImageService googleImageService;
 
-  public byte[] generateImage(String input, ImageGenerationModel model) {
+  public List<byte[]> generateImages(String input, ImageGenerationModel model) {
     return switch (model) {
-      case GPT_IMAGE_1 -> openAIImageService.generateImage(input);
-      case GPT_IMAGE_1_5 -> openAIImageService.generateImageWithModel15(input);
-      case IMAGEN_4_ULTRA -> googleImageService.generateImageWithImagen(input);
-      case GEMINI_3_PRO_IMAGE_PREVIEW -> googleImageService.generateImageWithNanoBananaPro(input);
+      case GPT_IMAGE_1_5 -> openAIImageService.generateImages(input);
+      case GEMINI_3_PRO_IMAGE_PREVIEW -> googleImageService.generateImage(input);
     };
   }
 }

--- a/test/tests/bulk-card-creation.spec.ts
+++ b/test/tests/bulk-card-creation.spec.ts
@@ -365,11 +365,12 @@ test('bulk card creation includes word data', async ({ page }) => {
     expect(image1.equals(yellowImage)).toBeTruthy();
     expect(image2.equals(redImage)).toBeTruthy();
 
-    expect(cardData.examples[0].images[0].model).toBe('GPT Image 1');
+    expect(cardData.examples[0].images[0].model).toBe('GPT Image 1.5');
     expect(cardData.examples[0].images[1].model).toBe('GPT Image 1.5');
-    expect(cardData.examples[0].images[2].model).toBe('Imagen 4 Ultra');
-    expect(cardData.examples[0].images[3].model).toBe('Gemini 3 Pro');
-    expect(cardData.examples[1].images[0].model).toBe('GPT Image 1');
+    expect(cardData.examples[0].images[2].model).toBe('GPT Image 1.5');
+    expect(cardData.examples[0].images[3].model).toBe('GPT Image 1.5');
+    expect(cardData.examples[0].images[4].model).toBe('Gemini 3 Pro');
+    expect(cardData.examples[1].images[0].model).toBe('GPT Image 1.5');
 
     expect(cardData.translationModel).toBe('gemini-3-pro-preview');
     expect(cardData.classificationModel).toBe('gemini-3-pro-preview');

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -246,11 +246,12 @@ test('card editing in db', async ({ page }) => {
     expect(img3.equals(redImage)).toBeTruthy();
 
     expect(cardData.examples[0].images).toHaveLength(1);
-    expect(cardData.examples[1].images).toHaveLength(5);
-    expect(cardData.examples[1].images[1].model).toBe('GPT Image 1');
-    expect(cardData.examples[1].images[2].model).toBe('GPT Image 1.5');
-    expect(cardData.examples[1].images[3].model).toBe('Imagen 4 Ultra');
-    expect(cardData.examples[1].images[4].model).toBe('Gemini 3 Pro');
+    expect(cardData.examples[1].images).toHaveLength(6);
+    expect(cardData.examples[1].images[1].model).toBe('GPT Image 1.5');
+    expect(cardData.examples[1].images[2].model).toBe('Gemini 3 Pro');
+    expect(cardData.examples[1].images[3].model).toBe('GPT Image 1.5');
+    expect(cardData.examples[1].images[4].model).toBe('GPT Image 1.5');
+    expect(cardData.examples[1].images[5].model).toBe('GPT Image 1.5');
   });
 });
 
@@ -554,8 +555,8 @@ test('image model name displayed below image', async ({ page }) => {
           en: "We leave at twelve o'clock.",
           ch: 'Mir fahred am zwöufi ab.',
           images: [
-            { id: image1, model: 'GPT Image 1' },
-            { id: image2, model: 'Imagen 4 Ultra' },
+            { id: image1, model: 'GPT Image 1.5' },
+            { id: image2, model: 'Gemini 3 Pro' },
           ],
         },
       ],
@@ -564,10 +565,10 @@ test('image model name displayed below image', async ({ page }) => {
 
   await navigateToCardEditing(page);
 
-  await expect(page.getByText('GPT Image 1')).toBeVisible();
+  await expect(page.getByText('GPT Image 1.5')).toBeVisible();
 
   await page.getByRole('button', { name: 'Next image' }).first().click();
-  await expect(page.getByText('Imagen 4 Ultra')).toBeVisible();
+  await expect(page.getByText('Gemini 3 Pro')).toBeVisible();
 });
 
 test('speech card editing page displays sentence and translations', async ({ page }) => {


### PR DESCRIPTION
Drop support for gpt-image-1 and imagen-4.0-ultra models. Generate 4 images
per prompt using gpt-image-1.5 in a single API call (n=4) and 1 image with
gemini-3-pro-image-preview. The /api/image endpoint now returns a list of
images, and the cost calculator correctly logs multi-image counts.

https://claude.ai/code/session_011rz8sctREbaP7JbmCXmo5a