### PR TITLE
Filter due cards by active study sessions

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
@@ -1,5 +1,8 @@
 package io.github.mucsi96.learnlanguage.controller;
 
+import static io.github.mucsi96.learnlanguage.util.TimezoneUtils.parseTimezone;
+import static io.github.mucsi96.learnlanguage.util.TimezoneUtils.startOfDayUtc;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -14,6 +17,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -172,8 +176,9 @@ public class SourceController {
 
   @PreAuthorize("hasAuthority('APPROLE_DeckReader') and hasAuthority('SCOPE_readDecks')")
   @GetMapping("/sources/due-cards-count")
-  public List<SourceDueCardCountResponse> getDueCardsCountBySource() {
-    return cardService.getDueCardCountsBySource();
+  public List<SourceDueCardCountResponse> getDueCardsCountBySource(
+      @RequestHeader(value = "X-Timezone", required = true) String timezone) {
+    return cardService.getDueCardCountsBySource(startOfDayUtc(parseTimezone(timezone)));
   }
 
   @PostMapping("/source")

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -1,7 +1,11 @@
 package io.github.mucsi96.learnlanguage.service;
 
+import static io.github.mucsi96.learnlanguage.repository.specification.StudySessionSpecifications.createdOnOrAfter;
+
 import io.github.mucsi96.learnlanguage.entity.Card;
 import io.github.mucsi96.learnlanguage.entity.CardView;
+import io.github.mucsi96.learnlanguage.entity.StudySession;
+import io.github.mucsi96.learnlanguage.entity.StudySessionCard;
 import io.github.mucsi96.learnlanguage.model.CardTableResponse;
 import io.github.mucsi96.learnlanguage.model.CardTableRow;
 import io.github.mucsi96.learnlanguage.model.AudioData;
@@ -10,6 +14,7 @@ import io.github.mucsi96.learnlanguage.model.SourceDueCardCountResponse;
 import io.github.mucsi96.learnlanguage.repository.CardRepository;
 import io.github.mucsi96.learnlanguage.repository.CardViewRepository;
 import io.github.mucsi96.learnlanguage.repository.ReviewLogRepository;
+import io.github.mucsi96.learnlanguage.repository.StudySessionRepository;
 import io.github.mucsi96.learnlanguage.service.cardtype.CardTypeStrategyFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -22,9 +27,13 @@ import org.springframework.util.StringUtils;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static io.github.mucsi96.learnlanguage.repository.specification.CardViewSpecifications.*;
 
@@ -37,6 +46,7 @@ public class CardService {
   private final CardRepository cardRepository;
   private final CardViewRepository cardViewRepository;
   private final ReviewLogRepository reviewLogRepository;
+  private final StudySessionRepository studySessionRepository;
   private final CardTypeStrategyFactory cardTypeStrategyFactory;
   private final FileStorageService fileStorageService;
 
@@ -53,14 +63,42 @@ public class CardService {
     cardRepository.deleteById(id);
   }
 
-  public List<SourceDueCardCountResponse> getDueCardCountsBySource() {
-    return cardRepository.findTop50MostDueGroupedByStateAndSourceId().stream()
+  public List<SourceDueCardCountResponse> getDueCardCountsBySource(LocalDateTime startOfDay) {
+    final List<StudySession> activeSessions = studySessionRepository.findAll(createdOnOrAfter(startOfDay));
+
+    final Set<String> sourcesWithSessions = activeSessions.stream()
+        .map(session -> session.getSource().getId())
+        .collect(Collectors.toSet());
+
+    final LocalDateTime cutoff = LocalDateTime.now(ZoneOffset.UTC).plusHours(1);
+
+    final List<SourceDueCardCountResponse> sessionCounts = activeSessions.stream()
+        .flatMap(session -> studySessionRepository.findWithCardsById(session.getId())
+            .stream()
+            .flatMap(loaded -> loaded.getCards().stream()
+                .map(StudySessionCard::getCard)
+                .filter(Card::isReady)
+                .filter(card -> !card.getDue().isAfter(cutoff))
+                .collect(Collectors.groupingBy(Card::getState, Collectors.counting()))
+                .entrySet().stream()
+                .map(entry -> SourceDueCardCountResponse.builder()
+                    .sourceId(loaded.getSource().getId())
+                    .state(entry.getKey())
+                    .count(entry.getValue())
+                    .build())))
+        .toList();
+
+    final List<SourceDueCardCountResponse> nonSessionCounts = cardRepository
+        .findTop50MostDueGroupedByStateAndSourceId().stream()
         .map(row -> SourceDueCardCountResponse.builder()
             .sourceId((String) row[0])
             .state((String) row[1])
             .count(((Number) row[2]).longValue())
             .build())
+        .filter(r -> !sourcesWithSessions.contains(r.getSourceId()))
         .toList();
+
+    return Stream.concat(sessionCounts.stream(), nonSessionCounts.stream()).toList();
   }
 
   public List<Card> getCardsByReadiness(String readiness) {


### PR DESCRIPTION
## Summary
Modified the due card counting logic to prioritize cards from active study sessions while maintaining backward compatibility with non-session cards.

## Key Changes
- **CardService.getDueCardCountsBySource()**: 
  - Now accepts a `LocalDateTime startOfDay` parameter to filter study sessions
  - Retrieves all active study sessions created on or after the start of day
  - Counts due cards from active study sessions separately, applying a 1-hour cutoff window
  - Filters out sources with active sessions from the general card repository query to avoid duplication
  - Combines session-based and non-session card counts in the response

- **SourceController.getDueCardsCountBySource()**:
  - Added `@RequestHeader` parameter to accept timezone information from clients
  - Parses the timezone and calculates the start of day in UTC
  - Passes the calculated start of day to the updated service method

- **New Dependencies**:
  - Added `StudySessionRepository` injection for querying active sessions
  - Added utility imports for timezone handling and stream operations

## Implementation Details
- Uses `StudySessionSpecifications.createdOnOrAfter()` to filter recent study sessions
- Applies a 1-hour cutoff (`LocalDateTime.now(ZoneOffset.UTC).plusHours(1)`) for session card readiness
- Filters cards by `isReady()` status and due date within the cutoff window
- Groups session cards by state and source for aggregation
- Excludes sources with active sessions from the general query to prevent counting the same cards twice

https://claude.ai/code/session_01N2MA7WFLWDmfZrBCKUzKBX