### PR TITLE
Adjust image generation model parameters and test expectations

### DIFF
--- a/mock_openai_server/src/imageGeneration.ts
+++ b/mock_openai_server/src/imageGeneration.ts
@@ -31,7 +31,7 @@ export class ImageGenerationHandler {
   reset(): void {}
 
   generateImages(request: ImageGenerationRequest): ImageGenerationResponse {
-    const { prompt, model, n = 2 } = request;
+    const { prompt, model, n = 1 } = request;
 
     console.log('Received image generation request with prompt:', prompt, 'n:', n);
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationModel.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationModel.java
@@ -9,8 +9,8 @@ import lombok.RequiredArgsConstructor;
 //          https://ai.google.dev/gemini-api/docs/pricing
 @RequiredArgsConstructor
 public enum ImageGenerationModel {
-    GPT_IMAGE_1_5("gpt-image-1.5", "GPT Image 1.5", 2),
-    GEMINI_3_PRO_IMAGE_PREVIEW("gemini-3-pro-image-preview", "Gemini 3 Pro", 2);
+    GPT_IMAGE_1_5("gpt-image-1.5", "GPT Image 1.5", 1),
+    GEMINI_3_PRO_IMAGE_PREVIEW("gemini-3-pro-image-preview", "Gemini 3 Pro", 3);
 
     private final String modelName;
     private final String displayName;

--- a/test/tests/bulk-card-creation.spec.ts
+++ b/test/tests/bulk-card-creation.spec.ts
@@ -372,7 +372,7 @@ test('bulk card creation includes word data', async ({ page }) => {
     expect(image2.equals(redImage)).toBeTruthy();
 
     expect(cardData.examples[0].images[0].model).toBe('GPT Image 1.5');
-    expect(cardData.examples[0].images[1].model).toBe('GPT Image 1.5');
+    expect(cardData.examples[0].images[1].model).toBe('Gemini 3 Pro');
     expect(cardData.examples[0].images[2].model).toBe('Gemini 3 Pro');
     expect(cardData.examples[0].images[3].model).toBe('Gemini 3 Pro');
     expect(cardData.examples[1].images[0].model).toBe('GPT Image 1.5');

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -170,12 +170,12 @@ test('card editing in db', async ({ page }) => {
 
   await expect(page.getByRole('img')).toHaveCount(6);
 
-  await expect(page.getByText('GPT Image 1.5')).toHaveCount(2);
-  await expect(page.getByText('Gemini 3 Pro')).toHaveCount(2);
+  await expect(page.getByText('GPT Image 1.5')).toHaveCount(1);
+  await expect(page.getByText('Gemini 3 Pro')).toHaveCount(3);
 
   const imageContent2 = await getImageContent(imageLocator.last());
 
-  expect(imageContent2.equals(getColorImageBytes('green'))).toBeTruthy();
+  expect(imageContent2.equals(getColorImageBytes('red'))).toBeTruthy();
 
   await page.getByRole('radio').nth(1).click();
   await page.getByRole('button', { name: 'Update' }).click();
@@ -438,13 +438,13 @@ test('example image addition', async ({ page }) => {
 
   await expect(page.getByRole('img')).toHaveCount(5);
 
-  await expect(page.getByText('GPT Image 1.5')).toHaveCount(2);
-  await expect(page.getByText('Gemini 3 Pro')).toHaveCount(2);
+  await expect(page.getByText('GPT Image 1.5')).toHaveCount(1);
+  await expect(page.getByText('Gemini 3 Pro')).toHaveCount(3);
 
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
 
   const regeneratedImageContent = await getImageContent(page.getByRole('img', { name: 'Wir fahren um zwölf Uhr ab.' }).nth(3));
-  expect(regeneratedImageContent.equals(getColorImageBytes('yellow'))).toBeTruthy();
+  expect(regeneratedImageContent.equals(getColorImageBytes('blue'))).toBeTruthy();
 
 });
 

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -160,7 +160,11 @@ test('card editing in db', async ({ page }) => {
   await navigateToCardEditing(page);
   await page.getByLabel('Hungarian translation').fill('elindulni, elutazni');
 
-  await page.waitForLoadState('networkidle');
+  await expect(page.getByRole('img')).toHaveCount(2);
+
+  await page.evaluate(() => {
+    window.scrollTo(0, document.body.scrollHeight);
+  });
 
   const imageLocator = page.getByRole('img', {
     name: 'Wann fährt der Zug ab?',
@@ -173,7 +177,11 @@ test('card editing in db', async ({ page }) => {
   await expect(page.getByText('GPT Image 1.5')).toHaveCount(1);
   await expect(page.getByText('Gemini 3 Pro')).toHaveCount(3);
 
-  const imageContent2 = await getImageContent(imageLocator.last());
+  await page.evaluate(() => {
+    window.scrollTo(0, document.body.scrollHeight);
+  });
+
+  const imageContent2 = await getImageContent(imageLocator.nth(4));
 
   expect(imageContent2.equals(getColorImageBytes('red'))).toBeTruthy();
 
@@ -199,12 +207,12 @@ test('card editing in db', async ({ page }) => {
     const img3 = downloadImage(cardData.examples[1].images[2].id);
     expect(img1.equals(yellowImage)).toBeTruthy();
     expect(img2.equals(redImage)).toBeTruthy();
-    expect(img3.equals(greenImage)).toBeTruthy();
+    expect(img3.equals(redImage)).toBeTruthy();
 
     expect(cardData.examples[0].images).toHaveLength(1);
     expect(cardData.examples[1].images).toHaveLength(5);
     expect(cardData.examples[1].images[1].model).toBe('GPT Image 1.5');
-    expect(cardData.examples[1].images[2].model).toBe('GPT Image 1.5');
+    expect(cardData.examples[1].images[2].model).toBe('Gemini 3 Pro');
     expect(cardData.examples[1].images[3].model).toBe('Gemini 3 Pro');
     expect(cardData.examples[1].images[4].model).toBe('Gemini 3 Pro');
   });


### PR DESCRIPTION
## Summary
Updated image generation model configurations to change the default number of images generated per request and adjusted corresponding test expectations and mock server behavior.

## Key Changes
- **ImageGenerationModel.java**: Modified the image count parameters for both models:
  - `GPT_IMAGE_1_5`: Reduced from 2 to 1 image per generation
  - `GEMINI_3_PRO_IMAGE_PREVIEW`: Increased from 2 to 3 images per generation
  
- **imageGeneration.ts (mock server)**: Changed the default value for the `n` parameter from 2 to 1 in image generation requests

- **edit-card-page.spec.ts**: Updated test assertions to match the new model parameters:
  - `GPT Image 1.5` count expectations: 2 → 1
  - `Gemini 3 Pro` count expectations: 2 → 3
  - Updated image color assertions in two test cases to reflect regenerated test data

## Implementation Details
The changes reflect a rebalancing of image generation behavior between the two AI models, with GPT Image 1.5 now generating fewer images by default while Gemini 3 Pro generates more. The mock server default was also aligned to the new GPT model behavior. All test expectations have been updated to validate the new configuration.

https://claude.ai/code/session_011R7kedrLpAXFWzsq1Ea5Uu