### PR TITLE
Clean up non-favorite images from reviewed cards and compress uploads

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,7 @@
         "editorconfig.editorconfig",
         "esbenp.prettier-vscode",
         "anweber.vscode-httpyac",
-        "ms-kubernetes-tools.vscode-kubernetes-tools"
+        "ms-kubernetes-tools.vscode-kubernetes-tools",
+        "ms-playwright.playwright"
     ]
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -19,6 +18,8 @@ public interface CardRepository
     List<Card> findByIdInOrderByIdAsc(List<String> ids);
 
     List<Card> findByReadinessOrderByDueAsc(String readiness);
+
+    List<Card> findByReadinessIn(List<String> readinessList);
 
     @Query("SELECT c FROM Card c ORDER BY c.lastReview DESC")
     List<Card> findTopByOrderByLastReviewDesc(Pageable pageable);
@@ -41,45 +42,6 @@ public interface CardRepository
 
     boolean existsByIdStartingWithAndIdNot(String prefix, String id);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying
     void deleteBySource(Source source);
-
-    @Modifying(clearAutomatically = true)
-    @Transactional
-    @Query(value = """
-        UPDATE learn_language.cards
-        SET data = jsonb_set(
-          data,
-          '{examples}',
-          (
-            SELECT COALESCE(jsonb_agg(
-              CASE
-                WHEN elem->'images' IS NOT NULL THEN
-                  jsonb_set(
-                    elem,
-                    '{images}',
-                    COALESCE(
-                      (SELECT jsonb_agg(img)
-                        FROM jsonb_array_elements(elem->'images') AS img
-                        WHERE img->>'isFavorite' = 'true'),
-                      '[]'::jsonb
-                    )
-                  )
-                ELSE elem
-              END
-              ORDER BY idx
-            ), '[]'::jsonb)
-            FROM jsonb_array_elements(data->'examples') WITH ORDINALITY AS arr(elem, idx)
-          )
-        )
-        WHERE readiness IN ('REVIEWED', 'READY', 'KNOWN')
-          AND data->'examples' IS NOT NULL
-          AND EXISTS (
-            SELECT 1
-            FROM jsonb_array_elements(data->'examples') AS ex,
-                 LATERAL jsonb_array_elements(COALESCE(ex->'images', '[]'::jsonb)) AS img
-            WHERE img->>'isFavorite' IS DISTINCT FROM 'true'
-          )
-        """, nativeQuery = true)
-    int stripNonFavoriteImagesFromReviewedCards();
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/FileStorageCleanupService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/FileStorageCleanupService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 
 import io.github.mucsi96.learnlanguage.entity.Card;
 import io.github.mucsi96.learnlanguage.model.AudioData;
+import io.github.mucsi96.learnlanguage.model.ExampleData;
 import io.github.mucsi96.learnlanguage.model.ExampleImageData;
 import io.github.mucsi96.learnlanguage.repository.CardRepository;
 import io.github.mucsi96.learnlanguage.repository.DocumentRepository;
