### PR TITLE
Allow restricted HTTP headers in Java HTTP client

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -32,4 +32,4 @@ COPY --from=build ${DEPENDENCY}/BOOT-INF/classes /app
 ENV SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}
 
 # Run the application
-ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-cp", "app:app/lib/*", "io.github.mucsi96.learnlanguage.LearnLanguageApplication"]
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-Djdk.httpclient.allowRestrictedHeaders=content-length", "-cp", "app:app/lib/*", "io.github.mucsi96.learnlanguage.LearnLanguageApplication"]


### PR DESCRIPTION
## Summary
Added JVM flag to allow the restricted HTTP header `content-length` to be set by the application when using Java's HTTP client.

## Key Changes
- Added `-Djdk.httpclient.allowRestrictedHeaders=content-length` JVM argument to the Docker entrypoint
- This enables the application to explicitly set the `content-length` header in HTTP requests, which is normally restricted by the Java HTTP client for security reasons

## Implementation Details
The Java HTTP client (`java.net.http.HttpClient`) restricts certain headers by default for security purposes. By setting this JVM property, we allow the application to override this restriction specifically for the `content-length` header, which may be necessary for certain HTTP communication scenarios or compatibility with specific APIs.

https://claude.ai/code/session_01BmqvfgUkugsZCSTSuzZUx3