### PR TITLE
Add timezone interceptor to include client timezone in HTTP requests

### DIFF
--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -13,6 +13,7 @@ import {
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { routes } from './app.routes';
 import { errorInterceptor } from './utils/error.interceptor';
+import { timezoneInterceptor } from './utils/timezone.interceptor';
 import { provideMsalConfig } from './msal.config';
 import {
   EnvironmentConfig,
@@ -30,7 +31,7 @@ export function getAppConfig(environment: EnvironmentConfig): ApplicationConfig 
       provideRouter(routes),
       provideHttpClient(
         withInterceptorsFromDi(),
-        withInterceptors([errorInterceptor])
+        withInterceptors([timezoneInterceptor, errorInterceptor])
       ),
       { provide: MAT_RIPPLE_GLOBAL_OPTIONS, useValue: globalRippleConfig },
       provideAnimationsAsync(),

--- a/client/src/app/cards-table/cards-table.service.ts
+++ b/client/src/app/cards-table/cards-table.service.ts
@@ -70,10 +70,7 @@ export class CardsTableService {
     return firstValueFrom(
       this.http.get<CardTableResponse>(
         `/api/source/${params.sourceId}/cards`,
-        {
-          params: httpParams,
-          headers: { 'X-Timezone': Intl.DateTimeFormat().resolvedOptions().timeZone },
-        }
+        { params: httpParams }
       )
     );
   }
@@ -110,12 +107,7 @@ export class CardsTableService {
     return firstValueFrom(
       this.http.get<string[]>(
         `/api/source/${params.sourceId}/card-ids`,
-        {
-          params: httpParams,
-          headers: {
-            'X-Timezone': Intl.DateTimeFormat().resolvedOptions().timeZone,
-          },
-        }
+        { params: httpParams }
       )
     );
   }

--- a/client/src/app/study-session.service.ts
+++ b/client/src/app/study-session.service.ts
@@ -18,10 +18,6 @@ export class StudySessionService {
   readonly hasExistingSession = signal(false);
   private sessionVersion = signal(0);
 
-  private readonly timezoneHeaders = {
-    'X-Timezone': Intl.DateTimeFormat().resolvedOptions().timeZone,
-  };
-
   readonly currentCard = resource({
     params: () => ({
       sourceId: this.sourceId(),
@@ -34,8 +30,7 @@ export class StudySessionService {
       }
       const result = await fetchJson<StudySessionCard>(
         this.http,
-        `/api/source/${sourceId}/study-session/current-card`,
-        { headers: this.timezoneHeaders }
+        `/api/source/${sourceId}/study-session/current-card`
       );
       if (result && result.card) {
         result.card = mapCardDatesFromISOStrings(result.card);
@@ -60,8 +55,7 @@ export class StudySessionService {
     try {
       const session = await fetchJson<StudySession>(
         this.http,
-        `/api/source/${sourceId}/study-session`,
-        { headers: this.timezoneHeaders }
+        `/api/source/${sourceId}/study-session`
       );
       const exists = session !== null;
       this.sourceId.set(sourceId);
@@ -78,7 +72,7 @@ export class StudySessionService {
     const session = await fetchJson<StudySession>(
       this.http,
       `/api/source/${sourceId}/study-session`,
-      { method: 'POST', headers: this.timezoneHeaders }
+      { method: 'POST' }
     );
     if (session) {
       this.sourceId.set(sourceId);

--- a/client/src/app/utils/timezone.interceptor.ts
+++ b/client/src/app/utils/timezone.interceptor.ts
@@ -1,0 +1,6 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+
+export const timezoneInterceptor: HttpInterceptorFn = (req, next) => {
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  return next(req.clone({ setHeaders: { 'X-Timezone': timezone } }));
+};


### PR DESCRIPTION
## Summary
This PR adds an HTTP interceptor that automatically includes the client's timezone information in all outgoing HTTP requests by setting an `X-Timezone` header.

## Key Changes
- Created a new `timezoneInterceptor` that extracts the client's timezone using the Intl API and adds it to request headers
- Registered the timezone interceptor in the application configuration, placing it before the error interceptor in the interceptor chain
- The interceptor uses Angular's `HttpInterceptorFn` functional approach for interceptor implementation

## Implementation Details
- The timezone is determined using `Intl.DateTimeFormat().resolvedOptions().timeZone`, which provides the browser's configured timezone
- The interceptor clones the request and adds the `X-Timezone` header before passing it to the next handler
- This allows the backend to be aware of the client's timezone for any timezone-dependent operations or logging

https://claude.ai/code/session_01UJY9MsXr6aMZhfrguujPrk