### PR TITLE
Add context parameter to audio generation for improved TTS

### DIFF
--- a/client/src/app/batch-audio-creation.service.ts
+++ b/client/src/app/batch-audio-creation.service.ts
@@ -159,7 +159,8 @@ export class BatchAudioCreationService {
             voice: voice.voice,
             model: voice.model,
             language: item.language,
-            selected: true
+            selected: true,
+            context: item.context
           } satisfies AudioSourceRequest,
           method: 'POST',
         }

--- a/client/src/app/cardTypes/vocabulary-card-type.strategy.ts
+++ b/client/src/app/cardTypes/vocabulary-card-type.strategy.ts
@@ -258,8 +258,8 @@ export class VocabularyCardType implements CardTypeStrategy {
     const selectedExample = card.data.examples?.find(example => example.isSelected);
 
     return [
-      card.data.word ? { text: card.data.word, language: LANGUAGE_CODES.GERMAN } : null,
-      card.data.translation?.['hu'] ? { text: card.data.translation['hu'], language: LANGUAGE_CODES.HUNGARIAN } : null,
+      card.data.word ? { text: card.data.word, language: LANGUAGE_CODES.GERMAN, context: selectedExample?.['de'] } : null,
+      card.data.translation?.['hu'] ? { text: card.data.translation['hu'], language: LANGUAGE_CODES.HUNGARIAN, context: selectedExample?.['hu'] } : null,
       selectedExample?.['de'] ? { text: selectedExample['de'], language: LANGUAGE_CODES.GERMAN } : null,
       selectedExample?.['hu'] ? { text: selectedExample['hu'], language: LANGUAGE_CODES.HUNGARIAN } : null,
     ].filter(nonNullable);

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -153,6 +153,7 @@ export type CardCreationResult = {
 export type AudioGenerationItem = {
   text: string;
   language: string;
+  context?: string;
 };
 
 export type ImagesByIndex = Map<number, ExampleImage[]>;

--- a/client/src/app/shared/types/audio-generation.types.ts
+++ b/client/src/app/shared/types/audio-generation.types.ts
@@ -4,6 +4,7 @@ export interface AudioSourceRequest {
   model?: string;
   language?: string;
   selected?: boolean;
+  context?: string;
 }
 
 export interface AudioResponse {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/AudioController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/AudioController.java
@@ -36,7 +36,7 @@ public class AudioController {
     String uuid = UUID.randomUUID().toString();
     String filePath = "audio/%s.mp3".formatted(uuid);
 
-    byte[] data = audioService.generateAudio(audioSource.getInput(), audioSource.getVoice(), audioSource.getModel(), audioSource.getLanguage());
+    byte[] data = audioService.generateAudio(audioSource.getInput(), audioSource.getVoice(), audioSource.getModel(), audioSource.getLanguage(), audioSource.getContext());
     fileStorageService.saveFile(BinaryData.fromBytes(data), filePath);
 
     return AudioData.builder()

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/AudioSourceRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/AudioSourceRequest.java
@@ -19,4 +19,5 @@ public class AudioSourceRequest {
   private String model;
   private String language;
   private Boolean selected;
+  private String context;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/AudioService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/AudioService.java
@@ -29,9 +29,9 @@ public class AudioService {
 
   private final ElevenLabsAudioService elevenLabsAudioService;
 
-  public byte[] generateAudio(String input, String voiceName, String model, String language) throws IOException {
+  public byte[] generateAudio(String input, String voiceName, String model, String language, String context) throws IOException {
     if ("eleven_turbo_v2_5".equals(model) || "eleven_v3".equals(model)) {
-      return elevenLabsAudioService.generateAudio(input, voiceName, model, language);
+      return elevenLabsAudioService.generateAudio(input, voiceName, model, language, context);
     } else {
       throw new IllegalArgumentException("Unsupported audio model: " + model);
     }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ElevenLabsAudioService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ElevenLabsAudioService.java
@@ -33,7 +33,7 @@ public class ElevenLabsAudioService {
   private final ElevenLabsVoicesApi voicesApi;
   private final ModelUsageLoggingService usageLoggingService;
 
-  public byte[] generateAudio(String input, String voiceId, String model, String language) {
+  public byte[] generateAudio(String input, String voiceId, String model, String language, String context) {
     long startTime = System.currentTimeMillis();
     try {
       String processedInput = input;
@@ -47,11 +47,16 @@ public class ElevenLabsAudioService {
         }
       }
 
-      var speechOptions = ElevenLabsTextToSpeechOptions.builder()
+      var optionsBuilder = ElevenLabsTextToSpeechOptions.builder()
           .voiceId(voiceId)
           .model(model)
-          .languageCode(languageCode)
-          .build();
+          .languageCode(languageCode);
+
+      if (context != null && !context.isEmpty()) {
+        optionsBuilder.previousText(context);
+      }
+
+      var speechOptions = optionsBuilder.build();
 
       var speechPrompt = new TextToSpeechPrompt(processedInput, speechOptions);
 


### PR DESCRIPTION
## Summary
This PR adds support for passing contextual information (previous text) to the ElevenLabs text-to-speech API to improve audio generation quality. The context is extracted from selected examples in vocabulary cards and propagated through the audio generation pipeline.

## Key Changes
- **Backend**: Added `context` parameter to audio generation methods in `AudioService` and `ElevenLabsAudioService`, which is passed to the ElevenLabs API's `previousText` option when available
- **Frontend**: Updated `VocabularyCardType` to extract context from selected examples and include it in audio generation requests
- **Data Models**: Added `context` field to `AudioSourceRequest` (both TypeScript and Java), `AudioGenerationItem`, and `AudioSourceRequest` interface
- **Request Handling**: Modified `AudioController` to pass the context parameter through the audio generation pipeline

## Implementation Details
- The context parameter is optional and only applied to the ElevenLabs API when it's non-null and non-empty
- Context is derived from the selected example in the same language as the text being synthesized
- The change maintains backward compatibility as the context parameter is optional throughout the stack

https://claude.ai/code/session_015zvfzC38sEYNmKYVaofFjn