### PR TITLE
Add bulk delete audio for selected cards on cards page

### DIFF
--- a/client/src/app/cards-table/cards-table.component.css
+++ b/client/src/app/cards-table/cards-table.component.css
@@ -54,6 +54,14 @@
   background-color: darkred;
 }
 
+.delete-audio-fab {
+  background-color: #ff6d00;
+}
+
+.delete-audio-fab:hover {
+  background-color: #e65100;
+}
+
 .cards-grid {
   width: 100%;
   height: 600px;

--- a/client/src/app/cards-table/cards-table.component.html
+++ b/client/src/app/cards-table/cards-table.component.html
@@ -86,6 +86,15 @@
       <button
         mat-fab
         extended
+        class="action-fab delete-audio-fab"
+        (click)="deleteSelectedAudio()"
+      >
+        <mat-icon>volume_off</mat-icon>
+        Delete audio {{ selectedCount() }}
+      </button>
+      <button
+        mat-fab
+        extended
         color="primary"
         class="action-fab"
         (click)="markSelectedAsKnown()"

--- a/client/src/app/cards-table/cards-table.component.ts
+++ b/client/src/app/cards-table/cards-table.component.ts
@@ -361,6 +361,7 @@ export class CardsTableComponent {
     if (!result) return;
 
     await this.cardsTableService.deleteCardsAudio(ids);
+    this.selectedIds.set([]);
     this.snackBar.open(`Audio deleted for ${ids.length} card(s)`, 'Close', {
       duration: 3000,
       verticalPosition: 'top',

--- a/client/src/app/cards-table/cards-table.component.ts
+++ b/client/src/app/cards-table/cards-table.component.ts
@@ -346,6 +346,28 @@ export class CardsTableComponent {
     this.refreshGrid();
   }
 
+  async deleteSelectedAudio(): Promise<void> {
+    const ids = this.selectedIds();
+    if (ids.length === 0) return;
+
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+      width: '300px',
+      data: {
+        message: `Are you sure you want to delete audio for ${ids.length} card(s)?`,
+      },
+    });
+
+    const result = await firstValueFrom(dialogRef.afterClosed());
+    if (!result) return;
+
+    await this.cardsTableService.deleteCardsAudio(ids);
+    this.snackBar.open(`Audio deleted for ${ids.length} card(s)`, 'Close', {
+      duration: 3000,
+      verticalPosition: 'top',
+    });
+    this.refreshGrid();
+  }
+
   private toggleSelection(id: string): void {
     const current = this.selectedIds();
     const currentSet = this.selectedIdsSet();

--- a/client/src/app/cards-table/cards-table.service.ts
+++ b/client/src/app/cards-table/cards-table.service.ts
@@ -114,4 +114,10 @@ export class CardsTableService {
       this.http.delete('/api/cards', { body: cardIds })
     );
   }
+
+  async deleteCardsAudio(cardIds: readonly string[]): Promise<void> {
+    await firstValueFrom(
+      this.http.delete('/api/cards/audio', { body: cardIds })
+    );
+  }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/CardController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/CardController.java
@@ -103,6 +103,15 @@ public class CardController {
         String.format("%d card(s) deleted", cardIds.size())));
   }
 
+  @DeleteMapping("/cards/audio")
+  @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
+  public ResponseEntity<Map<String, String>> deleteCardsAudio(@RequestBody List<String> cardIds) {
+    cardService.deleteAudioForCards(cardIds);
+
+    return ResponseEntity.ok(Map.of("detail",
+        String.format("Audio deleted for %d card(s)", cardIds.size())));
+  }
+
   @PostMapping("/card")
   @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
   public ResponseEntity<Map<String, String>> createCard(@RequestBody Card request) throws Exception {


### PR DESCRIPTION
Adds a new "Delete audio" button in the card selection actions that
removes all audio data and files for the selected cards, with a
confirmation dialog.

https://claude.ai/code/session_016CvEozjvMsFLvTCAg9Xq1L