### PR TITLE
Add duplicate word detection with visual warning indicator

### DIFF
--- a/client/src/app/cardTypes/vocabulary-card-type.strategy.ts
+++ b/client/src/app/cardTypes/vocabulary-card-type.strategy.ts
@@ -39,6 +39,7 @@ interface TranslationResponse {
 interface WordIdResponse {
   id: string;
   exists: boolean;
+  warning: boolean;
 }
 
 @Injectable({
@@ -98,6 +99,7 @@ export class VocabularyCardType implements CardTypeStrategy {
           ...word,
           id: wordIdResponse.id,
           exists: wordIdResponse.exists,
+          warning: wordIdResponse.warning,
           extractionModel: extractionResult.model,
         };
       })

--- a/client/src/app/parser/span/span-match.component.css
+++ b/client/src/app/parser/span/span-match.component.css
@@ -13,6 +13,10 @@
   outline-offset: 1px;
 }
 
+.word.warning {
+  outline-color: #f9a825;
+}
+
 a.word {
   outline: 3px solid var(--mat-sys-primary);
 }

--- a/client/src/app/parser/span/span-match.component.html
+++ b/client/src/app/parser/span/span-match.component.html
@@ -15,6 +15,7 @@
   } @else {
   <div
     class="word"
+    [class.warning]="warning()"
     exclude-selection
     [style.left]="left()"
     [style.top]="top()"
@@ -35,7 +36,7 @@
     {{ label() }}
   </a>
   } @else {
-  <div mat-menu-item [ariaDescription]="ariaDescription">
+  <div mat-menu-item [ariaDescription]="ariaDescription" [class.warning]="warning()">
     {{ label() }}
   </div>
   }

