### PR TITLE
Remove image resizing and JPG-to-WebP migration features

### DIFF
--- a/client/src/app/api-tokens/api-tokens.component.css
+++ b/client/src/app/api-tokens/api-tokens.component.css
@@ -30,40 +30,6 @@ mat-card-header {
   flex: 1;
 }
 
-.new-token-banner {
-  background: var(--mat-sys-surface-container);
-  border-radius: 12px;
-  padding: 16px;
-  margin-bottom: 16px;
-}
-
-.new-token-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 12px;
-  font-size: 14px;
-  color: var(--mat-sys-on-surface-variant);
-}
-
-.new-token-value {
-  background: var(--mat-sys-surface);
-  border-radius: 8px;
-  padding: 12px;
-  margin-bottom: 12px;
-  overflow-x: auto;
-}
-
-.new-token-value code {
-  font-size: 13px;
-  word-break: break-all;
-}
-
-.new-token-actions {
-  display: flex;
-  gap: 8px;
-}
-
 .tokens-list {
   max-height: 400px;
   overflow-y: auto;

--- a/client/src/app/api-tokens/api-tokens.component.html
+++ b/client/src/app/api-tokens/api-tokens.component.html
@@ -38,37 +38,6 @@
           </button>
         </div>
 
-        @if (newToken()) {
-        <div class="new-token-banner" role="alert" aria-label="New token">
-          <div class="new-token-header">
-            <mat-icon>info</mat-icon>
-            <span
-              >Copy this token now. It will not be shown again.</span
-            >
-          </div>
-          <div class="new-token-value">
-            <code>{{ newToken() }}</code>
-          </div>
-          <div class="new-token-actions">
-            <button
-              mat-flat-button
-              (click)="copyToken()"
-              aria-label="Copy token"
-            >
-              <mat-icon>content_copy</mat-icon>
-              Copy
-            </button>
-            <button
-              mat-button
-              (click)="dismissToken()"
-              aria-label="Dismiss token"
-            >
-              Dismiss
-            </button>
-          </div>
-        </div>
-        }
-
         @if (tokens.isLoading()) {
         <mat-list class="tokens-list">
           @for (row of skeletonRows; track $index) {

--- a/client/src/app/api-tokens/api-tokens.component.ts
+++ b/client/src/app/api-tokens/api-tokens.component.ts
@@ -63,7 +63,7 @@ export class ApiTokensComponent {
     const url = URL.createObjectURL(blob);
     const anchor = document.createElement('a');
     anchor.href = url;
-    anchor.download = 'learn-language.token';
+    anchor.download = 'ai-dictionary.token';
     anchor.click();
     URL.revokeObjectURL(url);
   }

--- a/client/src/app/api-tokens/api-tokens.component.ts
+++ b/client/src/app/api-tokens/api-tokens.component.ts
@@ -63,7 +63,7 @@ export class ApiTokensComponent {
     const url = URL.createObjectURL(blob);
     const anchor = document.createElement('a');
     anchor.href = url;
-    anchor.download = `${name}.token`;
+    anchor.download = 'learn-language.token';
     anchor.click();
     URL.revokeObjectURL(url);
   }

--- a/test/tests/dictionary.spec.ts
+++ b/test/tests/dictionary.spec.ts
@@ -13,7 +13,7 @@ async function createTokenViaUI(page: Page, name: string): Promise<string> {
   await page.getByRole('button', { name: 'Generate token' }).click();
 
   const download = await downloadPromise;
-  expect(download.suggestedFilename()).toBe('learn-language.token');
+  expect(download.suggestedFilename()).toBe('ai-dictionary.token');
   const filePath = await download.path();
   return fs.readFileSync(filePath!, 'utf-8');
 }

--- a/test/tests/dictionary.spec.ts
+++ b/test/tests/dictionary.spec.ts
@@ -13,7 +13,7 @@ async function createTokenViaUI(page: Page, name: string): Promise<string> {
   await page.getByRole('button', { name: 'Generate token' }).click();
 
   const download = await downloadPromise;
-  expect(download.suggestedFilename()).toBe(`${name}.token`);
+  expect(download.suggestedFilename()).toBe('learn-language.token');
   const filePath = await download.path();
   return fs.readFileSync(filePath!, 'utf-8');
 }

--- a/test/tests/dictionary.spec.ts
+++ b/test/tests/dictionary.spec.ts
@@ -1,4 +1,5 @@
 import { type Page } from '@playwright/test';
+import * as fs from 'fs';
 import { test, expect } from '../fixtures';
 import { setupDefaultChatModelSettings } from '../utils';
 
@@ -7,12 +8,14 @@ const API_URL = 'http://localhost:8180/api/dictionary';
 async function createTokenViaUI(page: Page, name: string): Promise<string> {
   await page.goto('http://localhost:8180/settings/api-tokens');
   await page.getByLabel('Token name').fill(name);
+
+  const downloadPromise = page.waitForEvent('download');
   await page.getByRole('button', { name: 'Generate token' }).click();
 
-  const alert = page.getByRole('alert', { name: 'New token' });
-  await expect(alert).toBeVisible();
-  const token = await alert.locator('code').textContent();
-  return token!;
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toBe(`${name}.token`);
+  const filePath = await download.path();
+  return fs.readFileSync(filePath!, 'utf-8');
 }
 
 test('dictionary endpoint translates a word to Hungarian', async ({ page }) => {

--- a/test/tests/file-storage-cleanup.spec.ts
+++ b/test/tests/file-storage-cleanup.spec.ts
@@ -8,10 +8,6 @@ import {
   redImage,
   germanAudioSample,
   withDbConnection,
-  createColorJpeg,
-  getImageDimensions,
-  getImageColor,
-  downloadImage,
 } from '../utils';
 
 function writeStorageFile(relativePath: string, data: Buffer): void {
@@ -158,52 +154,6 @@ test('strips non-favorite images from reviewed cards and deletes their files', a
     expect(cardData.examples[0].images[0].id).toBe(favoriteImageId);
     expect(cardData.examples[0].images[0].isFavorite).toBe(true);
   });
-});
-
-test('resizes oversized images on cleanup', async ({ page }) => {
-  const oversizedImageId = 'oversized-image-1';
-  const normalImageId = 'normal-image-1';
-
-  await createCard({
-    cardId: 'card-with-oversized-image',
-    sourceId: 'goethe-a1',
-    data: {
-      word: 'Haus',
-      type: 'NOUN',
-      translation: { en: 'house', hu: 'ház' },
-      forms: [],
-      examples: [
-        {
-          de: 'Das Haus ist groß.',
-          en: 'The house is big.',
-          hu: 'A ház nagy.',
-          isSelected: true,
-          images: [
-            { id: oversizedImageId, isFavorite: true },
-            { id: normalImageId },
-          ],
-        },
-      ],
-    },
-  });
-
-  const oversizedImage = await createColorJpeg(page, 'yellow', 2000, 1500);
-  writeStorageFile(`images/${oversizedImageId}.webp`, oversizedImage);
-  writeStorageFile(`images/${normalImageId}.webp`, yellowImage);
-
-  const beforeSize = fs.statSync(path.join(STORAGE_DIR, `images/${oversizedImageId}.webp`)).size;
-
-  await triggerCleanup();
-
-  const afterData = downloadImage(oversizedImageId);
-  const afterSize = afterData.length;
-  expect(afterSize).toBeLessThan(beforeSize);
-
-  const dimensions = await getImageDimensions(page, afterData);
-  expect(dimensions.width).toBeLessThanOrEqual(1200);
-  expect(dimensions.height).toBeLessThanOrEqual(1200);
-
-  expect(await getImageColor(page, afterData)).toBe('yellow');
 });
 
 test('preserves non-favorite images on in-review cards', async ({ page }) => {


### PR DESCRIPTION
## Summary
This PR removes the image resizing and JPG-to-WebP migration functionality from the file storage cleanup service, and updates the API token generation to download tokens as files instead of displaying them in a banner.

## Key Changes

### Backend (Java)
- Removed `resizeOversizedImages()` method that automatically resized images exceeding 1200px dimensions
- Removed `migrateJpgToWebp()` method that converted JPG images to WebP format
- Removed calls to both methods from the `cleanupUnreferencedFiles()` event listener
- Removed unused imports: `ByteArrayInputStream`, `ImageIO`, `BinaryData`
- Removed `ImageResizeService` dependency injection
- Removed `MAX_IMAGE_DIMENSION` constant

### Frontend (Angular)
- **API Tokens Component**: Changed token creation UX from displaying token in an on-screen banner to automatically downloading it as a file
  - Removed `newToken` signal and related UI elements (banner, copy button, dismiss button)
  - Removed `MatSnackBarModule` dependency
  - Replaced `copyToken()` and `dismissToken()` methods with `downloadTokenFile()` that creates and downloads a text file named `ai-dictionary.token`
  - Token is now immediately downloaded upon creation instead of being displayed for manual copying

### Tests
- Removed test case for image resizing functionality (`resizes oversized images on cleanup`)
- Removed test utilities: `createColorJpeg`, `getImageDimensions`, `getImageColor`, `downloadImage`
- Updated `dictionary.spec.ts` to handle token download via file instead of reading from UI banner

## Implementation Details
- The token file download uses the Blob API and creates a temporary object URL for download
- The downloaded file is always named `ai-dictionary.token` regardless of the token name provided
- This change improves security by not keeping the token visible in the UI after generation

https://claude.ai/code/session_01CqeSbmuAZVqcAVAVWDVLTD