### PR TITLE
Simplify dictionary lookup: remove streaming and consolidate logic

### DIFF
--- a/koreader-plugin/ai-dictionary.koplugin/main.lua
+++ b/koreader-plugin/ai-dictionary.koplugin/main.lua
@@ -51,23 +51,6 @@ local function loadConfig()
     return config, nil
 end
 
-local function parseSseResponse(raw)
-    local parts = {}
-    for line in raw:gmatch("[^\r\n]+") do
-        local data = line:match("^data:(.*)")
-        if data then
-            table.insert(parts, data)
-        end
-    end
-    local text = table.concat(parts, "\n")
-
-    text = text:gsub("<<H>>", "\239\191\177")
-    text = text:gsub("<<B>>", "\239\191\178")
-    text = text:gsub("<</B>>", "\239\191\179")
-
-    return text
-end
-
 local function queryDictionary(serverUrl, token, requestBody)
     local requestJson = json.encode(requestBody)
 
@@ -80,7 +63,6 @@ local function queryDictionary(serverUrl, token, requestBody)
             ["Content-Type"] = "application/json",
             ["Content-Length"] = tostring(#requestJson),
             ["Authorization"] = "Bearer " .. token,
-            ["Accept"] = "text/event-stream",
         },
         source = ltn12.source.string(requestJson),
         sink = ltn12.sink.table(responseBody),
@@ -93,7 +75,7 @@ local function queryDictionary(serverUrl, token, requestBody)
         return nil, reason
     end
 
-    return parseSseResponse(raw), nil
+    return raw, nil
 end
 
 local function getSentenceAroundSelection(document, selection)

--- a/koreader-plugin/ai-dictionary.koplugin/main.lua
+++ b/koreader-plugin/ai-dictionary.koplugin/main.lua
@@ -4,20 +4,10 @@ local NetworkMgr = require("ui/network/manager")
 local UIManager = require("ui/uimanager")
 local InfoMessage = require("ui/widget/infomessage")
 local TextViewer = require("ui/widget/textviewer")
-local InputDialog = require("ui/widget/inputdialog")
-local InputText = require("ui/widget/inputtext")
-local Font = require("ui/font")
-local Size = require("ui/size")
 
-local http = require("socket.http")
 local https = require("ssl.https")
-local socket = require("socket")
 local ltn12 = require("ltn12")
 local json = require("json")
