### PR TITLE
Add candidate card ID generation and status tracking for highlights

### DIFF
--- a/client/src/app/highlights/highlights.component.ts
+++ b/client/src/app/highlights/highlights.component.ts
@@ -43,6 +43,14 @@ interface TranslationResponse {
   examples: string[];
 }
 
+const CARD_STATUS_COLORS: Record<string, string> = {
+  EXISTS: '#4CAF50',
+  NEW: '#2196F3',
+};
+
+const badgeHtml = (label: string, color: string): string =>
+  `<span style="padding:1px 6px;border-radius:4px;font-size:0.7rem;font-weight:500;color:${color};background-color:${color}20;border:1px solid ${color}40">${label}</span>`;
+
 ModuleRegistry.registerModules([
   ClientSideRowModelModule,
   ValidationModule,
@@ -118,6 +126,30 @@ export class HighlightsComponent {
       resizable: false,
       cellRenderer: SelectionCheckboxComponent,
       headerComponent: SelectAllHeaderComponent,
+    },
+    {
+      headerName: 'Card ID',
+      field: 'candidateCardId',
+      flex: 1,
+      sortable: true,
+      cellRenderer: (params: { value: string | null }) => {
+        if (!params.value) return '<span style="color:hsl(220,13%,40%);font-size:0.75rem">-</span>';
+        return `<span style="color:hsl(220,13%,60%);font-size:0.75rem">${params.value}</span>`;
+      },
+    },
+    {
+      headerName: 'Status',
+      field: 'cardExists',
+      width: 100,
+      sortable: true,
+      cellRenderer: (params: { data: Highlight | undefined }) => {
+        if (!params.data?.candidateCardId) return '';
+        const exists = params.data.cardExists;
+        return badgeHtml(
+          exists ? 'EXISTS' : 'NEW',
+          exists ? CARD_STATUS_COLORS['EXISTS'] : CARD_STATUS_COLORS['NEW']
+        );
+      },
     },
     {
       headerName: 'Word',

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -240,6 +240,8 @@ export type ImageSource = {
 
 export type Highlight = {
   id: number;
+  candidateCardId: string | null;
+  cardExists: boolean;
   highlightedWord: string;
   sentence: string;
   createdAt: string;

--- a/mock_anthropic_server/src/chatHandler.ts
+++ b/mock_anthropic_server/src/chatHandler.ts
@@ -1,5 +1,5 @@
 import { ClaudeRequest } from './types';
-import { WORD_LISTS, TRANSLATIONS, WORD_TYPES, GENDERS, SENTENCE_LISTS, GRAMMAR_SENTENCE_LISTS, SENTENCE_TRANSLATIONS } from './data';
+import { WORD_LISTS, TRANSLATIONS, WORD_TYPES, GENDERS, SENTENCE_LISTS, GRAMMAR_SENTENCE_LISTS, SENTENCE_TRANSLATIONS, NORMALIZATIONS } from './data';
 import { messagesMatch, createClaudeResponse } from './utils';
 import { imageRequestMatch } from './ocr';
 
@@ -162,6 +162,20 @@ export class ChatHandler {
     return null;
   }
 
+  handleNormalization(request: ClaudeRequest): any | null {
+    if (!messagesMatch(request, 'normalize an inflected German word', '')) {
+      return null;
+    }
+
+    for (const word of Object.keys(NORMALIZATIONS)) {
+      if (messagesMatch(request, 'normalize an inflected German word', word)) {
+        return createClaudeResponse(NORMALIZATIONS[word]);
+      }
+    }
+
+    return null;
+  }
+
   handleSentenceTranslation(request: ClaudeRequest): any | null {
     const systemContent = request.system || '';
 
@@ -206,6 +220,9 @@ export class ChatHandler {
 
     const wordListResponse = await this.handleWordListExtraction(request);
     if (wordListResponse) return wordListResponse;
+
+    const normalizationResponse = this.handleNormalization(request);
+    if (normalizationResponse) return normalizationResponse;
 
     const translationResponse = this.handleTranslation(request);
     if (translationResponse) return translationResponse;

--- a/mock_anthropic_server/src/data.ts
+++ b/mock_anthropic_server/src/data.ts
@@ -188,6 +188,11 @@ export const GRAMMAR_SENTENCE_LISTS: Record<string, string[]> = {
   ],
 };
 
+export const NORMALIZATIONS: Record<string, { normalizedWord: string; forms: string[] }> = {
+  fahren: { normalizedWord: 'abfahren', forms: ['fährt ab', 'fuhr ab', 'abgefahren'] },
+  Haus: { normalizedWord: 'Haus', forms: ['die Häuser'] },
+};
+
 export const SENTENCE_TRANSLATIONS: Record<string, Record<string, string>> = {
   hungarian: {
     'Hören Sie.': 'Hallgasson.',

--- a/mock_google_ai_server/src/chatHandler.ts
+++ b/mock_google_ai_server/src/chatHandler.ts
@@ -8,6 +8,7 @@ import {
   SENTENCE_TRANSLATIONS,
   GRAMMAR_SENTENCE_LISTS,
   DICTIONARY_LOOKUPS,
+  NORMALIZATIONS,
 } from './data';
 import { messagesMatch, createGeminiResponse } from './utils';
 import { imageRequestMatch } from './ocr';
@@ -226,6 +227,23 @@ export class ChatHandler {
     return null;
   }
 
+  handleNormalization(request: GeminiRequest): any | null {
+    const systemContent = request.systemInstruction?.parts?.[0]?.text || '';
+    const userContent = getTextContent(request);
+
+    if (!systemContent.includes('normalize an inflected German word')) {
+      return null;
+    }
+
+    for (const word of Object.keys(NORMALIZATIONS)) {
+      if (userContent.includes(word)) {
+        return createGeminiResponse(NORMALIZATIONS[word]);
+      }
+    }
+
+    return null;
+  }
+
   handleSentenceTranslation(request: GeminiRequest): any | null {
     const systemContent = request.systemInstruction?.parts?.[0]?.text || '';
     const userContent = getTextContent(request);
@@ -267,6 +285,9 @@ export class ChatHandler {
 
     const wordListResponse = await this.handleWordListExtraction(request);
     if (wordListResponse) return wordListResponse;
+
+    const normalizationResponse = this.handleNormalization(request);
+    if (normalizationResponse) return normalizationResponse;
 
     const translationResponse = this.handleTranslation(request);
     if (translationResponse) return translationResponse;

--- a/mock_google_ai_server/src/data.ts
+++ b/mock_google_ai_server/src/data.ts
@@ -243,6 +243,11 @@ export const DICTIONARY_LOOKUPS: Record<string, Record<string, string>> = {
   },
 };
 
+export const NORMALIZATIONS: Record<string, { normalizedWord: string; forms: string[] }> = {
+  fahren: { normalizedWord: 'abfahren', forms: ['fährt ab', 'fuhr ab', 'abgefahren'] },
+  Haus: { normalizedWord: 'Haus', forms: ['die Häuser'] },
+};
+
 export const SENTENCE_TRANSLATIONS: Record<string, Record<string, string>> = {
   hungarian: {
     'Hören Sie.': 'Hallgasson.',

--- a/mock_openai_server/src/chatHandler.ts
+++ b/mock_openai_server/src/chatHandler.ts
@@ -1,7 +1,7 @@
 import {
   ChatMessage,
 } from './types';
-import { WORD_LISTS, TRANSLATIONS, WORD_TYPES, GENDERS, SENTENCE_LISTS, GRAMMAR_SENTENCE_LISTS, SENTENCE_TRANSLATIONS } from './data';
+import { WORD_LISTS, TRANSLATIONS, WORD_TYPES, GENDERS, SENTENCE_LISTS, GRAMMAR_SENTENCE_LISTS, SENTENCE_TRANSLATIONS, NORMALIZATIONS } from './data';
 import { messagesMatch, createAssistantResponse } from './utils';
 import { imageMessagesMatch, extractTextFromImageUrl } from './ocr';
 
@@ -180,6 +180,23 @@ export class ChatHandler {
     return null;
   }
 
+  handleNormalization(messages: ChatMessage[]): any | null {
+    const systemMessage = messages[0]?.content;
+    const userMessage = messages[1]?.content;
+
+    if (!systemMessage?.includes('normalize an inflected German word')) {
+      return null;
+    }
+
+    for (const word of Object.keys(NORMALIZATIONS)) {
+      if (typeof userMessage === 'string' && userMessage.includes(word)) {
+        return createAssistantResponse(NORMALIZATIONS[word]);
+      }
+    }
+
+    return null;
+  }
+
   handleSentenceTranslation(messages: ChatMessage[]): any | null {
     const systemMessage = messages[0]?.content;
     const userMessage = messages[1]?.content;
@@ -235,6 +252,9 @@ export class ChatHandler {
 
     // Debug OCR if image is present
     await this.handleOCRDebug(messages);
+
+    const normalizationResponse = this.handleNormalization(messages);
+    if (normalizationResponse) return normalizationResponse;
 
     // Try translation
     const translationResponse = await this.handleTranslation(messages);

--- a/mock_openai_server/src/data.ts
+++ b/mock_openai_server/src/data.ts
@@ -216,6 +216,11 @@ export const GRAMMAR_SENTENCE_LISTS: Record<string, string[]> = {
   ],
 };
 
+export const NORMALIZATIONS: Record<string, { normalizedWord: string; forms: string[] }> = {
+  fahren: { normalizedWord: 'abfahren', forms: ['fährt ab', 'fuhr ab', 'abgefahren'] },
+  Haus: { normalizedWord: 'Haus', forms: ['die Häuser'] },
+};
+
 export const SENTENCE_TRANSLATIONS: Record<string, Record<string, string>> = {
   hungarian: {
     'Hören Sie.': 'Hallgasson.',

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/entity/Highlight.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/entity/Highlight.java
@@ -32,6 +32,9 @@ public class Highlight {
   @Column(nullable = false, columnDefinition = "text")
   private String sentence;
 
+  @Column(name = "candidate_card_id")
+  private String candidateCardId;
+
   @Column(name = "created_at", nullable = false)
   private LocalDateTime createdAt;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/HighlightResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/HighlightResponse.java
@@ -2,11 +2,15 @@ package io.github.mucsi96.learnlanguage.model;
 
 import java.time.LocalDateTime;
 
+import lombok.Builder;
 import lombok.Value;
 
-@Value(staticConstructor = "of")
+@Value
+@Builder
 public class HighlightResponse {
     Integer id;
+    String candidateCardId;
+    boolean cardExists;
     String highlightedWord;
     String sentence;
     LocalDateTime createdAt;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/HighlightService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/HighlightService.java
@@ -2,28 +2,60 @@ package io.github.mucsi96.learnlanguage.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
 import io.github.mucsi96.learnlanguage.entity.Highlight;
 import io.github.mucsi96.learnlanguage.entity.Source;
+import io.github.mucsi96.learnlanguage.model.ChatModel;
 import io.github.mucsi96.learnlanguage.model.HighlightResponse;
+import io.github.mucsi96.learnlanguage.model.NormalizeWordResponse;
+import io.github.mucsi96.learnlanguage.model.OperationType;
+import io.github.mucsi96.learnlanguage.model.TranslationResponse;
+import io.github.mucsi96.learnlanguage.model.WordResponse;
+import io.github.mucsi96.learnlanguage.repository.CardRepository;
 import io.github.mucsi96.learnlanguage.repository.HighlightRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class HighlightService {
 
     private final HighlightRepository highlightRepository;
+    private final CardRepository cardRepository;
+    private final WordNormalizationService wordNormalizationService;
+    private final TranslationService translationService;
+    private final WordIdService wordIdService;
+    private final ChatModelSettingService chatModelSettingService;
 
     public List<HighlightResponse> getHighlightsBySource(Source source) {
-        return highlightRepository.findBySourceOrderByCreatedAtDesc(source).stream()
-                .map(h -> HighlightResponse.of(
-                        h.getId(),
-                        h.getHighlightedWord(),
-                        h.getSentence(),
-                        h.getCreatedAt()))
+        final List<Highlight> highlights = highlightRepository.findBySourceOrderByCreatedAtDesc(source);
+
+        final Set<String> existingCardIds = highlights.stream()
+                .map(Highlight::getCandidateCardId)
+                .filter(id -> id != null)
+                .collect(Collectors.toSet());
+
+        final Set<String> foundCardIds = existingCardIds.isEmpty()
+                ? Set.of()
+                : cardRepository.findAllById(existingCardIds).stream()
+                        .map(card -> card.getId())
+                        .collect(Collectors.toSet());
+
+        return highlights.stream()
+                .map(h -> HighlightResponse.builder()
+                        .id(h.getId())
+                        .candidateCardId(h.getCandidateCardId())
+                        .cardExists(h.getCandidateCardId() != null && foundCardIds.contains(h.getCandidateCardId()))
+                        .highlightedWord(h.getHighlightedWord())
+                        .sentence(h.getSentence())
+                        .createdAt(h.getCreatedAt())
+                        .build())
                 .toList();
     }
 
@@ -33,12 +65,51 @@ public class HighlightService {
             return;
         }
 
+        final String candidateCardId = generateCandidateCardId(highlightedWord, sentence);
+
         final Highlight highlight = Highlight.builder()
                 .source(source)
                 .highlightedWord(highlightedWord)
                 .sentence(sentence)
+                .candidateCardId(candidateCardId)
                 .createdAt(LocalDateTime.now())
                 .build();
         highlightRepository.save(highlight);
+    }
+
+    private String generateCandidateCardId(String highlightedWord, String sentence) {
+        try {
+            final Map<OperationType, String> primaryModels = chatModelSettingService.getPrimaryModelByOperation();
+
+            final String classificationModelName = primaryModels.get(OperationType.CLASSIFICATION);
+            final String translationModelName = primaryModels.get(OperationType.TRANSLATION);
+
+            if (classificationModelName == null || translationModelName == null) {
+                log.warn("Primary models not configured for classification or translation");
+                return null;
+            }
+
+            final ChatModel classificationModel = ChatModel.fromString(classificationModelName);
+            final ChatModel translationModel = ChatModel.fromString(translationModelName);
+
+            final NormalizeWordResponse normalizeResponse = wordNormalizationService.normalize(
+                    highlightedWord, sentence, classificationModel);
+
+            final WordResponse wordResponse = WordResponse.builder()
+                    .word(normalizeResponse.getNormalizedWord())
+                    .forms(normalizeResponse.getForms())
+                    .examples(List.of(sentence))
+                    .build();
+
+            final TranslationResponse translationResponse = translationService.translate(
+                    wordResponse, "hu", translationModel);
+
+            return wordIdService.generateWordId(
+                    normalizeResponse.getNormalizedWord(),
+                    translationResponse.getTranslation());
+        } catch (Exception e) {
+            log.warn("Failed to generate candidate card ID for '{}': {}", highlightedWord, e.getMessage());
+            return null;
+        }
     }
 }

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -137,11 +137,14 @@ CREATE TABLE IF NOT EXISTS learn_language.highlights (
     source_id character varying(255) NOT NULL,
     highlighted_word character varying(255) NOT NULL,
     sentence text NOT NULL,
+    candidate_card_id character varying(255),
     created_at timestamp(6) NOT NULL,
     CONSTRAINT highlights_pkey PRIMARY KEY (id),
     CONSTRAINT highlight_source_id_fkey FOREIGN KEY (source_id) REFERENCES learn_language.sources(id) ON DELETE CASCADE,
     CONSTRAINT highlights_unique UNIQUE (source_id, highlighted_word, sentence)
 );
+
+ALTER TABLE learn_language.highlights ADD COLUMN IF NOT EXISTS candidate_card_id character varying(255);
 
 CREATE TABLE IF NOT EXISTS learn_language.study_sessions (
     id character varying(255) NOT NULL,

--- a/test/tests/ebook-dictionary.spec.ts
+++ b/test/tests/ebook-dictionary.spec.ts
@@ -2,13 +2,12 @@ import * as fs from 'fs';
 import { type Page } from '@playwright/test';
 import { test, expect } from '../fixtures';
 import {
-  createSource,
-  createHighlight,
   createCard,
   getHighlights,
   getGridData,
   getSource,
   setupDefaultChatModelSettings,
+  withDbConnection,
 } from '../utils';
 
 const API_URL = 'http://localhost:8180/api/dictionary';
@@ -134,25 +133,11 @@ test('dictionary lookup does not duplicate source', async ({ page }) => {
 test('highlights page shows highlights for ebook dictionary source', async ({
   page,
 }) => {
-  await createSource({
-    id: 'test-ebook',
-    name: 'Test Ebook',
-    startPage: 1,
-    languageLevel: 'B1',
-    cardType: 'VOCABULARY',
-    formatType: 'WORD_LIST_WITH_EXAMPLES',
-    sourceType: 'EBOOK_DICTIONARY',
-  });
-  await createHighlight({
-    sourceId: 'test-ebook',
-    highlightedWord: 'fahren',
-    sentence: 'Wir fahren um zwölf Uhr ab.',
-  });
-  await createHighlight({
-    sourceId: 'test-ebook',
-    highlightedWord: 'Haus',
-    sentence: 'Das Haus ist groß.',
-  });
+  await setupDefaultChatModelSettings();
+  const token = await createTokenViaUI(page, 'Ebook Token');
+
+  await lookupWord(token, 'Test Ebook', 'fahren', 'Wir fahren um zwölf Uhr ab.');
+  await lookupWord(token, 'Test Ebook', 'Haus', 'Das Haus ist groß.');
 
   await page.goto('http://localhost:8180/sources/test-ebook/highlights');
 
@@ -171,15 +156,10 @@ test('highlights page shows highlights for ebook dictionary source', async ({
 test('admin page shows Highlights button for ebook dictionary source', async ({
   page,
 }) => {
-  await createSource({
-    id: 'test-ebook',
-    name: 'Test Ebook',
-    startPage: 1,
-    languageLevel: 'B1',
-    cardType: 'VOCABULARY',
-    formatType: 'WORD_LIST_WITH_EXAMPLES',
-    sourceType: 'EBOOK_DICTIONARY',
-  });
+  await setupDefaultChatModelSettings();
+  const token = await createTokenViaUI(page, 'Ebook Token');
+
+  await lookupWord(token, 'Test Ebook', 'test', 'This is a test.');
 
   await page.goto('http://localhost:8180/sources');
 
@@ -190,15 +170,10 @@ test('admin page shows Highlights button for ebook dictionary source', async ({
 test('admin page navigates to highlights page for ebook dictionary source', async ({
   page,
 }) => {
-  await createSource({
-    id: 'test-ebook',
-    name: 'Test Ebook',
-    startPage: 1,
-    languageLevel: 'B1',
-    cardType: 'VOCABULARY',
-    formatType: 'WORD_LIST_WITH_EXAMPLES',
-    sourceType: 'EBOOK_DICTIONARY',
-  });
+  await setupDefaultChatModelSettings();
+  const token = await createTokenViaUI(page, 'Ebook Token');
+
+  await lookupWord(token, 'Test Ebook', 'test', 'This is a test.');
 
   await page.goto('http://localhost:8180/sources');
 
@@ -211,25 +186,11 @@ test('admin page navigates to highlights page for ebook dictionary source', asyn
 test('highlights page select all checkbox selects all highlights', async ({
   page,
 }) => {
-  await createSource({
-    id: 'test-ebook',
-    name: 'Test Ebook',
-    startPage: 1,
-    languageLevel: 'B1',
-    cardType: 'VOCABULARY',
-    formatType: 'WORD_LIST_WITH_EXAMPLES',
-    sourceType: 'EBOOK_DICTIONARY',
-  });
-  await createHighlight({
-    sourceId: 'test-ebook',
-    highlightedWord: 'fahren',
-    sentence: 'Wir fahren um zwölf Uhr ab.',
-  });
-  await createHighlight({
-    sourceId: 'test-ebook',
-    highlightedWord: 'Haus',
-    sentence: 'Das Haus ist groß.',
-  });
+  await setupDefaultChatModelSettings();
+  const token = await createTokenViaUI(page, 'Ebook Token');
+
+  await lookupWord(token, 'Test Ebook', 'fahren', 'Wir fahren um zwölf Uhr ab.');
+  await lookupWord(token, 'Test Ebook', 'Haus', 'Das Haus ist groß.');
 
   await page.goto('http://localhost:8180/sources/test-ebook/highlights');
 
@@ -247,14 +208,18 @@ test('highlights page select all checkbox selects all highlights', async ({
 test('highlights page shows empty grid when no highlights', async ({
   page,
 }) => {
-  await createSource({
-    id: 'test-ebook',
-    name: 'Test Ebook',
-    startPage: 1,
-    languageLevel: 'B1',
-    cardType: 'VOCABULARY',
-    formatType: 'WORD_LIST_WITH_EXAMPLES',
-    sourceType: 'EBOOK_DICTIONARY',
+  await setupDefaultChatModelSettings();
+  const token = await createTokenViaUI(page, 'Ebook Token');
+
+  await lookupWord(token, 'Test Ebook', 'test', 'This is a test.');
+
+  const source = await getSource('test-ebook');
+  expect(source).not.toBeNull();
+
+  await withDbConnection(async (client) => {
+    await client.query('DELETE FROM learn_language.highlights WHERE source_id = $1', [
+      'test-ebook',
+    ]);
   });
 
   await page.goto('http://localhost:8180/sources/test-ebook/highlights');
@@ -270,32 +235,19 @@ test('highlights page shows empty grid when no highlights', async ({
 test('highlights page source selector navigates to other source highlights', async ({
   page,
 }) => {
-  await createSource({
-    id: 'test-ebook-1',
-    name: 'First Ebook',
-    startPage: 1,
-    languageLevel: 'B1',
-    cardType: 'VOCABULARY',
-    formatType: 'WORD_LIST_WITH_EXAMPLES',
-    sourceType: 'EBOOK_DICTIONARY',
-  });
-  await createSource({
-    id: 'test-ebook-2',
-    name: 'Second Ebook',
-    startPage: 1,
-    languageLevel: 'B1',
-    cardType: 'VOCABULARY',
-    formatType: 'WORD_LIST_WITH_EXAMPLES',
-    sourceType: 'EBOOK_DICTIONARY',
-  });
+  await setupDefaultChatModelSettings();
+  const token = await createTokenViaUI(page, 'Ebook Token');
 
-  await page.goto('http://localhost:8180/sources/test-ebook-1/highlights');
+  await lookupWord(token, 'First Ebook', 'test', 'This is a test.');
+  await lookupWord(token, 'Second Ebook', 'test', 'This is a test.');
+
+  await page.goto('http://localhost:8180/sources/first-ebook/highlights');
 
   await expect(page.getByRole('button', { name: 'First Ebook' })).toBeVisible();
   await page.getByRole('button', { name: 'First Ebook' }).click();
   await page.getByRole('menuitem', { name: 'Second Ebook' }).click();
 
-  await expect(page).toHaveURL(/\/sources\/test-ebook-2\/highlights/);
+  await expect(page).toHaveURL(/\/sources\/second-ebook\/highlights/);
 });
 
 test('dictionary lookup persists candidate card ID in highlight', async ({
@@ -319,21 +271,10 @@ test('dictionary lookup persists candidate card ID in highlight', async ({
 test('highlights grid shows Card ID and NEW status for highlight without matching card', async ({
   page,
 }) => {
-  await createSource({
-    id: 'test-ebook',
-    name: 'Test Ebook',
-    startPage: 1,
-    languageLevel: 'B1',
-    cardType: 'VOCABULARY',
-    formatType: 'WORD_LIST_WITH_EXAMPLES',
-    sourceType: 'EBOOK_DICTIONARY',
-  });
-  await createHighlight({
-    sourceId: 'test-ebook',
-    highlightedWord: 'fahren',
-    sentence: 'Wir fahren um zwölf Uhr ab.',
-    candidateCardId: 'abfahren-elindulni',
-  });
+  await setupDefaultChatModelSettings();
+  const token = await createTokenViaUI(page, 'Ebook Token');
+
+  await lookupWord(token, 'Test Ebook', 'fahren', 'Wir fahren um zwölf Uhr ab.');
 
   await page.goto('http://localhost:8180/sources/test-ebook/highlights');
 
@@ -359,17 +300,17 @@ test('highlights grid shows Card ID and NEW status for highlight without matchin
 test('highlights grid shows EXISTS status when card with candidate ID exists', async ({
   page,
 }) => {
-  await createSource({
-    id: 'test-ebook',
-    name: 'Test Ebook',
-    startPage: 1,
-    languageLevel: 'B1',
-    cardType: 'VOCABULARY',
-    formatType: 'WORD_LIST_WITH_EXAMPLES',
-    sourceType: 'EBOOK_DICTIONARY',
-  });
+  await setupDefaultChatModelSettings();
+  const token = await createTokenViaUI(page, 'Ebook Token');
+
+  await lookupWord(token, 'Test Ebook', 'fahren', 'Wir fahren um zwölf Uhr ab.');
+
+  const highlights = await getHighlights('test-ebook');
+  const candidateCardId = highlights[0].candidateCardId;
+  expect(candidateCardId).not.toBeNull();
+
   await createCard({
-    cardId: 'abfahren-elindulni',
+    cardId: candidateCardId!,
     sourceId: 'test-ebook',
     data: {
       word: 'abfahren',
@@ -379,12 +320,6 @@ test('highlights grid shows EXISTS status when card with candidate ID exists', a
       examples: [],
       audio: [],
     },
-  });
-  await createHighlight({
-    sourceId: 'test-ebook',
-    highlightedWord: 'fahren',
-    sentence: 'Wir fahren um zwölf Uhr ab.',
-    candidateCardId: 'abfahren-elindulni',
   });
 
   await page.goto('http://localhost:8180/sources/test-ebook/highlights');
@@ -398,7 +333,7 @@ test('highlights grid shows EXISTS status when card with candidate ID exists', a
     }>(grid);
     expect(rows).toEqual([
       expect.objectContaining({
-        'Card ID': 'abfahren-elindulni',
+        'Card ID': candidateCardId,
         Status: 'EXISTS',
         Word: 'fahren',
       }),
@@ -409,20 +344,22 @@ test('highlights grid shows EXISTS status when card with candidate ID exists', a
 test('highlights grid shows dash for Card ID when no candidate card ID', async ({
   page,
 }) => {
-  await createSource({
-    id: 'test-ebook',
-    name: 'Test Ebook',
-    startPage: 1,
-    languageLevel: 'B1',
-    cardType: 'VOCABULARY',
-    formatType: 'WORD_LIST_WITH_EXAMPLES',
-    sourceType: 'EBOOK_DICTIONARY',
-  });
-  await createHighlight({
-    sourceId: 'test-ebook',
-    highlightedWord: 'Haus',
-    sentence: 'Das Haus ist groß.',
-  });
+  await setupDefaultChatModelSettings();
+  const token = await createTokenViaUI(page, 'Ebook Token');
+
+  await lookupWord(token, 'Test Ebook', 'Haus', 'Das Haus ist groß.');
+
+  const highlights = await getHighlights('test-ebook');
+  expect(highlights).toHaveLength(1);
+
+  if (highlights[0].candidateCardId !== null) {
+    await withDbConnection(async (client) => {
+      await client.query(
+        'UPDATE learn_language.highlights SET candidate_card_id = NULL WHERE id = $1',
+        [highlights[0].id]
+      );
+    });
+  }
 
   await page.goto('http://localhost:8180/sources/test-ebook/highlights');
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1196,15 +1196,16 @@ export async function createHighlight(params: {
   sourceId: string;
   highlightedWord: string;
   sentence: string;
+  candidateCardId?: string | null;
 }): Promise<number> {
-  const { sourceId, highlightedWord, sentence } = params;
+  const { sourceId, highlightedWord, sentence, candidateCardId = null } = params;
 
   return await withDbConnection(async (client) => {
     const result = await client.query(
-      `INSERT INTO learn_language.highlights (source_id, highlighted_word, sentence, created_at)
-       VALUES ($1, $2, $3, NOW())
+      `INSERT INTO learn_language.highlights (source_id, highlighted_word, sentence, candidate_card_id, created_at)
+       VALUES ($1, $2, $3, $4, NOW())
        RETURNING id`,
-      [sourceId, highlightedWord, sentence]
+      [sourceId, highlightedWord, sentence, candidateCardId]
     );
     return result.rows[0].id;
   });
@@ -1215,11 +1216,12 @@ export async function getHighlights(sourceId: string): Promise<
     id: number;
     highlightedWord: string;
     sentence: string;
+    candidateCardId: string | null;
   }>
 > {
   return await withDbConnection(async (client) => {
     const result = await client.query(
-      `SELECT id, highlighted_word as "highlightedWord", sentence
+      `SELECT id, highlighted_word as "highlightedWord", sentence, candidate_card_id as "candidateCardId"
        FROM learn_language.highlights
        WHERE source_id = $1
        ORDER BY created_at DESC`,

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1192,24 +1192,6 @@ export async function createStudySession(params: {
   return sessionId;
 }
 
-export async function createHighlight(params: {
-  sourceId: string;
-  highlightedWord: string;
-  sentence: string;
-  candidateCardId?: string | null;
-}): Promise<number> {
-  const { sourceId, highlightedWord, sentence, candidateCardId = null } = params;
-
-  return await withDbConnection(async (client) => {
-    const result = await client.query(
-      `INSERT INTO learn_language.highlights (source_id, highlighted_word, sentence, candidate_card_id, created_at)
-       VALUES ($1, $2, $3, $4, NOW())
-       RETURNING id`,
-      [sourceId, highlightedWord, sentence, candidateCardId]
-    );
-    return result.rows[0].id;
-  });
-}
 
 export async function getHighlights(sourceId: string): Promise<
   Array<{


### PR DESCRIPTION
## Summary
This PR enhances the highlights feature by automatically generating candidate card IDs when highlights are created and tracking whether those cards already exist in the system. This enables users to see which highlighted words have already been added as study cards.

## Key Changes

**Backend (Java/Spring)**
- Added `candidateCardId` field to the `Highlight` entity with database migration
- Enhanced `HighlightService` to generate candidate card IDs using word normalization, translation, and word ID generation services
- Updated `getHighlightsBySource()` to check if candidate cards exist in the database and include this status in responses
- Modified `HighlightResponse` DTO to include `candidateCardId` and `cardExists` fields using builder pattern
- Added comprehensive error handling with logging for the card ID generation process

**Frontend (Angular)**
- Extended `Highlight` type to include `candidateCardId` and `cardExists` properties
- Added two new columns to the highlights grid:
  - **Card ID column**: Displays the generated candidate card ID (or "-" if not generated)
  - **Status column**: Shows a color-coded badge indicating whether the card "EXISTS" (green) or is "NEW" (blue)
- Implemented custom cell renderers with styling for better visual distinction

**Database**
- Added `candidate_card_id` column to the `highlights` table with migration script

## Implementation Details
- Card ID generation is wrapped in try-catch to gracefully handle failures and log warnings
- The service checks for primary model configuration before attempting generation
- Card existence is determined by querying the database with the generated IDs
- The UI provides visual feedback through color-coded status badges to help users identify which highlights correspond to existing cards

https://claude.ai/code/session_01DqwaTfJGmXVTT7G78cwkuV