@@ -27,15 +28,58 @@ public class FileStorageCleanupService {
   private final CardRepository cardRepository;
   private final DocumentRepository documentRepository;
 
+  private static final Set<String> REVIEWED_STATES = Set.of("REVIEW", "RELEARNING");
+
   @EventListener(ApplicationReadyEvent.class)
   public void cleanupUnreferencedFiles() {
+    final var strippedCards = stripNonFavoriteImagesFromReviewedCards();
     final var deletedAudioFiles = cleanupAudioFiles();
     final var deletedImageFiles = cleanupImageFiles();
     final var deletedSourceFiles = cleanupSourceDocuments();
 
     log.info(
-        "File storage cleanup completed. Deleted {} audio files, {} image files, {} source documents",
-        deletedAudioFiles.size(), deletedImageFiles.size(), deletedSourceFiles.size());
+        "File storage cleanup completed. Stripped non-favorite images from {} cards. Deleted {} audio files, {} image files, {} source documents",
+        strippedCards, deletedAudioFiles.size(), deletedImageFiles.size(), deletedSourceFiles.size());
+  }
+
+  private long stripNonFavoriteImagesFromReviewedCards() {
+    final var cards = cardRepository.findAll();
+
+    final var cardsToUpdate = cards.stream()
+        .filter(card -> REVIEWED_STATES.contains(card.getState()))
+        .filter(card -> Optional.ofNullable(card.getData().getExamples())
+            .map(examples -> examples.stream()
+                .anyMatch(example -> Optional.ofNullable(example.getImages())
+                    .map(images -> images.stream()
+                        .anyMatch(img -> !Boolean.TRUE.equals(img.getIsFavorite())))
+                    .orElse(false)))
+            .orElse(false))
+        .toList();
+
+    cardsToUpdate.forEach(card -> {
+      final var updatedExamples = card.getData().getExamples().stream()
+          .map(example -> {
+            final var filteredImages = Optional.ofNullable(example.getImages())
+                .map(images -> images.stream()
+                    .filter(img -> Boolean.TRUE.equals(img.getIsFavorite()))
+                    .toList())
+                .orElse(null);
+            return ExampleData.builder()
+                .de(example.getDe())
+                .en(example.getEn())
+                .hu(example.getHu())
+                .ch(example.getCh())
+                .isSelected(example.getIsSelected())
+                .images(filteredImages)
+                .build();
+          })
+          .toList();
+      card.getData().setExamples(updatedExamples);
+      log.info("Stripping non-favorite images from reviewed card: {}", card.getData().getWord());
+    });
+
+    cardRepository.saveAll(cardsToUpdate);
+    return cardsToUpdate.size();
   }
 
   private List<String> cleanupAudioFiles() {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/FileStorageCleanupService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/FileStorageCleanupService.java
@@ -28,7 +28,7 @@ public class FileStorageCleanupService {
   private final CardRepository cardRepository;
   private final DocumentRepository documentRepository;
 
-  private static final Set<String> REVIEWED_STATES = Set.of("REVIEW", "RELEARNING");
+  private static final Set<String> REVIEWED_READINESS = Set.of("REVIEWED", "READY", "KNOWN");
 
   @EventListener(ApplicationReadyEvent.class)
   public void cleanupUnreferencedFiles() {
@@ -46,7 +46,7 @@ public class FileStorageCleanupService {
     final var cards = cardRepository.findAll();
 
     final var cardsToUpdate = cards.stream()
-        .filter(card -> REVIEWED_STATES.contains(card.getState()))
+        .filter(card -> REVIEWED_READINESS.contains(card.getReadiness()))
         .filter(card -> Optional.ofNullable(card.getData().getExamples())
             .map(examples -> examples.stream()
                 .anyMatch(example -> Optional.ofNullable(example.getImages())

--- a/test/tests/bulk-card-creation.spec.ts
+++ b/test/tests/bulk-card-creation.spec.ts
@@ -7,8 +7,7 @@ import {
   scrollElementToTop,
   withDbConnection,
   downloadImage,
-  yellowImage,
-  redImage,
+  isJpeg,
   menschenA1Image,
   ensureTimezoneAware,
   setupDefaultChatModelSettings,
@@ -368,8 +367,8 @@ test('bulk card creation includes word data', async ({ page }) => {
 
     const image1 = downloadImage(cardData.examples[0].images[0].id);
     const image2 = downloadImage(cardData.examples[1].images[0].id);
-    expect(image1.equals(yellowImage)).toBeTruthy();
-    expect(image2.equals(redImage)).toBeTruthy();
+    expect(isJpeg(image1)).toBeTruthy();
+    expect(isJpeg(image2)).toBeTruthy();
 
     expect(cardData.examples[0].images[0].model).toBe('GPT Image 1.5');
     expect(cardData.examples[0].images[1].model).toBe('Gemini 3 Pro');

--- a/test/tests/bulk-card-creation.spec.ts
+++ b/test/tests/bulk-card-creation.spec.ts
@@ -7,7 +7,7 @@ import {
   scrollElementToTop,
   withDbConnection,
   downloadImage,
-  isJpeg,
+  getImageColor,
   menschenA1Image,
   ensureTimezoneAware,
   setupDefaultChatModelSettings,
@@ -367,8 +367,8 @@ test('bulk card creation includes word data', async ({ page }) => {
 
     const image1 = downloadImage(cardData.examples[0].images[0].id);
     const image2 = downloadImage(cardData.examples[1].images[0].id);
-    expect(isJpeg(image1)).toBeTruthy();
-    expect(isJpeg(image2)).toBeTruthy();
+    expect(await getImageColor(page, image1)).toBe('yellow');
+    expect(await getImageColor(page, image2)).toBe('red');
 
     expect(cardData.examples[0].images[0].model).toBe('GPT Image 1.5');
     expect(cardData.examples[0].images[1].model).toBe('Gemini 3 Pro');

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '../fixtures';
 import {
   createCard,
   downloadImage,
-  isJpeg,
+  getImageColor,
   getColorImageBytes,
   getImageContent,
   withDbConnection,
@@ -184,7 +184,7 @@ test('card editing in db', async ({ page }) => {
 
   const imageContent2 = await getImageContent(imageLocator.nth(4));
 
-  expect(isJpeg(imageContent2)).toBeTruthy();
+  expect(await getImageColor(page, imageContent2)).toBe('red');
 
   await page.getByRole('radio').nth(1).click();
   await page.getByRole('button', { name: 'Update' }).click();
@@ -207,8 +207,8 @@ test('card editing in db', async ({ page }) => {
     const img2 = downloadImage(cardData.examples[1].images[1].id);
     const img3 = downloadImage(cardData.examples[1].images[2].id);
     expect(img1.equals(yellowImage)).toBeTruthy();
-    expect(isJpeg(img2)).toBeTruthy();
-    expect(isJpeg(img3)).toBeTruthy();
+    expect(await getImageColor(page, img2)).toBe('red');
+    expect(await getImageColor(page, img3)).toBe('red');
 
     expect(cardData.examples[0].images).toHaveLength(1);
     expect(cardData.examples[1].images).toHaveLength(5);
@@ -453,7 +453,7 @@ test('example image addition', async ({ page }) => {
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
 
   const regeneratedImageContent = await getImageContent(page.getByRole('img', { name: 'Wir fahren um zwölf Uhr ab.' }).nth(3));
-  expect(isJpeg(regeneratedImageContent)).toBeTruthy();
+  expect(await getImageColor(page, regeneratedImageContent)).toBe('blue');
 
 });
 

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '../fixtures';
 import {
   createCard,
   downloadImage,
+  isJpeg,
   getColorImageBytes,
   getImageContent,
   withDbConnection,
@@ -183,7 +184,7 @@ test('card editing in db', async ({ page }) => {
 
   const imageContent2 = await getImageContent(imageLocator.nth(4));
 
-  expect(imageContent2.equals(getColorImageBytes('red'))).toBeTruthy();
+  expect(isJpeg(imageContent2)).toBeTruthy();
 
   await page.getByRole('radio').nth(1).click();
   await page.getByRole('button', { name: 'Update' }).click();
@@ -206,8 +207,8 @@ test('card editing in db', async ({ page }) => {
     const img2 = downloadImage(cardData.examples[1].images[1].id);
     const img3 = downloadImage(cardData.examples[1].images[2].id);
     expect(img1.equals(yellowImage)).toBeTruthy();
-    expect(img2.equals(redImage)).toBeTruthy();
-    expect(img3.equals(redImage)).toBeTruthy();
+    expect(isJpeg(img2)).toBeTruthy();
+    expect(isJpeg(img3)).toBeTruthy();
 
     expect(cardData.examples[0].images).toHaveLength(1);
     expect(cardData.examples[1].images).toHaveLength(5);
@@ -452,7 +453,7 @@ test('example image addition', async ({ page }) => {
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
 
   const regeneratedImageContent = await getImageContent(page.getByRole('img', { name: 'Wir fahren um zwölf Uhr ab.' }).nth(3));
-  expect(regeneratedImageContent.equals(getColorImageBytes('blue'))).toBeTruthy();
+  expect(isJpeg(regeneratedImageContent)).toBeTruthy();
 
 });
 

--- a/test/tests/file-storage-cleanup.spec.ts
+++ b/test/tests/file-storage-cleanup.spec.ts
@@ -5,7 +5,9 @@ import {
   STORAGE_DIR,
   createCard,
   yellowImage,
+  redImage,
   germanAudioSample,
+  withDbConnection,
 } from '../utils';
 
 function writeStorageFile(relativePath: string, data: Buffer): void {
@@ -105,4 +107,96 @@ test('deletes unreferenced source documents on cleanup', async ({ page }) => {
   expect(storageFileExists('sources/Goethe-Zertifikat_A2_Wortliste.pdf')).toBe(true);
   expect(storageFileExists('sources/Goethe-Zertifikat_B1_Wortliste.pdf')).toBe(true);
   expect(storageFileExists('sources/orphan-document.pdf')).toBe(false);
+});
+
+test('strips non-favorite images from reviewed cards and deletes their files', async ({ page }) => {
+  const favoriteImageId = 'fav-image-1';
+  const nonFavoriteImageId = 'non-fav-image-1';
+
+  await createCard({
+    cardId: 'reviewed-card-with-images',
+    sourceId: 'goethe-a1',
+    readiness: 'REVIEWED',
+    data: {
+      word: 'Schule',
+      type: 'NOUN',
+      translation: { en: 'school', hu: 'iskola' },
+      forms: [],
+      examples: [
+        {
+          de: 'Die Schule ist groß.',
+          en: 'The school is big.',
+          hu: 'Az iskola nagy.',
+          isSelected: true,
+          images: [
+            { id: favoriteImageId, isFavorite: true },
+            { id: nonFavoriteImageId },
+          ],
+        },
+      ],
+    },
+  });
+
+  writeStorageFile(`images/${favoriteImageId}.jpg`, yellowImage);
+  writeStorageFile(`images/${nonFavoriteImageId}.jpg`, redImage);
+
+  await triggerCleanup();
+
+  expect(storageFileExists(`images/${favoriteImageId}.jpg`)).toBe(true);
+  expect(storageFileExists(`images/${nonFavoriteImageId}.jpg`)).toBe(false);
+
+  await withDbConnection(async (client) => {
+    const result = await client.query(
+      "SELECT data FROM learn_language.cards WHERE id = 'reviewed-card-with-images'"
+    );
+    const cardData = result.rows[0].data;
+    expect(cardData.examples[0].images).toHaveLength(1);
+    expect(cardData.examples[0].images[0].id).toBe(favoriteImageId);
+    expect(cardData.examples[0].images[0].isFavorite).toBe(true);
+  });
+});
+
+test('preserves non-favorite images on in-review cards', async ({ page }) => {
+  const favoriteImageId = 'fav-image-2';
+  const nonFavoriteImageId = 'non-fav-image-2';
+
+  await createCard({
+    cardId: 'in-review-card-with-images',
+    sourceId: 'goethe-a1',
+    readiness: 'IN_REVIEW',
+    data: {
+      word: 'Buch',
+      type: 'NOUN',
+      translation: { en: 'book', hu: 'könyv' },
+      forms: [],
+      examples: [
+        {
+          de: 'Das Buch ist interessant.',
+          en: 'The book is interesting.',
+          hu: 'A könyv érdekes.',
+          isSelected: true,
+          images: [
+            { id: favoriteImageId, isFavorite: true },
+            { id: nonFavoriteImageId },
+          ],
+        },
+      ],
+    },
+  });
+
+  writeStorageFile(`images/${favoriteImageId}.jpg`, yellowImage);
+  writeStorageFile(`images/${nonFavoriteImageId}.jpg`, redImage);
+
+  await triggerCleanup();
+
+  expect(storageFileExists(`images/${favoriteImageId}.jpg`)).toBe(true);
+  expect(storageFileExists(`images/${nonFavoriteImageId}.jpg`)).toBe(true);
+
+  await withDbConnection(async (client) => {
+    const result = await client.query(
+      "SELECT data FROM learn_language.cards WHERE id = 'in-review-card-with-images'"
+    );
+    const cardData = result.rows[0].data;
+    expect(cardData.examples[0].images).toHaveLength(2);
+  });
 });

--- a/test/tests/file-storage-cleanup.spec.ts
+++ b/test/tests/file-storage-cleanup.spec.ts
@@ -87,7 +87,7 @@ test('deletes unreferenced image files on cleanup', async ({ page }) => {
           en: 'The tree is big.',
           hu: 'A fa nagy.',
           isSelected: true,
-          images: [{ id: referencedImageId }],
+          images: [{ id: referencedImageId, isFavorite: true }],
         },
       ],
     },

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -507,6 +507,10 @@ export function downloadImage(id: string): Buffer {
   return fs.readFileSync(imagePath);
 }
 
+export function isJpeg(data: Buffer): boolean {
+  return data.length > 2 && data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff;
+}
+
 export function downloadAudio(id: string): Buffer {
   const audioPath = path.join(STORAGE_DIR, 'audio', `${id}.mp3`);
 


### PR DESCRIPTION
## Summary
This PR improves image management by automatically removing non-favorite images from reviewed cards during startup and compressing all uploaded images to a maximum dimension of 1200x1200 pixels.

## Key Changes
- **FileStorageCleanupService**: Added `stripNonFavoriteImagesFromReviewedCards()` method that runs on application startup to remove non-favorite images from cards with "REVIEWED", "READY", or "KNOWN" status
  - Filters cards that have examples with non-favorite images
  - Rebuilds example data with only favorite images retained
  - Logs the number of cards processed and specific card words being updated
  
- **ImageController**: Added image compression during upload
  - Introduced `MAX_IMAGE_DIMENSION` constant set to 1200 pixels
  - Images are now resized before being saved to storage
  - Includes error handling for compression failures

## Implementation Details
- The cleanup service uses a multi-level stream filter to identify cards needing updates, avoiding unnecessary processing
- Image compression is applied to all newly uploaded images regardless of source
- Non-favorite image stripping only applies to cards in reviewed/ready/known states, preserving images in other card states

https://claude.ai/code/session_012mTDkB8d77xEqZnTFF3Lr6