### PR TITLE
Add single word audio generation support for vocabulary cards

### DIFF
--- a/client/src/app/batch-audio-creation.service.ts
+++ b/client/src/app/batch-audio-creation.service.ts
@@ -168,7 +168,8 @@ export class BatchAudioCreationService {
             model: voice.model,
             language: item.language,
             selected: true,
-            context: item.context
+            context: item.context,
+            singleWord: item.singleWord
           } satisfies AudioSourceRequest,
           method: 'POST',
         }

--- a/client/src/app/cardTypes/vocabulary-card-type.strategy.ts
+++ b/client/src/app/cardTypes/vocabulary-card-type.strategy.ts
@@ -258,8 +258,8 @@ export class VocabularyCardType implements CardTypeStrategy {
     const selectedExample = card.data.examples?.find(example => example.isSelected);
 
     return [
-      card.data.word ? { text: card.data.word, language: LANGUAGE_CODES.GERMAN, context: selectedExample?.['de'] } : null,
-      card.data.translation?.['hu'] ? { text: card.data.translation['hu'], language: LANGUAGE_CODES.HUNGARIAN, context: selectedExample?.['hu'] } : null,
+      card.data.word ? { text: card.data.word, language: LANGUAGE_CODES.GERMAN, context: selectedExample?.['de'], singleWord: true } : null,
+      card.data.translation?.['hu'] ? { text: card.data.translation['hu'], language: LANGUAGE_CODES.HUNGARIAN, context: selectedExample?.['hu'], singleWord: true } : null,
       selectedExample?.['de'] ? { text: selectedExample['de'], language: LANGUAGE_CODES.GERMAN } : null,
       selectedExample?.['hu'] ? { text: selectedExample['hu'], language: LANGUAGE_CODES.HUNGARIAN } : null,
     ].filter(nonNullable);

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -154,6 +154,7 @@ export type AudioGenerationItem = {
   text: string;
   language: string;
   context?: string;
+  singleWord?: boolean;
 };
 
 export type ImagesByIndex = Map<number, ExampleImage[]>;

--- a/client/src/app/shared/types/audio-generation.types.ts
+++ b/client/src/app/shared/types/audio-generation.types.ts
@@ -5,6 +5,7 @@ export interface AudioSourceRequest {
   language?: string;
   selected?: boolean;
   context?: string;
+  singleWord?: boolean;
 }
 
 export interface AudioResponse {

--- a/mock_elevenlabs_server/src/audioGeneration.ts
+++ b/mock_elevenlabs_server/src/audioGeneration.ts
@@ -44,7 +44,7 @@ export class AudioGenerationHandler {
     let audioBase64 = '';
     let detectedLanguage = languageCode;
 
-    const audioTagMatch = text.match(/^\[speaking (German|Hungarian)\]/i);
+    const audioTagMatch = text.match(/\[speaking (German|Hungarian)\]/i);
     if (audioTagMatch) {
       const tagLanguage = audioTagMatch[1].toLowerCase();
       detectedLanguage = tagLanguage === 'german' ? 'de' : tagLanguage === 'hungarian' ? 'hu' : undefined;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/AudioController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/AudioController.java
@@ -36,7 +36,7 @@ public class AudioController {
     String uuid = UUID.randomUUID().toString();
     String filePath = "audio/%s.mp3".formatted(uuid);
 
-    byte[] data = audioService.generateAudio(audioSource.getInput(), audioSource.getVoice(), audioSource.getModel(), audioSource.getLanguage(), audioSource.getContext());
+    byte[] data = audioService.generateAudio(audioSource.getInput(), audioSource.getVoice(), audioSource.getModel(), audioSource.getLanguage(), audioSource.getContext(), Boolean.TRUE.equals(audioSource.getSingleWord()));
     fileStorageService.saveFile(BinaryData.fromBytes(data), filePath);
 
     return AudioData.builder()

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/AudioSourceRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/AudioSourceRequest.java
@@ -20,4 +20,5 @@ public class AudioSourceRequest {
   private String language;
   private Boolean selected;
   private String context;
+  private Boolean singleWord;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/AudioService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/AudioService.java
@@ -29,9 +29,9 @@ public class AudioService {
 
   private final ElevenLabsAudioService elevenLabsAudioService;
 
-  public byte[] generateAudio(String input, String voiceName, String model, String language, String context) throws IOException {
+  public byte[] generateAudio(String input, String voiceName, String model, String language, String context, boolean singleWord) throws IOException {
     if ("eleven_turbo_v2_5".equals(model) || "eleven_v3".equals(model)) {
-      return elevenLabsAudioService.generateAudio(input, voiceName, model, language, context);
+      return elevenLabsAudioService.generateAudio(input, voiceName, model, language, context, singleWord);
     } else {
       throw new IllegalArgumentException("Unsupported audio model: " + model);
     }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ElevenLabsAudioService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ElevenLabsAudioService.java
@@ -42,7 +42,8 @@ public class ElevenLabsAudioService {
       if (ELEVEN_V3_MODEL.equals(model) && language != null) {
         String languageName = LANGUAGE_NAMES.get(language);
         if (languageName != null) {
-          processedInput = "[speaking " + languageName + "] " + input;
+          String sayTag = input.contains(" ") ? "[say single sentence]" : "[say single word]";
+          processedInput = sayTag + "[speaking " + languageName + "] " + input;
           languageCode = null;
         }
       }
@@ -52,7 +53,7 @@ public class ElevenLabsAudioService {
           .model(model)
           .languageCode(languageCode);
 
-      if (context != null && !context.isEmpty()) {
+      if (!ELEVEN_V3_MODEL.equals(model) && context != null && !context.isEmpty()) {
         optionsBuilder.previousText(context);
       }
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ElevenLabsAudioService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ElevenLabsAudioService.java
@@ -33,7 +33,7 @@ public class ElevenLabsAudioService {
   private final ElevenLabsVoicesApi voicesApi;
   private final ModelUsageLoggingService usageLoggingService;
 
-  public byte[] generateAudio(String input, String voiceId, String model, String language, String context) {
+  public byte[] generateAudio(String input, String voiceId, String model, String language, String context, boolean singleWord) {
     long startTime = System.currentTimeMillis();
     try {
       String processedInput = input;
@@ -42,7 +42,7 @@ public class ElevenLabsAudioService {
       if (ELEVEN_V3_MODEL.equals(model) && language != null) {
         String languageName = LANGUAGE_NAMES.get(language);
         if (languageName != null) {
-          String sayTag = input.contains(" ") ? "[say single sentence]" : "[say single word]";
+          String sayTag = singleWord ? "[say single word]" : "[say single sentence]";
           processedInput = sayTag + "[speaking " + languageName + "] " + input;
           languageCode = null;
         }


### PR DESCRIPTION
## Summary
This PR adds support for generating audio with different pronunciation hints based on whether the input is a single word or a sentence. This allows the ElevenLabs API to optimize audio generation for vocabulary words versus example sentences.

## Key Changes
- Added `singleWord` boolean parameter throughout the audio generation pipeline (client and server)
- Updated `ElevenLabsAudioService` to include `[say single word]` or `[say single sentence]` tags in the prompt when using the ElevenLabs V3 model
- Modified vocabulary card strategy to mark individual words and translations as `singleWord: true`
- Disabled context/previousText parameter for ElevenLabs V3 model (only used for V2.5)
- Updated type definitions across client and server to support the new parameter

## Implementation Details
- The `singleWord` flag is passed through the entire request chain: client → `BatchAudioCreationService` → `AudioController` → `AudioService` → `ElevenLabsAudioService`
- When generating audio for V3 model, the prompt is prefixed with either `[say single word]` or `[say single sentence]` followed by the language specification
- Example sentences are generated without the `singleWord` flag, allowing natural sentence pronunciation
- The context parameter is now conditionally applied only for non-V3 models to avoid conflicts with V3's prompt-based approach

https://claude.ai/code/session_012awnWCuVt5gMxGm86MJqt6