### PR TITLE
Add confetti celebration animation when all cards are caught up

### DIFF
--- a/client/src/app/study/confetti/confetti.component.css
+++ b/client/src/app/study/confetti/confetti.component.css
@@ -1,0 +1,15 @@
+:host {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  pointer-events: none;
+  z-index: 1000;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}

--- a/client/src/app/study/confetti/confetti.component.ts
+++ b/client/src/app/study/confetti/confetti.component.ts
@@ -23,7 +23,9 @@ const COLORS = [
   '#FF6EC7', '#845EC2', '#FFC75F', '#00C9A7',
 ];
 
-const PARTICLE_COUNT = 150;
+const PARTICLES_PER_BURST = 150;
+const BURST_COUNT = 3;
+const BURST_INTERVAL_MS = 800;
 const GRAVITY = 0.12;
 const FADE_RATE = 0.001;
 const INITIAL_VELOCITY_X = 8;
@@ -75,15 +77,15 @@ export class ConfettiComponent implements OnInit, OnDestroy {
   private readonly canvasRef = viewChild.required<ElementRef<HTMLCanvasElement>>('canvas');
   private animationFrameId = 0;
   private particles: readonly Particle[] = [];
+  private burstTimeouts: readonly ReturnType<typeof setTimeout>[] = [];
 
   ngOnInit(): void {
     const canvas = this.canvasRef().nativeElement;
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
 
-    this.particles = Array.from(
-      { length: PARTICLE_COUNT },
-      () => createParticle(canvas.width)
+    this.burstTimeouts = Array.from({ length: BURST_COUNT }, (_, i) =>
+      setTimeout(() => this.spawnBurst(canvas.width), i * BURST_INTERVAL_MS)
     );
 
     this.animate();
@@ -91,6 +93,15 @@ export class ConfettiComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     cancelAnimationFrame(this.animationFrameId);
+    this.burstTimeouts.forEach(clearTimeout);
+  }
+
+  private spawnBurst(canvasWidth: number): void {
+    const newParticles = Array.from(
+      { length: PARTICLES_PER_BURST },
+      () => createParticle(canvasWidth)
+    );
+    this.particles = [...this.particles, ...newParticles];
   }
 
   private animate(): void {

--- a/client/src/app/study/confetti/confetti.component.ts
+++ b/client/src/app/study/confetti/confetti.component.ts
@@ -1,0 +1,113 @@
+import {
+  Component,
+  ElementRef,
+  OnDestroy,
+  OnInit,
+  viewChild,
+} from '@angular/core';
+
+interface Particle {
+  readonly x: number;
+  readonly y: number;
+  readonly vx: number;
+  readonly vy: number;
+  readonly rotation: number;
+  readonly rotationSpeed: number;
+  readonly color: string;
+  readonly size: number;
+  readonly opacity: number;
+}
+
+const COLORS = [
+  '#FF6B6B', '#FFD93D', '#6BCB77', '#4D96FF',
+  '#FF6EC7', '#845EC2', '#FFC75F', '#00C9A7',
+];
+
+const PARTICLE_COUNT = 150;
+const GRAVITY = 0.12;
+const FADE_RATE = 0.003;
+const INITIAL_VELOCITY_X = 8;
+const INITIAL_VELOCITY_Y_MIN = -14;
+const INITIAL_VELOCITY_Y_MAX = -4;
+
+function createParticle(canvasWidth: number): Particle {
+  return {
+    x: Math.random() * canvasWidth,
+    y: -10,
+    vx: (Math.random() - 0.5) * INITIAL_VELOCITY_X,
+    vy: Math.random() * (INITIAL_VELOCITY_Y_MAX - INITIAL_VELOCITY_Y_MIN) + INITIAL_VELOCITY_Y_MIN,
+    rotation: Math.random() * 360,
+    rotationSpeed: (Math.random() - 0.5) * 10,
+    color: COLORS[Math.floor(Math.random() * COLORS.length)],
+    size: Math.random() * 8 + 4,
+    opacity: 1,
+  };
+}
+
+function updateParticle(p: Particle): Particle {
+  return {
+    ...p,
+    x: p.x + p.vx,
+    y: p.y + p.vy,
+    vy: p.vy + GRAVITY,
+    rotation: p.rotation + p.rotationSpeed,
+    opacity: p.opacity - FADE_RATE,
+  };
+}
+
+function drawParticle(ctx: CanvasRenderingContext2D, p: Particle): void {
+  ctx.save();
+  ctx.translate(p.x, p.y);
+  ctx.rotate((p.rotation * Math.PI) / 180);
+  ctx.globalAlpha = Math.max(0, p.opacity);
+  ctx.fillStyle = p.color;
+  ctx.fillRect(-p.size / 2, -p.size / 4, p.size, p.size / 2);
+  ctx.restore();
+}
+
+@Component({
+  selector: 'app-confetti',
+  standalone: true,
+  template: `<canvas #canvas aria-hidden="true"></canvas>`,
+  styleUrl: './confetti.component.css',
+})
+export class ConfettiComponent implements OnInit, OnDestroy {
+  private readonly canvasRef = viewChild.required<ElementRef<HTMLCanvasElement>>('canvas');
+  private animationFrameId = 0;
+  private particles: readonly Particle[] = [];
+
+  ngOnInit(): void {
+    const canvas = this.canvasRef().nativeElement;
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+
+    this.particles = Array.from(
+      { length: PARTICLE_COUNT },
+      () => createParticle(canvas.width)
+    );
+
+    this.animate();
+  }
+
+  ngOnDestroy(): void {
+    cancelAnimationFrame(this.animationFrameId);
+  }
+
+  private animate(): void {
+    const canvas = this.canvasRef().nativeElement;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    this.particles = this.particles
+      .map(updateParticle)
+      .filter((p) => p.opacity > 0 && p.y < canvas.height + 50);
+
+    this.particles.forEach((p) => drawParticle(ctx, p));
+
+    if (this.particles.length > 0) {
+      this.animationFrameId = requestAnimationFrame(() => this.animate());
+    }
+  }
+}

--- a/client/src/app/study/confetti/confetti.component.ts
+++ b/client/src/app/study/confetti/confetti.component.ts
@@ -25,7 +25,7 @@ const COLORS = [
 
 const PARTICLE_COUNT = 150;
 const GRAVITY = 0.12;
-const FADE_RATE = 0.003;
+const FADE_RATE = 0.001;
 const INITIAL_VELOCITY_X = 8;
 const INITIAL_VELOCITY_Y_MIN = -14;
 const INITIAL_VELOCITY_Y_MAX = -4;
@@ -39,7 +39,7 @@ function createParticle(canvasWidth: number): Particle {
     rotation: Math.random() * 360,
     rotationSpeed: (Math.random() - 0.5) * 10,
     color: COLORS[Math.floor(Math.random() * COLORS.length)],
-    size: Math.random() * 8 + 4,
+    size: Math.random() * 24 + 12,
     opacity: 1,
   };
 }

--- a/client/src/app/study/confetti/confetti.component.ts
+++ b/client/src/app/study/confetti/confetti.component.ts
@@ -23,9 +23,7 @@ const COLORS = [
   '#FF6EC7', '#845EC2', '#FFC75F', '#00C9A7',
 ];
 
-const PARTICLES_PER_BURST = 150;
-const BURST_COUNT = 3;
-const BURST_INTERVAL_MS = 800;
+const PARTICLE_COUNT = 150;
 const GRAVITY = 0.12;
 const FADE_RATE = 0.001;
 const INITIAL_VELOCITY_X = 8;
@@ -77,15 +75,15 @@ export class ConfettiComponent implements OnInit, OnDestroy {
   private readonly canvasRef = viewChild.required<ElementRef<HTMLCanvasElement>>('canvas');
   private animationFrameId = 0;
   private particles: readonly Particle[] = [];
-  private burstTimeouts: readonly ReturnType<typeof setTimeout>[] = [];
 
   ngOnInit(): void {
     const canvas = this.canvasRef().nativeElement;
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
 
-    this.burstTimeouts = Array.from({ length: BURST_COUNT }, (_, i) =>
-      setTimeout(() => this.spawnBurst(canvas.width), i * BURST_INTERVAL_MS)
+    this.particles = Array.from(
+      { length: PARTICLE_COUNT },
+      () => createParticle(canvas.width)
     );
 
     this.animate();
@@ -93,15 +91,6 @@ export class ConfettiComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     cancelAnimationFrame(this.animationFrameId);
-    this.burstTimeouts.forEach(clearTimeout);
-  }
-
-  private spawnBurst(canvasWidth: number): void {
-    const newParticles = Array.from(
-      { length: PARTICLES_PER_BURST },
-      () => createParticle(canvasWidth)
-    );
-    this.particles = [...this.particles, ...newParticles];
   }
 
   private animate(): void {

--- a/client/src/app/study/learn-card/learn-card.component.html
+++ b/client/src/app/study/learn-card/learn-card.component.html
@@ -30,6 +30,7 @@
   </div>
 </div>
 } @else if (card() === null || card() === undefined) {
+<app-confetti />
 <div class="empty-state">
   <mat-icon class="empty-icon">school</mat-icon>
   <h2>All caught up!</h2>

--- a/client/src/app/study/learn-card/learn-card.component.ts
+++ b/client/src/app/study/learn-card/learn-card.component.ts
@@ -21,6 +21,7 @@ import { LearnVocabularyCardComponent } from '../learn-vocabulary-card/learn-voc
 import { LearnSpeechCardComponent } from '../learn-speech-card/learn-speech-card.component';
 import { LearnGrammarCardComponent } from '../learn-grammar-card/learn-grammar-card.component';
 import { LearnCardSkeletonComponent } from '../learn-card-skeleton/learn-card-skeleton.component';
+import { ConfettiComponent } from '../confetti/confetti.component';
 import { AudioPlaybackService } from '../../shared/services/audio-playback.service';
 import { Card, LanguageTexts } from '../../parser/types';
 import { CardResourceLike } from '../../shared/types/card-resource.types';
@@ -40,6 +41,7 @@ import { CardTypeRegistry } from '../../cardTypes/card-type.registry';
     LearnSpeechCardComponent,
     LearnGrammarCardComponent,
     LearnCardSkeletonComponent,
+    ConfettiComponent,
   ],
   templateUrl: './learn-card.component.html',
   styleUrl: './learn-card.component.css',

--- a/test/tests/study-page.spec.ts
+++ b/test/tests/study-page.spec.ts
@@ -975,6 +975,33 @@ test('grading with no next card shows empty state', async ({ page }) => {
   await expect(page.getByText('Great job keeping up with your studies! 🎉')).toBeVisible();
 });
 
+test('confetti celebration appears when all cards are caught up', async ({ page }) => {
+  await createCard({
+    cardId: 'confetti-test-card',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 51,
+    data: {
+      word: 'feiern',
+      type: 'VERB',
+      translation: { en: 'to celebrate', hu: 'ünnepelni', ch: 'fiire' },
+    },
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
+
+  const flashcard = page.getByRole('article', { name: 'Flashcard' });
+
+  await flashcard.getByRole('heading', { name: 'ünnepelni' }).click();
+  await page.getByRole('button', { name: 'Good' }).click();
+
+  await flashcard.getByRole('heading', { name: 'ünnepelni' }).click();
+  await page.getByRole('button', { name: 'Good' }).click();
+
+  await expect(page.getByText('All caught up!')).toBeVisible();
+  await expect(page.locator('app-confetti canvas')).toBeVisible();
+});
+
 test('cards due more than 1 hour from now are removed from session', async ({ page }) => {
   const now = new Date();
   const yesterday = new Date(now.getTime() - 86400000);


### PR DESCRIPTION
## Summary
This PR adds a celebratory confetti animation that displays when users complete all cards in a study session and reach the "All caught up!" state.

## Key Changes
- **New ConfettiComponent**: Created a standalone Angular component that renders an animated canvas-based confetti effect
  - Implements particle physics with gravity, velocity, rotation, and fade-out effects
  - Uses 150 colorful particles that animate and fall down the screen
  - Automatically cleans up animation frames on component destruction
  - Positioned as a fixed overlay with `pointer-events: none` to avoid interfering with user interactions

- **Integration**: Added the ConfettiComponent to the LearnCardComponent's empty state template, displaying when no more cards are available to study

- **Test Coverage**: Added an end-to-end test that verifies the confetti animation appears after completing all cards in a study session

## Implementation Details
- Particles are immutable objects updated each frame using functional transformations
- Canvas rendering uses 2D context with proper save/restore for transformations
- Particles are filtered out when they fade completely or fall below the viewport
- Animation stops automatically when no particles remain, preventing unnecessary CPU usage
- Component uses Angular's new `viewChild.required` API for type-safe canvas reference

https://claude.ai/code/session_01HH8dCBcwSe9s9VXSHC8TRu