### PR TITLE
Simplify dictionary lookup response format

### DIFF
--- a/mock_google_ai_server/src/data.ts
+++ b/mock_google_ai_server/src/data.ts
@@ -237,22 +237,22 @@ export const GRAMMAR_SENTENCE_LISTS: Record<string, string[]> = {
 export const DICTIONARY_LOOKUPS: Record<string, Record<string, string>> = {
   hu: {
     fahren: [
-      '<<H>><<B>>abfahren  <<B>>VERB<</B>><</B>>',
-      '<<B>>Forms: <</B>>fährt ab, fuhr ab, ist abgefahren',
-      '<<B>>Translation (hu): <</B>>elindulni, elhagyni',
+      '<<H>><<B>>elindulni, elhagyni<</B>>',
       '',
-      '<<B>>Example (de): <</B>>Wir fahren ab.',
-      '<<B>>Example (hu): <</B>>Elindulunk.',
+      'Wir fahren ab.',
+      'Elindulunk.',
+      '',
+      'fährt ab, fuhr ab, ist abgefahren',
     ].join('\n'),
   },
   en: {
     fahren: [
-      '<<H>><<B>>abfahren  <<B>>VERB<</B>><</B>>',
-      '<<B>>Forms: <</B>>fährt ab, fuhr ab, ist abgefahren',
-      '<<B>>Translation (en): <</B>>to depart, to leave',
+      '<<H>><<B>>to depart, to leave<</B>>',
       '',
-      '<<B>>Example (de): <</B>>Wir fahren ab.',
-      '<<B>>Example (en): <</B>>We depart.',
+      'Wir fahren ab.',
+      'We depart.',
+      '',
+      'fährt ab, fuhr ab, ist abgefahren',
     ].join('\n'),
   },
 };

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/DictionaryService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/DictionaryService.java
@@ -85,14 +85,10 @@ public class DictionaryService {
                 For nouns: include the article (e.g., "Häuser" becomes "das Haus").
                 For adjectives: use the base form (e.g., "großen" becomes "groß").
 
-                Determine the word type: VERB, NOUN, ADJECTIVE, ADVERB, PRONOUN, PREPOSITION, CONJUNCTION, INTERJECTION, ARTICLE, NUMERAL, or DETERMINER.
-
-                If the word is a noun, determine its grammatical gender: MASCULINE, FEMININE, or NEUTER. For non-nouns, omit gender.
-
                 Generate standard grammatical forms:
                 - For nouns: the plural form (e.g., "die Häuser")
                 - For verbs: 3. Person Singular Präsens, 3. Person Singular Präteritum, and 3. Person Singular Perfekt. Do NOT include pronouns - only the verb forms themselves.
-                - For other word types: omit forms line entirely.
+                - For other word types: omit forms entirely.
 
                 Translate the normalized word to %1$s.
 
@@ -105,32 +101,23 @@ public class DictionaryService {
                 - <<B>> = bold start
                 - <</B>> = bold end
 
-                Return exactly this format (each item on its own line, no blank lines except before the example block):
+                Return exactly this format:
 
-                For verbs:
-                <<H>><<B>>WORD  <<B>>WORD_TYPE<</B>><</B>>
-                <<B>>Forms: <</B>>form1, form2, form3
-                <<B>>Translation (%2$s): <</B>>translation
+                For words with forms (verbs and nouns):
+                <<H>><<B>>translation<</B>>
 
-                <<B>>Example (de): <</B>>German example sentence
-                <<B>>Example (%2$s): <</B>>Translated example sentence
+                German example sentence
+                Translated example sentence
 
-                For nouns:
-                <<H>><<B>>WORD  <<B>>NOUN<</B>> (GENDER)<</B>>
-                <<B>>Forms: <</B>>plural form
-                <<B>>Translation (%2$s): <</B>>translation
+                form1, form2, form3
 
-                <<B>>Example (de): <</B>>German example sentence
-                <<B>>Example (%2$s): <</B>>Translated example sentence
+                For other word types (no forms):
+                <<H>><<B>>translation<</B>>
 
-                For other word types (no forms line):
-                <<H>><<B>>WORD  <<B>>WORD_TYPE<</B>><</B>>
-                <<B>>Translation (%2$s): <</B>>translation
+                German example sentence
+                Translated example sentence
 
-                <<B>>Example (de): <</B>>German example sentence
-                <<B>>Example (%2$s): <</B>>Translated example sentence
-
-                Do not include any other text, explanation, or markdown. Only the formatted output.
+                Do not include any labels, word types, genders, or other text. Only the formatted output.
                 """
                 .formatted(languageName, targetLanguage);
     }

--- a/test/tests/dictionary.spec.ts
+++ b/test/tests/dictionary.spec.ts
@@ -52,17 +52,10 @@ test('dictionary endpoint translates a word to Hungarian', async ({ page }) => {
   expect(response.status).toBe(200);
   expect(response.headers.get('content-type')).toContain('text/plain');
   const text = await response.text();
-  expect(text).toContain(bold('VERB'));
-  expect(text).toContain(bold('Forms: ') + 'fährt ab, fuhr ab, ist abgefahren');
-  expect(text).toContain(
-    bold('Translation (hu): ') + 'elindulni, elhagyni'
-  );
-  expect(text).toContain(
-    bold('Example (de): ') + 'Wir fahren ab.'
-  );
-  expect(text).toContain(
-    bold('Example (hu): ') + 'Elindulunk.'
-  );
+  expect(text).toContain(bold('elindulni, elhagyni'));
+  expect(text).toContain('Wir fahren ab.');
+  expect(text).toContain('Elindulunk.');
+  expect(text).toContain('fährt ab, fuhr ab, ist abgefahren');
 });
 
 test('dictionary endpoint translates a word to English', async ({ page }) => {
@@ -74,17 +67,10 @@ test('dictionary endpoint translates a word to English', async ({ page }) => {
   expect(response.status).toBe(200);
   expect(response.headers.get('content-type')).toContain('text/plain');
   const text = await response.text();
-  expect(text).toContain(bold('VERB'));
-  expect(text).toContain(bold('Forms: ') + 'fährt ab, fuhr ab, ist abgefahren');
-  expect(text).toContain(
-    bold('Translation (en): ') + 'to depart, to leave'
-  );
-  expect(text).toContain(
-    bold('Example (de): ') + 'Wir fahren ab.'
-  );
-  expect(text).toContain(
-    bold('Example (en): ') + 'We depart.'
-  );
+  expect(text).toContain(bold('to depart, to leave'));
+  expect(text).toContain('Wir fahren ab.');
+  expect(text).toContain('We depart.');
+  expect(text).toContain('fährt ab, fuhr ab, ist abgefahren');
 });
 
 test('dictionary endpoint returns 401 without authorization header', async ({


### PR DESCRIPTION
## Summary
Refactored the dictionary lookup response format to be more concise and user-friendly by removing redundant labels and metadata while reorganizing the output structure.

## Key Changes
- **Removed metadata labels**: Eliminated "VERB", "NOUN", word type indicators, and gender information from the response
- **Simplified translation display**: Changed from labeled "Translation (language):" to bold translation text as the primary heading
- **Reorganized output structure**: 
  - Translation (bold) appears first as the main heading
  - Example sentences follow without language labels
  - Grammatical forms appear at the end without "Forms:" prefix
- **Updated prompt instructions**: Modified the AI prompt to reflect the new simpler format and removed instructions for including word types and genders
- **Updated test expectations**: Adjusted test assertions to match the new response format, removing checks for word type labels and language-prefixed example labels

## Implementation Details
- The new format prioritizes the translation as the primary information
- Example sentences are presented plainly without "Example (de):" and "Example (language):" prefixes
- Grammatical forms (verb conjugations, noun plurals) are listed at the end for reference
- The format is now consistent across all word types (verbs, nouns, and other parts of speech)
- Mock data in the test server was updated to reflect the new format

https://claude.ai/code/session_01HxLHQQgUrk3sEbysnaLEYR