-local ffi = require("ffi")
-local ffiutil = require("ffi/util")
-
-local Screen = Device.screen
 
 local AIDictionary = WidgetContainer:extend {
     name = "ai-dictionary",
@@ -61,141 +51,53 @@ local function loadConfig()
     return config, nil
 end
 
-local function applyMarkers(text)
-    return text:gsub("<<H>>", "\239\191\177")
-               :gsub("<<B>>", "\239\191\178")
-               :gsub("<</B>>", "\239\191\179")
-end
-
-local StreamText = InputText:extend{}
-
-function StreamText:addChars(chars)
-    self.readonly = false
-    InputText.addChars(self, chars)
-end
-
-function StreamText:initTextBox(text, char_added)
-    self.for_measurement_only = true
-    InputText.initTextBox(self, text, char_added)
-    UIManager:setDirty(self.parent, function() return "fast", self.dimen end)
-    self.for_measurement_only = false
-end
-
-function StreamText:onCloseWidget()
-    UIManager:setDirty(self.parent, function() return "flashui", self.dimen end)
-    return InputText.onCloseWidget(self)
-end
-
-local PROTOCOL_NON_200 = "X-NON-200:"
-
-local function wrapFd(fd)
-    local obj = {}
-    function obj:write(chunk)
-        ffiutil.writeToFD(fd, chunk)
-        return self
-    end
-    function obj:close() return true end
-    return obj
-end
-
-local function backgroundRequest(url, token, requestJson)
-    return function(pid, child_write_fd)
-        https.cert_verify = false
-        local pipe_w = wrapFd(child_write_fd)
-        local code = socket.skip(1, http.request {
-            url = url,
-            method = "POST",
-            headers = {
-                ["Content-Type"] = "application/json",
-                ["Content-Length"] = tostring(#requestJson),
-                ["Authorization"] = "Bearer " .. token,
-                ["Accept"] = "text/event-stream",
-            },
-            source = ltn12.source.string(requestJson),
-            sink = ltn12.sink.file(pipe_w),
-        })
-        if code ~= 200 then
-            ffiutil.writeToFD(child_write_fd,
-                string.format("\r\n%sHTTP %s\n", PROTOCOL_NON_200, tostring(code or "failed")))
-        end
-        ffi.C.close(child_write_fd)
-    end
-end
-
-local function processStream(bgQuery, onChunk)
-    local pid, parent_read_fd = ffiutil.runInSubProcess(bgQuery, true)
-    if not pid then
-        return nil, "Failed to start request"
-    end
-
-    local _coroutine = coroutine.running()
-    local check_interval = 0.125
-    local chunksize = 1024 * 16
-    local buffer = ffi.new('char[?]', chunksize, {0})
-    local buffer_ptr = ffi.cast('void*', buffer)
-    local partial_data = ""
-    local result_parts = {}
-    local completed = false
-    local non200 = false
-
-    while not completed do
-        UIManager:scheduleIn(check_interval, function()
-            coroutine.resume(_coroutine)
-        end)
-        coroutine.yield()
-
-        local readsize = ffiutil.getNonBlockingReadSize(parent_read_fd)
-        if readsize > 0 then
-            local bytes_read = tonumber(ffi.C.read(parent_read_fd, buffer_ptr, chunksize))
-            if bytes_read <= 0 then break end
-
-            partial_data = partial_data .. ffi.string(buffer, bytes_read)
-
-            while true do
-                local line_end = partial_data:find("[\r\n]")
-                if not line_end then break end
-
-                local line = partial_data:sub(1, line_end - 1)
-                partial_data = partial_data:sub(line_end + 1)
-
-                if line:sub(1, 5) == "data:" then
-                    local data = line:sub(6)
-                    table.insert(result_parts, data)
-                    onChunk(data)
-                elseif line:sub(1, #PROTOCOL_NON_200) == PROTOCOL_NON_200 then
-                    non200 = true
-                    table.insert(result_parts, line:sub(#PROTOCOL_NON_200 + 1))
-                    completed = true
-                    break
-                end
-            end
-        elseif readsize == 0 then
-            completed = ffiutil.isSubProcessDone(pid)
+local function parseSseResponse(raw)
+    local parts = {}
+    for line in raw:gmatch("[^\r\n]+") do
+        local data = line:match("^data:(.*)")
+        if data then
+            table.insert(parts, data)
         end
     end
+    local text = table.concat(parts, "\n")
 
-    ffiutil.terminateSubProcess(pid)
+    text = text:gsub("<<H>>", "\239\191\177")
+    text = text:gsub("<<B>>", "\239\191\178")
+    text = text:gsub("<</B>>", "\239\191\179")
 
-    local function collectAndClean()
-        if ffiutil.isSubProcessDone(pid) then
-            if parent_read_fd then ffiutil.readAllFromFD(parent_read_fd) end
-        else
-            if parent_read_fd and ffiutil.getNonBlockingReadSize(parent_read_fd) ~= 0 then
-                ffiutil.readAllFromFD(parent_read_fd)
-                parent_read_fd = nil
-            end
-            UIManager:scheduleIn(5, collectAndClean)
-        end
+    return text
+end
+
+local function queryDictionary(serverUrl, token, requestBody)
+    local requestJson = json.encode(requestBody)
+
+    local responseBody = {}
+
+    local _, code = https.request {
+        url = serverUrl .. "/api/dictionary",
+        method = "POST",
+        headers = {
+            ["Content-Type"] = "application/json",
+            ["Content-Length"] = tostring(#requestJson),
+            ["Authorization"] = "Bearer " .. token,
+            ["Accept"] = "text/event-stream",
+        },
+        source = ltn12.source.string(requestJson),
+        sink = ltn12.sink.table(responseBody),
+    }
+
+    local raw = table.concat(responseBody)
+
+    if code ~= 200 then
+        local reason = code and ("HTTP " .. code .. ": " .. raw) or "Connection failed"
+        return nil, reason
     end
-    UIManager:scheduleIn(5, collectAndClean)
 
-    local result = table.concat(result_parts)
-    if non200 then return nil, "HTTP error: " .. result end
-    if #result == 0 then return nil, "No response received" end
-    return applyMarkers(result), nil
+    return parseSseResponse(raw), nil
 end
 
 local function getSentenceAroundSelection(document, selection)
+    local Screen = Device.screen
     local page_text = nil
 
     pcall(function()
@@ -297,62 +199,26 @@ function AIDictionary:lookup(highlightedText)
         self.ui.document, highlightedText
     )
 
+    local viewer = TextViewer:new {
+        title = "AI Dictionary",
+        text = "Looking up...",
+    }
+
+    UIManager:show(viewer)
+
     local targetLanguage = config.targetLanguage or "en"
     local serverUrl = config.serverUrl
 
-    local requestJson = json.encode({
-        bookTitle = title,
-        author = author,
-        targetLanguage = targetLanguage,
-        sentence = sentence,
-        highlightedWord = highlightedText,
-    })
+    UIManager:scheduleIn(0.01, function()
+        local result, err = queryDictionary(serverUrl, config.token, {
+            bookTitle = title,
+            author = author,
+            targetLanguage = targetLanguage,
+            sentence = sentence,
+            highlightedWord = highlightedText,
+        })
 
-    local streamDialog = InputDialog:new {
-        title = "AI Dictionary",
-        inputtext_class = StreamText,
-        input_face = Font:getFace("infofont", 20),
-        width = Screen:getWidth() - 2 * Size.margin.default,
-        use_available_height = true,
-        readonly = true,
-        fullscreen = false,
-        allow_newline = true,
-        add_nav_bar = false,
-        cursor_at_end = true,
-        add_scroll_buttons = true,
-        condensed = true,
-        scroll_by_pan = true,
-        buttons = {{
-            {
-                text = "Close",
-                id = "close",
-                callback = function()
-                    UIManager:close(streamDialog)
-                end,
-            },
-        }},
-    }
-
-    streamDialog._input_widget:setText("Looking up...", true)
-    UIManager:show(streamDialog)
-
-    local bgQuery = backgroundRequest(
-        serverUrl .. "/api/dictionary", config.token, requestJson
-    )
-
-    local co = coroutine.create(function()
-        local first_content = true
-        local result, err = processStream(bgQuery, function(chunk)
-            UIManager:nextTick(function()
-                if first_content then
-                    streamDialog._input_widget:setText("", true)
-                    first_content = false
-                end
-                streamDialog:addTextToInput(chunk)
-            end)
-        end)
-
-        UIManager:close(streamDialog)
+        UIManager:close(viewer)
 
         if err then
             UIManager:show(InfoMessage:new {
@@ -366,8 +232,6 @@ function AIDictionary:lookup(highlightedText)
             text = result,
         })
     end)
-
-    coroutine.resume(co)
 end
 
 return AIDictionary

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/DictionaryController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/DictionaryController.java
@@ -1,53 +1,73 @@
 package io.github.mucsi96.learnlanguage.controller;
 
-import java.io.IOException;
+import java.util.Locale;
 
 import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import io.github.mucsi96.learnlanguage.entity.Source;
+import io.github.mucsi96.learnlanguage.model.CardType;
 import io.github.mucsi96.learnlanguage.model.DictionaryRequest;
+import io.github.mucsi96.learnlanguage.model.LanguageLevel;
+import io.github.mucsi96.learnlanguage.model.SourceFormatType;
+import io.github.mucsi96.learnlanguage.model.SourceType;
 import io.github.mucsi96.learnlanguage.service.ApiTokenService;
 import io.github.mucsi96.learnlanguage.service.DictionaryService;
+import io.github.mucsi96.learnlanguage.service.HighlightService;
+import io.github.mucsi96.learnlanguage.service.SourceService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequiredArgsConstructor
-@Slf4j
 public class DictionaryController {
 
     private final ApiTokenService apiTokenService;
     private final DictionaryService dictionaryService;
+    private final SourceService sourceService;
+    private final HighlightService highlightService;
 
-    @PostMapping(value = "/dictionary", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter translate(
+    @PostMapping(value = "/dictionary", produces = MediaType.TEXT_PLAIN_VALUE)
+    @Transactional
+    public String translate(
             @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
             @Valid @RequestBody DictionaryRequest request) {
         apiTokenService.validateBearerToken(authorizationHeader);
 
-        final SseEmitter emitter = new SseEmitter(120_000L);
+        if (request.getBookTitle() != null && request.getHighlightedWord() != null
+                && request.getSentence() != null) {
+            final Source source = getOrCreateSource(request.getBookTitle());
+            highlightService.persistHighlight(source, request.getHighlightedWord(), request.getSentence());
+        }
 
-        dictionaryService.streamLookup(request).subscribe(
-                chunk -> {
-                    try {
-                        emitter.send(SseEmitter.event().data(chunk));
-                    } catch (IOException e) {
-                        emitter.completeWithError(e);
-                    }
-                },
-                error -> {
-                    log.error("Streaming error: {}", error.getMessage());
-                    emitter.completeWithError(error);
-                },
-                emitter::complete);
+        return dictionaryService.lookup(request);
+    }
 
-        dictionaryService.persistHighlightIfPresent(request);
+    private Source getOrCreateSource(String bookTitle) {
+        final String sourceId = toSourceId(bookTitle);
 
-        return emitter;
+        return sourceService.getSourceById(sourceId)
+                .orElseGet(() -> {
+                    final Source newSource = Source.builder()
+                            .id(sourceId)
+                            .name(bookTitle)
+                            .sourceType(SourceType.EBOOK_DICTIONARY)
+                            .startPage(1)
+                            .languageLevel(LanguageLevel.B1)
+                            .cardType(CardType.VOCABULARY)
+                            .formatType(SourceFormatType.WORD_LIST_WITH_EXAMPLES)
+                            .build();
+                    return sourceService.saveSource(newSource);
+                });
+    }
+
+    private static String toSourceId(String bookTitle) {
+        return bookTitle.toLowerCase(Locale.ROOT)
+                .replaceAll("[^a-z0-9]+", "-")
+                .replaceAll("^-|-$", "");
     }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/DictionaryRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/DictionaryRequest.java
@@ -15,5 +15,4 @@ public class DictionaryRequest {
     private String targetLanguage;
     private String sentence;
     private String highlightedWord;
-    private String model;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ChatService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ChatService.java
@@ -3,7 +3,6 @@ package io.github.mucsi96.learnlanguage.service;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import org.springframework.ai.chat.client.ChatClient;
@@ -19,7 +18,6 @@ import io.github.mucsi96.learnlanguage.model.ChatModel;
 import io.github.mucsi96.learnlanguage.model.OperationType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import reactor.core.publisher.Flux;
 
 @Service
 @RequiredArgsConstructor
@@ -117,40 +115,6 @@ public class ChatService {
         logUsage(model, operationType, response, jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(text), processingTime);
 
         return text;
-    }
-
-    public Flux<String> streamForText(
-            ChatModel model,
-            OperationType operationType,
-            String systemPrompt,
-            String userMessage) {
-
-        final long startTime = System.currentTimeMillis();
-        final ChatClient chatClient = chatClientService.getChatClient(model);
-        final StringBuilder contentBuffer = new StringBuilder();
-        final AtomicReference<ChatResponse> lastResponse = new AtomicReference<>();
-
-        return chatClient
-                .prompt()
-                .system(systemPrompt)
-                .user(u -> u.text(userMessage))
-                .stream()
-                .chatResponse()
-                .doOnNext(lastResponse::set)
-                .mapNotNull(response -> response.getResult() != null
-                        && response.getResult().getOutput() != null
-                                ? response.getResult().getOutput().getText()
-                                : null)
-                .doOnNext(contentBuffer::append)
-                .doOnError(error -> log.error("Stream error for model {} operation {}: {}",
-                        model.getModelName(), operationType.getCode(), error.getMessage()))
-                .doFinally(signal -> {
-                    final long processingTime = System.currentTimeMillis() - startTime;
-                    final ChatResponse response = lastResponse.get();
-                    if (response != null) {
-                        logUsage(model, operationType, response, contentBuffer.toString(), processingTime);
-                    }
-                });
     }
 
     private <T> T callWithLoggingInternal(

--- a/test/tests/dictionary.spec.ts
+++ b/test/tests/dictionary.spec.ts
@@ -5,22 +5,10 @@ import { setupDefaultChatModelSettings } from '../utils';
 
 const API_URL = 'http://localhost:8180/api/dictionary';
 
-// Reassembles an SSE stream into a single string: data lines within
-// each event are joined with \n (per SSE spec), events are concatenated
-// without separator because the AI response is a continuous text stream.
-async function readSseStream(response: Response): Promise<string> {
-  const raw = await response.text();
-  const events = raw.split('\n\n').filter((e) => e.trim());
-  return events
-    .map((event) =>
-      event
-        .split('\n')
-        .filter((line) => line.startsWith('data:'))
-        .map((line) => line.slice(5))
-        .join('\n')
-    )
-    .join('');
-}
+const PTF_BOLD_START = '\uFFF2';
+const PTF_BOLD_END = '\uFFF3';
+
+const bold = (s: string) => PTF_BOLD_START + s + PTF_BOLD_END;
 
 async function createTokenViaUI(page: Page, name: string): Promise<string> {
   await page.goto('http://localhost:8180/settings/api-tokens');
@@ -55,44 +43,48 @@ async function lookupWord(
   });
 }
 
-test('dictionary endpoint streams a word translation to Hungarian', async ({
-  page,
-}) => {
+test('dictionary endpoint translates a word to Hungarian', async ({ page }) => {
   await setupDefaultChatModelSettings();
   const token = await createTokenViaUI(page, 'Test Token');
 
   const response = await lookupWord(token, 'hu');
 
   expect(response.status).toBe(200);
-  expect(response.headers.get('content-type')).toContain('text/event-stream');
-  const text = await readSseStream(response);
-  expect(text).toContain('<<B>>VERB<</B>>');
-  expect(text).toContain('<<B>>Forms: <</B>>fährt ab, fuhr ab, ist abgefahren');
+  expect(response.headers.get('content-type')).toContain('text/plain');
+  const text = await response.text();
+  expect(text).toContain(bold('VERB'));
+  expect(text).toContain(bold('Forms: ') + 'fährt ab, fuhr ab, ist abgefahren');
   expect(text).toContain(
-    '<<B>>Translation (hu): <</B>>elindulni, elhagyni'
+    bold('Translation (hu): ') + 'elindulni, elhagyni'
   );
-  expect(text).toContain('<<B>>Example (de): <</B>>Wir fahren ab.');
-  expect(text).toContain('<<B>>Example (hu): <</B>>Elindulunk.');
+  expect(text).toContain(
+    bold('Example (de): ') + 'Wir fahren ab.'
+  );
+  expect(text).toContain(
+    bold('Example (hu): ') + 'Elindulunk.'
+  );
 });
 
-test('dictionary endpoint streams a word translation to English', async ({
-  page,
-}) => {
+test('dictionary endpoint translates a word to English', async ({ page }) => {
   await setupDefaultChatModelSettings();
   const token = await createTokenViaUI(page, 'Test Token');
 
   const response = await lookupWord(token, 'en');
 
   expect(response.status).toBe(200);
-  expect(response.headers.get('content-type')).toContain('text/event-stream');
-  const text = await readSseStream(response);
-  expect(text).toContain('<<B>>VERB<</B>>');
-  expect(text).toContain('<<B>>Forms: <</B>>fährt ab, fuhr ab, ist abgefahren');
+  expect(response.headers.get('content-type')).toContain('text/plain');
+  const text = await response.text();
+  expect(text).toContain(bold('VERB'));
+  expect(text).toContain(bold('Forms: ') + 'fährt ab, fuhr ab, ist abgefahren');
   expect(text).toContain(
-    '<<B>>Translation (en): <</B>>to depart, to leave'
+    bold('Translation (en): ') + 'to depart, to leave'
   );
-  expect(text).toContain('<<B>>Example (de): <</B>>Wir fahren ab.');
-  expect(text).toContain('<<B>>Example (en): <</B>>We depart.');
+  expect(text).toContain(
+    bold('Example (de): ') + 'Wir fahren ab.'
+  );
+  expect(text).toContain(
+    bold('Example (en): ') + 'We depart.'
+  );
 });
 
 test('dictionary endpoint returns 401 without authorization header', async ({


### PR DESCRIPTION
## Summary
This PR simplifies the dictionary lookup feature by removing server-sent events (SSE) streaming and consolidating business logic. The implementation now uses a single synchronous HTTP request/response cycle instead of streaming chunks, making the code simpler and easier to maintain.

## Key Changes

**KOReader Plugin (Lua)**
- Removed streaming infrastructure: eliminated `StreamText` class, `backgroundRequest()`, and `processStream()` functions
- Replaced `InputDialog` with `TextViewer` for displaying results
- Simplified the lookup flow to use a single synchronous `queryDictionary()` call instead of coroutine-based streaming
- Removed unused imports (InputDialog, InputText, Font, Size, socket, ffi, etc.)
- Moved marker replacement logic to the server side

**Backend Service Layer**
- Removed `streamLookup()` method from `DictionaryService` and replaced with synchronous `lookup()`
- Moved highlight persistence logic from service to controller
- Removed model parameter from request and simplified `resolveModel()` to always use primary model
- Added `replacePlaceholdersWithUnicode()` method to convert `<<H>>`, `<<B>>`, `<</B>>` markers to Unicode characters (`\uFFF1`, `\uFFF2`, `\uFFF3`)

**Backend Controller**
- Changed endpoint from SSE streaming (`TEXT_EVENT_STREAM`) to plain text response (`TEXT_PLAIN`)
- Moved source creation and highlight persistence logic from service to controller
- Simplified response handling to return a single string instead of managing SSE emitter

**Mock Server & Tests**
- Removed streaming endpoint implementation from mock Google AI server
- Updated tests to expect plain text responses instead of SSE streams
- Simplified test assertions to work with direct text content

## Implementation Details
- The Unicode character replacements (`\uFFF1`, `\uFFF2`, `\uFFF3`) are used by KOReader's text rendering engine to display formatted text (highlighting/bold)
- The synchronous approach eliminates the need for coroutines and subprocess management on the client side
- All business logic for source/highlight management is now in the controller, making the service layer focused on the core dictionary lookup operation

https://claude.ai/code/session_01V616Vy6x25x2Zvjtpn7xxr