### PR TITLE
Add select-all filtered cards functionality to cards table

### DIFF
--- a/client/src/app/cards-table/cards-table.component.html
+++ b/client/src/app/cards-table/cards-table.component.html
@@ -66,6 +66,7 @@
     [cacheBlockSize]="100"
     [maxBlocksInCache]="10"
     [rowSelection]="rowSelection"
+    [selectionColumnDef]="selectionColumnDef"
     [getRowId]="getRowId"
     (gridReady)="onGridReady($event)"
     (sortChanged)="onSortChanged($event)"

--- a/client/src/app/cards-table/cards-table.component.html
+++ b/client/src/app/cards-table/cards-table.component.html
@@ -65,12 +65,10 @@
     [rowModelType]="'infinite'"
     [cacheBlockSize]="100"
     [maxBlocksInCache]="10"
-    [rowSelection]="rowSelection"
-    [selectionColumnDef]="selectionColumnDef"
+    [context]="gridContext"
     [getRowId]="getRowId"
     (gridReady)="onGridReady($event)"
     (sortChanged)="onSortChanged($event)"
-    (selectionChanged)="onSelectionChanged()"
     (rowClicked)="onRowClicked($event)"
   />
 

--- a/client/src/app/cards-table/cards-table.component.ts
+++ b/client/src/app/cards-table/cards-table.component.ts
@@ -25,6 +25,7 @@ import {
   TextFilterModule,
   NumberFilterModule,
   DateFilterModule,
+  ColumnAutoSizeModule,
   themeMaterial,
   colorSchemeDarkBlue,
 } from 'ag-grid-community';
