### PR TITLE
Update image model pricing to reflect current API costs

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/config/ModelPricingConfig.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/config/ModelPricingConfig.java
@@ -40,11 +40,12 @@ public class ModelPricingConfig {
 
     private static final Map<String, ImageModelPricing> IMAGE_MODEL_PRICING = Map.of(
         // OpenAI image models (1024x1024 high quality)
-        "gpt-image-1", new ImageModelPricing(new BigDecimal("0.25")),
-        "gpt-image-1.5", new ImageModelPricing(new BigDecimal("0.20")),
+        "gpt-image-1", new ImageModelPricing(new BigDecimal("0.167")),
+        "gpt-image-1.5", new ImageModelPricing(new BigDecimal("0.133")),
         // Google image models
         "imagen-4.0-ultra-generate-001", new ImageModelPricing(new BigDecimal("0.06")),
-        "gemini-3-pro-image-preview", new ImageModelPricing(new BigDecimal("0.134"))
+        // Gemini Developer API: 1,290 output tokens per 1024x1024 image at $30/M tokens
+        "gemini-3-pro-image-preview", new ImageModelPricing(new BigDecimal("0.039"))
     );
 
     private static final Map<String, AudioModelPricing> AUDIO_MODEL_PRICING = Map.of(


### PR DESCRIPTION
## Summary
Updated pricing configuration for image generation models to reflect current API pricing from OpenAI and Google's Gemini services.

## Key Changes
- **OpenAI image models**: Adjusted pricing for gpt-image-1 and gpt-image-1.5 to match current rates
  - gpt-image-1: $0.25 → $0.167 per image
  - gpt-image-1.5: $0.20 → $0.133 per image
- **Google Gemini**: Updated gemini-3-pro-image-preview pricing based on token-based calculation
  - Previous: $0.134 per image
  - New: $0.039 per image (calculated from 1,290 output tokens per 1024x1024 image at $30/M tokens)
  - Added clarifying comment documenting the calculation basis

## Implementation Details
The pricing updates are based on current API documentation and token consumption rates. The Gemini model pricing now includes a comment explaining the derivation from the Gemini Developer API's token-based pricing model, improving maintainability for future updates.

https://claude.ai/code/session_017C5v7qNkMrvXhotdo9Hz88