--- a/client/src/app/parser/span/span-match.component.ts
+++ b/client/src/app/parser/span/span-match.component.ts
@@ -14,6 +14,7 @@ export class SpanMatchComponent {
   readonly cardId = input.required<string>();
   readonly exists = input.required<boolean>();
   readonly label = input.required<string>();
+  readonly warning = input(false);
   readonly inline = input(false);
   readonly left = input<string>();
   readonly top = input<string>();
@@ -21,6 +22,9 @@ export class SpanMatchComponent {
   readonly height = input<string>();
 
   get ariaDescription() {
-    return this.exists() ? 'Card exists' : 'Card does not exist';
+    if (this.exists()) {
+      return 'Card exists';
+    }
+    return this.warning() ? 'Possible duplicate' : 'Card does not exist';
   }
 }

--- a/client/src/app/parser/span/span.component.html
+++ b/client/src/app/parser/span/span.component.html
@@ -16,6 +16,7 @@
   [pageNumber]="pageNumber()"
   [cardId]="matches[0].id"
   [exists]="matches[0].exists"
+  [warning]="matches[0].warning ?? false"
   [label]="text() ?? ''"
   [left]="left"
   [top]="top"
@@ -42,6 +43,7 @@
     [pageNumber]="pageNumber()"
     [cardId]="match.id"
     [exists]="match.exists"
+    [warning]="match.warning ?? false"
     [label]="getItemLabel(match)"
 
   />

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -99,6 +99,7 @@ export type CardType = 'vocabulary' | 'speech' | 'grammar';
 export type ExtractedItem = {
   id: string;
   exists: boolean;
+  warning?: boolean;
   extractionModel?: string;
 };
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/WordIdController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/WordIdController.java
@@ -19,12 +19,15 @@ public class WordIdController {
     @PostMapping("/word-id")
     @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
     public ResponseEntity<WordIdResponse> generateWordId(@RequestBody WordIdRequest request) {
-        String id = wordIdService.generateWordId(request.getGermanWord(), request.getHungarianTranslation());
-        boolean exists = cardRepository.existsById(id);
+        final String id = wordIdService.generateWordId(request.getGermanWord(), request.getHungarianTranslation());
+        final boolean exists = cardRepository.existsById(id);
+        final String germanPrefix = wordIdService.normalizeGermanWord(request.getGermanWord()) + "-";
+        final boolean warning = !exists && cardRepository.existsByIdStartingWithAndIdNot(germanPrefix, id);
 
-        WordIdResponse response = WordIdResponse.builder()
+        final WordIdResponse response = WordIdResponse.builder()
                 .id(id)
                 .exists(exists)
+                .warning(warning)
                 .build();
 
         return ResponseEntity.ok(response);

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/WordIdResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/WordIdResponse.java
@@ -12,4 +12,5 @@ import lombok.NoArgsConstructor;
 public class WordIdResponse {
     private String id;
     private boolean exists;
+    private boolean warning;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
@@ -38,6 +38,8 @@ public interface CardRepository
         """, nativeQuery = true)
     List<Object[]> findTop50MostDueGroupedByStateAndSourceId();
 
+    boolean existsByIdStartingWithAndIdNot(String prefix, String id);
+
     @Modifying
     void deleteBySource(Source source);
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/WordIdService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/WordIdService.java
@@ -16,9 +16,13 @@ public class WordIdService {
     private static final Pattern HUNGARIAN_ARTICLE_PATTERN = Pattern.compile("^(a|az|egy)\\s+", Pattern.CASE_INSENSITIVE);
 
     public String generateWordId(String germanWord, String hungarianWord) {
-        String normalizedGerman = normalizeWord(stripGermanArticle(germanWord));
-        String normalizedHungarian = normalizeWord(stripHungarianArticle(hungarianWord));
+        final String normalizedGerman = normalizeGermanWord(germanWord);
+        final String normalizedHungarian = normalizeWord(stripHungarianArticle(hungarianWord));
         return normalizedGerman + "-" + normalizedHungarian;
+    }
+
+    public String normalizeGermanWord(String germanWord) {
+        return normalizeWord(stripGermanArticle(germanWord));
     }
 
     private String stripGermanArticle(String word) {

--- a/test/tests/sources-page.spec.ts
+++ b/test/tests/sources-page.spec.ts
@@ -113,6 +113,27 @@ test('drag to select multiple regions highlights matching words', async ({ page 
   await expect(page.getByText('die Adresse').first()).toHaveAccessibleDescription('Card does not exist');
 });
 
+test('drag to select words highlights possible duplicates with warning', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await createCard({
+    cardId: 'abfahren-tavozni',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'abfahren',
+      type: 'VERB',
+      translation: { en: 'to depart', hu: 'távozni', ch: 'abfahren' },
+      forms: [],
+      examples: [],
+    },
+  });
+  await navigateToSource(page, 'Goethe A1');
+
+  await selectTextRange(page, 'aber', 'Vor der Abfahrt rufe ich an.');
+
+  await expect(page.getByText('abfahren').first()).toHaveAccessibleDescription('Possible duplicate');
+});
+
 test('source selector routing works', async ({ page }) => {
   // Navigate to first source page
   await page.goto('http://localhost:8180/sources/goethe-a1/page/9');


### PR DESCRIPTION
## Summary
This PR adds functionality to detect and warn users about possible duplicate words when selecting text in the sources page. When a word is selected that doesn't exist as a card but shares the same German root with an existing card, a visual warning is displayed.

## Key Changes
- **Backend duplicate detection**: Added `existsByIdStartingWithAndIdNot()` query to CardRepository to find cards with matching German word prefixes
- **Word ID response enhancement**: Extended `WordIdResponse` to include a `warning` boolean flag indicating possible duplicates
- **German word normalization**: Extracted `normalizeGermanWord()` method in WordIdService for reusability in duplicate detection logic
- **Frontend warning display**: 
  - Added `warning` input property to SpanMatchComponent
  - Updated aria-description to show "Possible duplicate" when warning is true
  - Added orange outline styling (`.word.warning` with `#f9a825` color) to visually distinguish warnings from non-existent cards
  - Propagated warning flag through component hierarchy (VocabularyCardType → SpanComponent → SpanMatchComponent)
- **Type definitions**: Updated ExtractedItem type to include optional `warning` property

## Implementation Details
- The duplicate detection checks if a card with the same German word prefix exists but with a different ID (avoiding false positives for the exact same card)
- Visual distinction: Non-existent cards show no outline, duplicates show orange outline, existing cards show primary color outline
- The warning is only triggered when `exists` is false but a similar word exists, preventing confusion with actual existing cards

https://claude.ai/code/session_01VSGBKR5isD2bEQo1BLiit5