@@ -82,6 +83,7 @@ ModuleRegistry.registerModules([
   TextFilterModule,
   NumberFilterModule,
   DateFilterModule,
+  ColumnAutoSizeModule,
 ]);
 
 @Component({

--- a/client/src/app/cards-table/cards-table.service.ts
+++ b/client/src/app/cards-table/cards-table.service.ts
@@ -69,6 +69,40 @@ export class CardsTableService {
     );
   }
 
+  async fetchFilteredCardIds(params: {
+    sourceId: string;
+    readiness?: string;
+    state?: string;
+    lastReviewDaysAgo?: number;
+    lastReviewRating?: number;
+  }): Promise<string[]> {
+    const httpParams = Object.entries({
+      ...(params.readiness ? { readiness: params.readiness } : {}),
+      ...(params.state ? { state: params.state } : {}),
+      ...(params.lastReviewDaysAgo !== undefined
+        ? { lastReviewDaysAgo: params.lastReviewDaysAgo }
+        : {}),
+      ...(params.lastReviewRating !== undefined
+        ? { lastReviewRating: params.lastReviewRating }
+        : {}),
+    }).reduce(
+      (acc, [key, value]) => acc.set(key, String(value)),
+      new HttpParams()
+    );
+
+    return firstValueFrom(
+      this.http.get<string[]>(
+        `/api/source/${params.sourceId}/card-ids`,
+        {
+          params: httpParams,
+          headers: {
+            'X-Timezone': Intl.DateTimeFormat().resolvedOptions().timeZone,
+          },
+        }
+      )
+    );
+  }
+
   async markCardsAsKnown(cardIds: readonly string[]): Promise<void> {
     await firstValueFrom(
       this.http.put('/api/cards/mark-known', cardIds)

--- a/client/src/app/cards-table/select-all-header.component.ts
+++ b/client/src/app/cards-table/select-all-header.component.ts
@@ -11,11 +11,11 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { IHeaderAngularComp } from 'ag-grid-angular';
 import type { IHeaderParams } from 'ag-grid-community';
 
-export type SelectAllHeaderParams = {
+export type SelectAllContext = {
   selectedIds: Signal<readonly string[]>;
   totalFilteredCount: Signal<number>;
-  onSelectAll: () => void;
-  onDeselectAll: () => void;
+  selectAll: () => void;
+  deselectAll: () => void;
 };
 
 @Component({
@@ -40,17 +40,15 @@ export class SelectAllHeaderComponent implements IHeaderAngularComp {
   private readonly injector = inject(Injector);
   readonly checked = signal(false);
   readonly indeterminate = signal(false);
-  private onSelectAllFn = (): void => {};
-  private onDeselectAllFn = (): void => {};
+  private context!: SelectAllContext;
 
-  agInit(params: IHeaderParams & SelectAllHeaderParams): void {
-    this.onSelectAllFn = params.onSelectAll;
-    this.onDeselectAllFn = params.onDeselectAll;
+  agInit(params: IHeaderParams): void {
+    this.context = params.context as SelectAllContext;
 
     runInInjectionContext(this.injector, () => {
       effect(() => {
-        const selectedCount = params.selectedIds().length;
-        const total = params.totalFilteredCount();
+        const selectedCount = this.context.selectedIds().length;
+        const total = this.context.totalFilteredCount();
         this.checked.set(total > 0 && selectedCount === total);
         this.indeterminate.set(selectedCount > 0 && selectedCount < total);
       });
@@ -63,9 +61,9 @@ export class SelectAllHeaderComponent implements IHeaderAngularComp {
 
   onToggle(): void {
     if (this.checked() || this.indeterminate()) {
-      this.onDeselectAllFn();
+      this.context.deselectAll();
     } else {
-      this.onSelectAllFn();
+      this.context.selectAll();
     }
   }
 }

--- a/client/src/app/cards-table/select-all-header.component.ts
+++ b/client/src/app/cards-table/select-all-header.component.ts
@@ -1,0 +1,71 @@
+import {
+  Component,
+  signal,
+  inject,
+  Injector,
+  effect,
+  runInInjectionContext,
+  type Signal,
+} from '@angular/core';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { IHeaderAngularComp } from 'ag-grid-angular';
+import type { IHeaderParams } from 'ag-grid-community';
+
+export type SelectAllHeaderParams = {
+  selectedIds: Signal<readonly string[]>;
+  totalFilteredCount: Signal<number>;
+  onSelectAll: () => void;
+  onDeselectAll: () => void;
+};
+
+@Component({
+  standalone: true,
+  imports: [MatCheckboxModule],
+  template: `
+    <mat-checkbox
+      [checked]="checked()"
+      [indeterminate]="indeterminate()"
+      (change)="onToggle()"
+      aria-label="Select all cards"
+    ></mat-checkbox>
+  `,
+  styles: `
+    :host {
+      display: flex;
+      align-items: center;
+    }
+  `,
+})
+export class SelectAllHeaderComponent implements IHeaderAngularComp {
+  private readonly injector = inject(Injector);
+  readonly checked = signal(false);
+  readonly indeterminate = signal(false);
+  private onSelectAllFn = (): void => {};
+  private onDeselectAllFn = (): void => {};
+
+  agInit(params: IHeaderParams & SelectAllHeaderParams): void {
+    this.onSelectAllFn = params.onSelectAll;
+    this.onDeselectAllFn = params.onDeselectAll;
+
+    runInInjectionContext(this.injector, () => {
+      effect(() => {
+        const selectedCount = params.selectedIds().length;
+        const total = params.totalFilteredCount();
+        this.checked.set(total > 0 && selectedCount === total);
+        this.indeterminate.set(selectedCount > 0 && selectedCount < total);
+      });
+    });
+  }
+
+  refresh(): boolean {
+    return true;
+  }
+
+  onToggle(): void {
+    if (this.checked() || this.indeterminate()) {
+      this.onDeselectAllFn();
+    } else {
+      this.onSelectAllFn();
+    }
+  }
+}

--- a/client/src/app/cards-table/selection-checkbox.component.ts
+++ b/client/src/app/cards-table/selection-checkbox.component.ts
@@ -44,6 +44,7 @@ export class SelectionCheckboxComponent implements ICellRendererAngularComp {
 
   agInit(params: ICellRendererParams): void {
     this.context = params.context as SelectionContext;
+    if (!params.data) return;
     this.rowId.set(params.data.id);
 
     runInInjectionContext(this.injector, () => {
@@ -54,6 +55,7 @@ export class SelectionCheckboxComponent implements ICellRendererAngularComp {
   }
 
   refresh(params: ICellRendererParams): boolean {
+    if (!params.data) return true;
     this.rowId.set(params.data.id);
     return true;
   }

--- a/client/src/app/cards-table/selection-checkbox.component.ts
+++ b/client/src/app/cards-table/selection-checkbox.component.ts
@@ -1,0 +1,64 @@
+import {
+  Component,
+  computed,
+  inject,
+  Injector,
+  effect,
+  runInInjectionContext,
+  signal,
+  type WritableSignal,
+  type Signal,
+} from '@angular/core';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { ICellRendererAngularComp } from 'ag-grid-angular';
+import type { ICellRendererParams } from 'ag-grid-community';
+
+export type SelectionContext = {
+  selectedIdsSet: Signal<ReadonlySet<string>>;
+  toggleSelection: (id: string) => void;
+};
+
+@Component({
+  standalone: true,
+  imports: [MatCheckboxModule],
+  template: `
+    <mat-checkbox
+      [checked]="checked()"
+      (change)="toggle($event)"
+      (click)="$event.stopPropagation()"
+      aria-label="Select card"
+    ></mat-checkbox>
+  `,
+  styles: `
+    :host {
+      display: flex;
+      align-items: center;
+    }
+  `,
+})
+export class SelectionCheckboxComponent implements ICellRendererAngularComp {
+  private readonly injector = inject(Injector);
+  private readonly rowId = signal('');
+  readonly checked = signal(false);
+  private context!: SelectionContext;
+
+  agInit(params: ICellRendererParams): void {
+    this.context = params.context as SelectionContext;
+    this.rowId.set(params.data.id);
+
+    runInInjectionContext(this.injector, () => {
+      effect(() => {
+        this.checked.set(this.context.selectedIdsSet().has(this.rowId()));
+      });
+    });
+  }
+
+  refresh(params: ICellRendererParams): boolean {
+    this.rowId.set(params.data.id);
+    return true;
+  }
+
+  toggle(event: { checked: boolean }): void {
+    this.context.toggleSelection(this.rowId());
+  }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/CardController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/CardController.java
@@ -65,6 +65,26 @@ public class CardController {
     return ResponseEntity.ok(response);
   }
 
+  @GetMapping("/source/{sourceId}/card-ids")
+  @PreAuthorize("hasAuthority('APPROLE_DeckReader') and hasAuthority('SCOPE_readDecks')")
+  public ResponseEntity<List<String>> getFilteredCardIds(
+      @PathVariable String sourceId,
+      @RequestHeader(value = "X-Timezone", required = true) String timezone,
+      @RequestParam(required = false) String readiness,
+      @RequestParam(required = false) String state,
+      @RequestParam(required = false) Integer minReps,
+      @RequestParam(required = false) Integer maxReps,
+      @RequestParam(required = false) Integer lastReviewDaysAgo,
+      @RequestParam(required = false) Integer lastReviewRating) {
+
+    final List<String> ids = cardService.getFilteredCardIds(
+        sourceId, readiness, state, minReps, maxReps,
+        lastReviewDaysAgo, lastReviewRating,
+        startOfDayUtc(parseTimezone(timezone)));
+
+    return ResponseEntity.ok(ids);
+  }
+
   @PutMapping("/cards/mark-known")
   @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
   public ResponseEntity<Map<String, String>> markCardsAsKnown(@RequestBody List<String> cardIds) {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -91,6 +91,22 @@ public class CardService {
         .toList();
   }
 
+  public List<String> getFilteredCardIds(
+      String sourceId,
+      String readiness, String state,
+      Integer minReps, Integer maxReps,
+      Integer lastReviewDaysAgo, Integer lastReviewRating,
+      LocalDateTime startOfDayUtc) {
+
+    final Specification<Card> spec = buildCardTableSpec(
+        sourceId, readiness, state, minReps, maxReps,
+        lastReviewDaysAgo, lastReviewRating, startOfDayUtc);
+
+    return cardRepository.findAll(spec).stream()
+        .map(Card::getId)
+        .toList();
+  }
+
   public CardTableResponse getCardTable(
       String sourceId, int startRow, int endRow,
       String sortField, String sortDirection,


### PR DESCRIPTION
Introduces a server endpoint (GET /source/{sourceId}/card-ids) that returns
all card IDs matching the current filter criteria without pagination. Adds a
custom header checkbox component in the ag-grid selection column that
selects/deselects all filtered cards via this endpoint. The selectedIds
signal is now the source of truth for selection state, with diff-based
sync to handle individual row clicks alongside bulk select-all. Filter
changes automatically reset the selection.

https://claude.ai/code/session_01A2SXJ7wZsJ9tKMmhJACqzd