### PR TITLE
Add cards to existing study sessions after bulk audio generation

### DIFF
--- a/client/src/app/batch-audio-creation-fab/batch-audio-creation-fab.component.ts
+++ b/client/src/app/batch-audio-creation-fab/batch-audio-creation-fab.component.ts
@@ -75,6 +75,16 @@ export class BatchAudioCreationFabComponent {
       );
 
       if (results.successful > 0) {
+        const cardIds = cards.map(c => c.id);
+        try {
+          await fetchJson(this.http, '/api/study-sessions/add-cards', {
+            method: 'POST',
+            body: { cardIds },
+          });
+        } catch {
+          // Session addition is best-effort
+        }
+
         this.cards.reload();
         this.snackBar.open(
           `Audio generated successfully for ${results.successful} card${results.successful === 1 ? '' : 's'}!`,

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/StudySessionController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/StudySessionController.java
@@ -8,9 +8,11 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.github.mucsi96.learnlanguage.model.AddCardsToSessionRequest;
 import io.github.mucsi96.learnlanguage.model.StudySessionCardResponse;
 import io.github.mucsi96.learnlanguage.model.StudySessionResponse;
 import io.github.mucsi96.learnlanguage.service.StudySessionService;
@@ -48,5 +50,14 @@ public class StudySessionController {
         return studySessionService.getCurrentCardBySourceId(sourceId, startOfDayUtc(parseTimezone(timezone)))
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.noContent().build());
+    }
+
+    @PostMapping("/study-sessions/add-cards")
+    @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
+    public ResponseEntity<Void> addCardsToSessions(
+            @RequestBody AddCardsToSessionRequest request,
+            @RequestHeader(value = "X-Timezone", required = true) String timezone) {
+        studySessionService.addCardsToSessions(request.getCardIds(), startOfDayUtc(parseTimezone(timezone)));
+        return ResponseEntity.noContent().build();
     }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/AddCardsToSessionRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/AddCardsToSessionRequest.java
@@ -1,0 +1,16 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AddCardsToSessionRequest {
+    private List<String> cardIds;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/StudySessionService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/StudySessionService.java
@@ -7,6 +7,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -31,6 +32,7 @@ import io.github.mucsi96.learnlanguage.model.StudySessionResponse;
 import io.github.mucsi96.learnlanguage.repository.CardRepository;
 import io.github.mucsi96.learnlanguage.repository.ReviewLogRepository;
 import io.github.mucsi96.learnlanguage.repository.SourceRepository;
+import io.github.mucsi96.learnlanguage.repository.StudySessionCardRepository;
 import io.github.mucsi96.learnlanguage.repository.StudySessionRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -49,6 +51,7 @@ public class StudySessionService {
     private final CardRepository cardRepository;
     private final SourceRepository sourceRepository;
     private final StudySessionRepository studySessionRepository;
+    private final StudySessionCardRepository studySessionCardRepository;
     private final ReviewLogRepository reviewLogRepository;
     private final LearningPartnerService learningPartnerService;
 
@@ -90,8 +93,8 @@ public class StudySessionService {
                 .build();
 
         final List<StudySessionCard> sessionCards = activePartner
-                .map(partner -> assignCardsSmartly(dueCards, session, partner))
-                .orElseGet(() -> assignCardsSolo(dueCards, session));
+                .map(partner -> assignCardsSmartly(dueCards, session, partner, SESSION_CARD_LIMIT, 0))
+                .orElseGet(() -> assignCardsSolo(dueCards, session, SESSION_CARD_LIMIT, 0));
 
         final StudySession sessionWithCards = session.toBuilder()
                 .cards(new ArrayList<>(sessionCards))
@@ -104,22 +107,23 @@ public class StudySessionService {
                 .build();
     }
 
-    List<StudySessionCard> assignCardsSolo(List<Card> cards, StudySession session) {
-        List<Card> limitedCards = cards.stream()
-                .limit(SESSION_CARD_LIMIT)
+    List<StudySessionCard> assignCardsSolo(List<Card> cards, StudySession session, int limit, int positionOffset) {
+        final List<Card> limitedCards = cards.stream()
+                .limit(limit)
                 .toList();
 
         return IntStream.range(0, limitedCards.size())
                 .mapToObj(i -> StudySessionCard.builder()
                         .session(session)
                         .card(limitedCards.get(i))
-                        .position(i)
+                        .position(positionOffset + i)
                         .learningPartner(null)
                         .build())
                 .toList();
     }
 
-    List<StudySessionCard> assignCardsSmartly(List<Card> cards, StudySession session, LearningPartner partner) {
+    List<StudySessionCard> assignCardsSmartly(List<Card> cards, StudySession session, LearningPartner partner, int limit,
+            int positionOffset) {
         if (cards.isEmpty()) {
             return List.of();
         }
@@ -127,37 +131,37 @@ public class StudySessionService {
         final double defaultComplexity = 4 * 30;
         final List<String> cardIds = cards.stream().map(Card::getId).toList();
         final Map<String, Double> userComplexities = toComplexityMap(
-            reviewLogRepository.findCardComplexitiesWithoutPartner(cardIds));
+                reviewLogRepository.findCardComplexitiesWithoutPartner(cardIds));
         final Map<String, Double> partnerComplexities = toComplexityMap(
-            reviewLogRepository.findCardComplexitiesWithPartner(cardIds, partner.getId()));
+                reviewLogRepository.findCardComplexitiesWithPartner(cardIds, partner.getId()));
 
-        List<Card> mostComplexCards = cards.stream()
+        final List<Card> mostComplexCards = cards.stream()
                 .sorted(Comparator.comparingDouble(
                         (Card card) -> Math.max(
-                            userComplexities.getOrDefault(card.getId(), defaultComplexity),
-                            partnerComplexities.getOrDefault(card.getId(), defaultComplexity)))
+                                userComplexities.getOrDefault(card.getId(), defaultComplexity),
+                                partnerComplexities.getOrDefault(card.getId(), defaultComplexity)))
                         .reversed())
-                .limit(SESSION_CARD_LIMIT)
+                .limit(limit)
                 .toList();
 
-        List<Card> sortedByPreference = mostComplexCards.stream()
+        final List<Card> sortedByPreference = mostComplexCards.stream()
                 .sorted(Comparator.comparingDouble(
                         (Card card) -> userComplexities.getOrDefault(card.getId(), defaultComplexity)
-                            - partnerComplexities.getOrDefault(card.getId(), defaultComplexity))
+                                - partnerComplexities.getOrDefault(card.getId(), defaultComplexity))
                         .reversed())
                 .toList();
 
-        int userSlots = (sortedByPreference.size() + 1) / 2;
+        final int userSlots = (sortedByPreference.size() + 1) / 2;
 
-        List<Card> userCards = sortedByPreference.stream()
+        final List<Card> userCards = sortedByPreference.stream()
                 .limit(userSlots)
                 .toList();
 
-        List<Card> partnerCards = sortedByPreference.stream()
+        final List<Card> partnerCards = sortedByPreference.stream()
                 .skip(userSlots)
                 .toList();
 
-        List<Card> partnerCardsReversed = IntStream.range(0, partnerCards.size())
+        final List<Card> partnerCardsReversed = IntStream.range(0, partnerCards.size())
                 .mapToObj(i -> partnerCards.get(partnerCards.size() - 1 - i))
                 .toList();
 
@@ -165,7 +169,7 @@ public class StudySessionService {
                 .mapToObj(i -> StudySessionCard.builder()
                         .session(session)
                         .card(i % 2 == 0 ? userCards.get(i / 2) : partnerCardsReversed.get(i / 2))
-                        .position(i)
+                        .position(positionOffset + i)
                         .learningPartner(i % 2 == 0 ? null : partner)
                         .build())
                 .toList();
@@ -176,6 +180,56 @@ public class StudySessionService {
                 .collect(Collectors.toMap(
                         row -> (String) row[0],
                         row -> ((Number) row[1]).doubleValue()));
+    }
+
+    @Transactional
+    public void addCardsToSessions(List<String> cardIds, LocalDateTime startOfDay) {
+        final List<Card> cards = cardRepository.findByIdIn(cardIds).stream()
+                .filter(Card::isReady)
+                .toList();
+
+        cards.stream()
+                .collect(Collectors.groupingBy(c -> c.getSource().getId()))
+                .forEach((sourceId, sourceCards) -> addCardsToSourceSession(sourceCards, sourceId, startOfDay));
+    }
+
+    private void addCardsToSourceSession(List<Card> cards, String sourceId, LocalDateTime startOfDay) {
+        studySessionRepository.findBySource_IdAndCreatedAtGreaterThanEqual(sourceId, startOfDay)
+                .flatMap(session -> studySessionRepository.findWithCardsById(session.getId()))
+                .ifPresent(session -> {
+                    final Set<String> existingCardIds = session.getCards().stream()
+                            .map(sc -> sc.getCard().getId())
+                            .collect(Collectors.toSet());
+
+                    final List<Card> newCards = cards.stream()
+                            .filter(c -> !existingCardIds.contains(c.getId()))
+                            .toList();
+
+                    if (newCards.isEmpty()) {
+                        return;
+                    }
+
+                    final int remainingSlots = SESSION_CARD_LIMIT - session.getCards().size();
+                    if (remainingSlots <= 0) {
+                        return;
+                    }
+
+                    final int positionOffset = session.getCards().stream()
+                            .mapToInt(StudySessionCard::getPosition)
+                            .max()
+                            .orElse(-1) + 1;
+
+                    final Optional<LearningPartner> activePartner = "WITH_PARTNER".equals(session.getStudyMode())
+                            ? learningPartnerService.getActivePartner()
+                            : Optional.empty();
+
+                    final List<StudySessionCard> newSessionCards = activePartner
+                            .map(partner -> assignCardsSmartly(newCards, session, partner, remainingSlots,
+                                    positionOffset))
+                            .orElseGet(() -> assignCardsSolo(newCards, session, remainingSlots, positionOffset));
+
+                    studySessionCardRepository.saveAll(newSessionCards);
+                });
     }
 
     @Transactional

--- a/test/tests/bulk-audio-creation.spec.ts
+++ b/test/tests/bulk-audio-creation.spec.ts
@@ -1021,6 +1021,10 @@ test('bulk audio creation respects session card limit', async ({ page }) => {
         translation: { en: `word${i}`, hu: `szo${i}` },
         forms: [],
         examples: [],
+        audio: [
+          { id: `audio-de-${i}`, text: `wort${i}`, voice: 'v', model: 'm', language: 'de', selected: true },
+          { id: `audio-hu-${i}`, text: `szo${i}`, voice: 'v', model: 'm', language: 'hu', selected: true },
+        ],
       },
       readiness: 'READY',
     });

--- a/test/tests/bulk-audio-creation.spec.ts
+++ b/test/tests/bulk-audio-creation.spec.ts
@@ -2,6 +2,8 @@ import { test, expect } from '../fixtures';
 import {
   createCard,
   createVoiceConfiguration,
+  createStudySession,
+  getStudySessionCardsBySource,
   withDbConnection,
   germanAudioSample,
   hungarianAudioSample,
@@ -924,4 +926,201 @@ test('bulk audio creation assigns voices in round-robin per card', async ({ page
         expect(audio.voice).toBe(card2GermanVoice);
       });
   });
+});
+
+test('bulk audio creation adds cards to existing study session', async ({ page }) => {
+  await setupVoiceConfigurations();
+
+  // Create a READY card that's already in a session
+  await createCard({
+    cardId: 'existing-card',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 15,
+    data: {
+      word: 'lesen',
+      type: 'VERB',
+      translation: { en: 'to read', hu: 'olvasni', ch: 'lese' },
+      forms: ['liest', 'las', 'gelesen'],
+      examples: [
+        {
+          de: 'Ich lese ein Buch.',
+          hu: 'Olvasok egy könyvet.',
+          en: 'I read a book.',
+          ch: 'Ich les es Buech.',
+          isSelected: true,
+          images: [{ id: 'test-image-id' }],
+        },
+      ],
+      audio: [
+        { id: 'a1', text: 'lesen', voice: 'v', model: 'm', language: 'de', selected: true },
+        { id: 'a2', text: 'olvasni', voice: 'v', model: 'm', language: 'hu', selected: true },
+        { id: 'a3', text: 'Ich lese ein Buch.', voice: 'v', model: 'm', language: 'de', selected: true },
+        { id: 'a4', text: 'Olvasok egy könyvet.', voice: 'v', model: 'm', language: 'hu', selected: true },
+      ],
+    },
+    readiness: 'READY',
+  });
+
+  await createStudySession({
+    sourceId: 'goethe-a1',
+    cardIds: ['existing-card'],
+  });
+
+  // Create a REVIEWED card that needs audio
+  await createCard({
+    cardId: 'new-card',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 15,
+    data: {
+      word: 'verstehen',
+      type: 'VERB',
+      translation: { en: 'to understand', hu: 'érteni', ch: 'verstoh' },
+      forms: ['versteht', 'verstand', 'verstanden'],
+      examples: [
+        {
+          de: 'Ich verstehe Deutsch.',
+          hu: 'Értem a németet.',
+          en: 'I understand German.',
+          ch: 'Ich verstoh Tüütsch.',
+          isSelected: true,
+          images: [{ id: 'test-image-id-2' }],
+        },
+      ],
+    },
+    readiness: 'REVIEWED',
+  });
+
+  await page.goto('http://localhost:8180/in-review-cards');
+  await page.getByRole('button', { name: 'Generate audio for cards' }).click();
+
+  await expect(page.getByText('Audio generated successfully for 1 card!')).toBeVisible();
+
+  const sessionCards = await getStudySessionCardsBySource('goethe-a1');
+  expect(sessionCards.length).toBe(2);
+  expect(sessionCards[0].cardId).toBe('existing-card');
+  expect(sessionCards[0].position).toBe(0);
+  expect(sessionCards[1].cardId).toBe('new-card');
+  expect(sessionCards[1].position).toBe(1);
+});
+
+test('bulk audio creation respects session card limit', async ({ page }) => {
+  await setupVoiceConfigurations();
+
+  // Create 49 READY cards and add them to a session
+  const existingCardIds: string[] = [];
+  for (let i = 0; i < 49; i++) {
+    const cardId = `existing-card-${i}`;
+    existingCardIds.push(cardId);
+    await createCard({
+      cardId,
+      sourceId: 'goethe-a1',
+      sourcePageNumber: 15,
+      data: {
+        word: `wort${i}`,
+        type: 'NOUN',
+        translation: { en: `word${i}`, hu: `szo${i}` },
+        forms: [],
+        examples: [],
+      },
+      readiness: 'READY',
+    });
+  }
+
+  await createStudySession({
+    sourceId: 'goethe-a1',
+    cardIds: existingCardIds,
+  });
+
+  // Create 2 REVIEWED cards that need audio
+  await createCard({
+    cardId: 'new-card-1',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 15,
+    data: {
+      word: 'verstehen',
+      type: 'VERB',
+      translation: { en: 'to understand', hu: 'érteni', ch: 'verstoh' },
+      forms: ['versteht', 'verstand', 'verstanden'],
+      examples: [
+        {
+          de: 'Ich verstehe Deutsch.',
+          hu: 'Értem a németet.',
+          en: 'I understand German.',
+          ch: 'Ich verstoh Tüütsch.',
+          isSelected: true,
+          images: [{ id: 'test-image-id' }],
+        },
+      ],
+    },
+    readiness: 'REVIEWED',
+  });
+
+  await createCard({
+    cardId: 'new-card-2',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 15,
+    data: {
+      word: 'sprechen',
+      type: 'VERB',
+      translation: { en: 'to speak', hu: 'beszélni', ch: 'rede' },
+      forms: ['spricht', 'sprach', 'gesprochen'],
+      examples: [
+        {
+          de: 'Ich spreche Deutsch.',
+          hu: 'Németül beszélek.',
+          en: 'I speak German.',
+          ch: 'Ich red Tüütsch.',
+          isSelected: true,
+          images: [{ id: 'test-image-id-2' }],
+        },
+      ],
+    },
+    readiness: 'REVIEWED',
+  });
+
+  await page.goto('http://localhost:8180/in-review-cards');
+  await page.getByRole('button', { name: 'Generate audio for cards' }).click();
+
+  await expect(page.getByText('Audio generated successfully for 2 cards!')).toBeVisible();
+
+  const sessionCards = await getStudySessionCardsBySource('goethe-a1');
+  // 49 existing + 1 new (limit is 50, only 1 slot remaining)
+  expect(sessionCards.length).toBe(50);
+  expect(sessionCards[49].cardId).toBe('new-card-1');
+  expect(sessionCards[49].position).toBe(49);
+});
+
+test('bulk audio creation does not fail when no session exists', async ({ page }) => {
+  await setupVoiceConfigurations();
+
+  await createCard({
+    cardId: 'verstehen-erteni',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 15,
+    data: {
+      word: 'verstehen',
+      type: 'VERB',
+      translation: { en: 'to understand', hu: 'érteni', ch: 'verstoh' },
+      forms: ['versteht', 'verstand', 'verstanden'],
+      examples: [
+        {
+          de: 'Ich verstehe Deutsch.',
+          hu: 'Értem a németet.',
+          en: 'I understand German.',
+          ch: 'Ich verstoh Tüütsch.',
+          isSelected: true,
+          images: [{ id: 'test-image-id' }],
+        },
+      ],
+    },
+    readiness: 'REVIEWED',
+  });
+
+  await page.goto('http://localhost:8180/in-review-cards');
+  await page.getByRole('button', { name: 'Generate audio for cards' }).click();
+
+  await expect(page.getByText('Audio generated successfully for 1 card!')).toBeVisible();
+
+  const sessionCards = await getStudySessionCardsBySource('goethe-a1');
+  expect(sessionCards.length).toBe(0);
 });


### PR DESCRIPTION
## Summary
This PR adds functionality to automatically add newly generated cards to existing study sessions when bulk audio creation is performed. Previously, cards with generated audio would remain unassigned to sessions.

## Key Changes

- **StudySessionService**: 
  - Added `addCardsToSessions()` method to add ready cards to existing sessions for their source
  - Added `addCardsToSourceSession()` helper method that respects the 50-card session limit and intelligently assigns cards using existing solo/partner logic
  - Refactored `assignCardsSolo()` and `assignCardsSmartly()` to accept `limit` and `positionOffset` parameters, enabling incremental card addition to sessions

- **StudySessionController**: 
  - Added new POST endpoint `/study-sessions/add-cards` to trigger card addition to sessions
  - Endpoint requires `DeckCreator` role and `createDeck` scope

- **BatchAudioCreationFabComponent**: 
  - Integrated call to new endpoint after successful audio generation
  - Implemented best-effort error handling (failures don't block UI updates)

- **Test Utilities**: 
  - Added `createStudySession()` helper to set up test sessions with cards
  - Added `getStudySessionCardsBySource()` helper to verify session card assignments

- **Test Coverage**: 
  - Added test for adding cards to existing sessions with proper position tracking
  - Added test verifying 50-card session limit is respected when adding new cards
  - Added test confirming graceful handling when no session exists for a source

## Implementation Details

- New cards are only added if they're in READY state and don't already exist in the session
- Position offsets are calculated based on existing session cards to maintain proper ordering
- When a session has a learning partner, the intelligent assignment algorithm is used; otherwise solo assignment is used
- The feature is non-blocking—audio generation completes successfully even if session addition fails

https://claude.ai/code/session_01CjqYh16efyXJTRZkuTepc7