### PR TITLE
Replace Unicode markers with readable placeholders in dictionary formatting

### DIFF
--- a/koreader-plugin/ai-dictionary.koplugin/main.lua
+++ b/koreader-plugin/ai-dictionary.koplugin/main.lua
@@ -123,6 +123,7 @@ function AIDictionary:init()
             enabled = true,
             callback = function()
                 local selected_text = tostring(this.selected_text.text)
+                this:saveHighlight(true)
                 this:onClose()
                 self:lookup(selected_text)
             end,

--- a/koreader-plugin/ai-dictionary.koplugin/main.lua
+++ b/koreader-plugin/ai-dictionary.koplugin/main.lua
@@ -123,7 +123,7 @@ function AIDictionary:init()
             enabled = true,
             callback = function()
                 local selected_text = tostring(this.selected_text.text)
-                this:saveHighlight(true)
+                this:saveHighlight()
                 this:onClose()
                 self:lookup(selected_text)
             end,

--- a/mock_google_ai_server/src/data.ts
+++ b/mock_google_ai_server/src/data.ts
@@ -223,22 +223,22 @@ export const GRAMMAR_SENTENCE_LISTS: Record<string, string[]> = {
 export const DICTIONARY_LOOKUPS: Record<string, Record<string, string>> = {
   hu: {
     fahren: [
-      '\uFFF1\uFFF2abfahren  \uFFF2VERB\uFFF3\uFFF3',
-      '\uFFF2Forms: \uFFF3fährt ab, fuhr ab, ist abgefahren',
-      '\uFFF2Translation (hu): \uFFF3elindulni, elhagyni',
+      '<<H>><<B>>abfahren  <<B>>VERB<</B>><</B>>',
+      '<<B>>Forms: <</B>>fährt ab, fuhr ab, ist abgefahren',
+      '<<B>>Translation (hu): <</B>>elindulni, elhagyni',
       '',
-      '\uFFF2Example (de): \uFFF3Wir fahren ab.',
-      '\uFFF2Example (hu): \uFFF3Elindulunk.',
+      '<<B>>Example (de): <</B>>Wir fahren ab.',
+      '<<B>>Example (hu): <</B>>Elindulunk.',
     ].join('\n'),
   },
   en: {
     fahren: [
-      '\uFFF1\uFFF2abfahren  \uFFF2VERB\uFFF3\uFFF3',
-      '\uFFF2Forms: \uFFF3fährt ab, fuhr ab, ist abgefahren',
-      '\uFFF2Translation (en): \uFFF3to depart, to leave',
+      '<<H>><<B>>abfahren  <<B>>VERB<</B>><</B>>',
+      '<<B>>Forms: <</B>>fährt ab, fuhr ab, ist abgefahren',
+      '<<B>>Translation (en): <</B>>to depart, to leave',
       '',
-      '\uFFF2Example (de): \uFFF3Wir fahren ab.',
-      '\uFFF2Example (en): \uFFF3We depart.',
+      '<<B>>Example (de): <</B>>Wir fahren ab.',
+      '<<B>>Example (en): <</B>>We depart.',
     ].join('\n'),
   },
 };

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/DictionaryService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/DictionaryService.java
@@ -47,11 +47,20 @@ public class DictionaryService {
 
         final String userMessage = jsonMapper.writeValueAsString(input);
 
-        return chatService.callForTextWithLogging(
+        final String rawResponse = chatService.callForTextWithLogging(
                 model,
                 OperationType.TRANSLATION,
                 systemPrompt,
                 userMessage);
+
+        return replacePlaceholdersWithUnicode(rawResponse);
+    }
+
+    private String replacePlaceholdersWithUnicode(String text) {
+        return text
+                .replace("<<H>>", "\uFFF1")
+                .replace("<<B>>", "\uFFF2")
+                .replace("<</B>>", "\uFFF3");
     }
 
     private ChatModel resolveModel() {
@@ -91,35 +100,35 @@ public class DictionaryService {
 
                 Use the book title and author as context for appropriate register and style.
 
-                You must format the output as plain text using these special Unicode markers:
-                - \\uFFF1 = header line marker (place at the very start of the first line)
-                - \\uFFF2 = bold start
-                - \\uFFF3 = bold end
+                You must format the output as plain text using these special markers:
+                - <<H>> = header line marker (place at the very start of the first line)
+                - <<B>> = bold start
+                - <</B>> = bold end
 
                 Return exactly this format (each item on its own line, no blank lines except before the example block):
 
                 For verbs:
-                \\uFFF1\\uFFF2WORD  \\uFFF2WORD_TYPE\\uFFF3\\uFFF3
-                \\uFFF2Forms: \\uFFF3form1, form2, form3
-                \\uFFF2Translation (%2$s): \\uFFF3translation
+                <<H>><<B>>WORD  <<B>>WORD_TYPE<</B>><</B>>
+                <<B>>Forms: <</B>>form1, form2, form3
+                <<B>>Translation (%2$s): <</B>>translation
 
-                \\uFFF2Example (de): \\uFFF3German example sentence
-                \\uFFF2Example (%2$s): \\uFFF3Translated example sentence
+                <<B>>Example (de): <</B>>German example sentence
+                <<B>>Example (%2$s): <</B>>Translated example sentence
 
                 For nouns:
-                \\uFFF1\\uFFF2WORD  \\uFFF2NOUN\\uFFF3 (GENDER)\\uFFF3
-                \\uFFF2Forms: \\uFFF3plural form
-                \\uFFF2Translation (%2$s): \\uFFF3translation
+                <<H>><<B>>WORD  <<B>>NOUN<</B>> (GENDER)<</B>>
+                <<B>>Forms: <</B>>plural form
+                <<B>>Translation (%2$s): <</B>>translation
 
-                \\uFFF2Example (de): \\uFFF3German example sentence
-                \\uFFF2Example (%2$s): \\uFFF3Translated example sentence
+                <<B>>Example (de): <</B>>German example sentence
+                <<B>>Example (%2$s): <</B>>Translated example sentence
 
                 For other word types (no forms line):
-                \\uFFF1\\uFFF2WORD  \\uFFF2WORD_TYPE\\uFFF3\\uFFF3
-                \\uFFF2Translation (%2$s): \\uFFF3translation
+                <<H>><<B>>WORD  <<B>>WORD_TYPE<</B>><</B>>
+                <<B>>Translation (%2$s): <</B>>translation
 
-                \\uFFF2Example (de): \\uFFF3German example sentence
-                \\uFFF2Example (%2$s): \\uFFF3Translated example sentence
+                <<B>>Example (de): <</B>>German example sentence
+                <<B>>Example (%2$s): <</B>>Translated example sentence
 
                 Do not include any other text, explanation, or markdown. Only the formatted output.
                 """


### PR DESCRIPTION
## Summary
This PR refactors the dictionary lookup formatting system to use human-readable placeholder markers instead of raw Unicode characters, improving code maintainability and readability.

## Key Changes
- **DictionaryService**: 
  - Extracted Unicode replacement logic into a new `replacePlaceholdersWithUnicode()` method
  - Updated the system prompt to use readable placeholders (`<<H>>`, `<<B>>`, `<</B>>`) instead of Unicode escape sequences (`\uFFF1`, `\uFFF2`, `\uFFF3`)
  - The method converts placeholders to their corresponding Unicode characters after receiving the response from the chat service

- **Mock Data**: Updated test data in `mock_google_ai_server` to use the new placeholder format for consistency

- **KOReader Plugin**: Added `this:saveHighlight(true)` call when a dictionary lookup is triggered to preserve the user's text selection

## Implementation Details
The placeholder-to-Unicode conversion happens at the service layer, allowing:
- The AI model to work with human-readable markers in prompts
- Cleaner, more maintainable prompt templates
- Consistent formatting across the application
- Easier debugging and testing of prompt formatting

https://claude.ai/code/session_0159rEnNd5Hp7XcZvayBiv1a