### PR TITLE
Prevent duplicate highlights when looking up selected text

### DIFF
--- a/koreader-plugin/ai-dictionary.koplugin/main.lua
+++ b/koreader-plugin/ai-dictionary.koplugin/main.lua
@@ -14,30 +14,6 @@ local AIDictionary = WidgetContainer:extend {
     is_doc_only = true,
 }
 
-local function positionsEqual(a, b)
-    if type(a) ~= type(b) then return false end
-    if type(a) == "string" then return a == b end
-    if type(a) == "table" then
-        return a.x == b.x and a.y == b.y and a.page == b.page
-    end
-    return false
-end
-
-local function highlightExistsAtPosition(ui, selected_text)
-    local annotations = ui.annotation and ui.annotation.annotations
-    if not annotations then return false end
-    local pos0 = selected_text.pos0
-    local pos1 = selected_text.pos1
-    for _, item in ipairs(annotations) do
-        if item.drawer and item.pos0 and item.pos1
-                and positionsEqual(item.pos0, pos0)
-                and positionsEqual(item.pos1, pos1) then
-            return true
-        end
-    end
-    return false
-end
-
 local function getPluginDir()
     local info = debug.getinfo(1, "S")
     return info.source:match("@?(.*/)") or "."
@@ -165,7 +141,14 @@ function AIDictionary:init()
             enabled = true,
             callback = function()
                 local selected_text = tostring(this.selected_text.text)
-                if not highlightExistsAtPosition(this.ui, this.selected_text) then
+                local existing = this.ui.annotation:getItemIndex({
+                    pos0 = this.selected_text.pos0,
+                    pos1 = this.selected_text.pos1,
+                    page = this.ui.paging
+                        and this.selected_text.pos0.page
+                        or this.selected_text.pos0,
+                })
+                if not existing then
                     this:saveHighlight()
                 end
                 this:onClose()

--- a/koreader-plugin/ai-dictionary.koplugin/main.lua
+++ b/koreader-plugin/ai-dictionary.koplugin/main.lua
@@ -14,6 +14,30 @@ local AIDictionary = WidgetContainer:extend {
     is_doc_only = true,
 }
 
+local function positionsEqual(a, b)
+    if type(a) ~= type(b) then return false end
+    if type(a) == "string" then return a == b end
+    if type(a) == "table" then
+        return a.x == b.x and a.y == b.y and a.page == b.page
+    end
+    return false
+end
+
+local function highlightExistsAtPosition(ui, selected_text)
+    local annotations = ui.annotation and ui.annotation.annotations
+    if not annotations then return false end
+    local pos0 = selected_text.pos0
+    local pos1 = selected_text.pos1
+    for _, item in ipairs(annotations) do
+        if item.drawer and item.pos0 and item.pos1
+                and positionsEqual(item.pos0, pos0)
+                and positionsEqual(item.pos1, pos1) then
+            return true
+        end
+    end
+    return false
+end
+
 local function getPluginDir()
     local info = debug.getinfo(1, "S")
     return info.source:match("@?(.*/)") or "."
@@ -141,7 +165,9 @@ function AIDictionary:init()
             enabled = true,
             callback = function()
                 local selected_text = tostring(this.selected_text.text)
-                this:saveHighlight()
+                if not highlightExistsAtPosition(this.ui, this.selected_text) then
+                    this:saveHighlight()
+                end
                 this:onClose()
                 self:lookup(selected_text)
             end,


### PR DESCRIPTION
## Summary
This change prevents the AI Dictionary plugin from creating duplicate highlights when a user looks up text that already has an existing highlight at the same position.

## Key Changes
- Added `positionsEqual()` helper function to compare position objects (supporting both string and table formats with x, y, page coordinates)
- Added `highlightExistsAtPosition()` function to check if a highlight already exists at the selected text's position by comparing against existing annotations
- Modified the lookup callback to only call `saveHighlight()` if no highlight already exists at that position, avoiding duplicate highlights

## Implementation Details
The solution checks the annotation system before saving a new highlight. The position comparison handles both string-based and coordinate-based position formats to ensure compatibility with different highlight types in the system.

https://claude.ai/code/session_01ABjSfgSRNR6UrT5FwuiPdy