### PR TITLE
Make draft card creation asynchronous and refactor source handling

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/LearnLanguageApplication.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/LearnLanguageApplication.java
@@ -2,8 +2,10 @@ package io.github.mucsi96.learnlanguage;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class LearnLanguageApplication {
 
 	public static void main(String[] args) {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/DraftCardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/DraftCardService.java
@@ -2,75 +2,117 @@ package io.github.mucsi96.learnlanguage.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import io.github.mucsi96.learnlanguage.entity.Card;
 import io.github.mucsi96.learnlanguage.entity.Source;
 import io.github.mucsi96.learnlanguage.model.CardData;
 import io.github.mucsi96.learnlanguage.model.CardReadiness;
+import io.github.mucsi96.learnlanguage.model.CardType;
 import io.github.mucsi96.learnlanguage.model.ChatModel;
+import io.github.mucsi96.learnlanguage.model.LanguageLevel;
 import io.github.mucsi96.learnlanguage.model.NormalizeWordResponse;
 import io.github.mucsi96.learnlanguage.model.OperationType;
+import io.github.mucsi96.learnlanguage.model.SourceFormatType;
+import io.github.mucsi96.learnlanguage.model.SourceType;
 import io.github.mucsi96.learnlanguage.model.TranslateWordRequest;
 import io.github.mucsi96.learnlanguage.model.TranslationResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class DraftCardService {
 
     private final CardService cardService;
+    private final SourceService sourceService;
     private final WordNormalizationService wordNormalizationService;
     private final TranslationService translationService;
     private final WordIdService wordIdService;
     private final ChatModelSettingService chatModelSettingService;
 
-    public void createDraftCard(Source source, String highlightedWord, String sentence) {
-        final Map<OperationType, String> primaryModels = chatModelSettingService.getPrimaryModelByOperation();
+    @Async
+    @Transactional
+    public void createDraftCard(String bookTitle, String highlightedWord, String sentence) {
+        try {
+            final Source source = getOrCreateSource(bookTitle);
 
-        final ChatModel classificationModel = ChatModel
-                .fromString(primaryModels.get(OperationType.CLASSIFICATION));
-        final ChatModel translationModel = ChatModel
-                .fromString(primaryModels.get(OperationType.TRANSLATION));
+            final Map<OperationType, String> primaryModels = chatModelSettingService.getPrimaryModelByOperation();
 
-        final NormalizeWordResponse normalizeResponse = wordNormalizationService.normalize(
-                highlightedWord, sentence, classificationModel);
+            final ChatModel classificationModel = ChatModel
+                    .fromString(primaryModels.get(OperationType.CLASSIFICATION));
+            final ChatModel translationModel = ChatModel
+                    .fromString(primaryModels.get(OperationType.TRANSLATION));
 
-        final TranslationResponse translationResponse = translationService.translate(
-                TranslateWordRequest.builder()
-                        .word(normalizeResponse.getNormalizedWord())
-                        .examples(List.of(sentence))
-                        .build(),
-                "hu", translationModel);
+            final NormalizeWordResponse normalizeResponse = wordNormalizationService.normalize(
+                    highlightedWord, sentence, classificationModel);
 
-        final String cardId = wordIdService.generateWordId(
-                normalizeResponse.getNormalizedWord(),
-                translationResponse.getTranslation());
+            final TranslationResponse translationResponse = translationService.translate(
+                    TranslateWordRequest.builder()
+                            .word(normalizeResponse.getNormalizedWord())
+                            .examples(List.of(sentence))
+                            .build(),
+                    "hu", translationModel);
 
-        if (cardService.getCardById(cardId).isPresent()) {
-            return;
+            final String cardId = wordIdService.generateWordId(
+                    normalizeResponse.getNormalizedWord(),
+                    translationResponse.getTranslation());
+
+            if (cardService.getCardById(cardId).isPresent()) {
+                return;
+            }
+
+            cardService.saveCard(Card.builder()
+                    .id(cardId)
+                    .source(source)
+                    .sourcePageNumber(1)
+                    .data(CardData.builder()
+                            .word(normalizeResponse.getNormalizedWord())
+                            .translation(Map.of("hu", translationResponse.getTranslation()))
+                            .build())
+                    .readiness(CardReadiness.DRAFT)
+                    .state("NEW")
+                    .due(LocalDateTime.now())
+                    .stability(0f)
+                    .difficulty(0f)
+                    .elapsedDays(0f)
+                    .scheduledDays(0f)
+                    .learningSteps(0)
+                    .reps(0)
+                    .lapses(0)
+                    .build());
+        } catch (Exception e) {
+            log.error("Failed to create draft card for word '{}': {}", highlightedWord, e.getMessage(), e);
         }
+    }
 
-        cardService.saveCard(Card.builder()
-                .id(cardId)
-                .source(source)
-                .sourcePageNumber(1)
-                .data(CardData.builder()
-                        .word(normalizeResponse.getNormalizedWord())
-                        .translation(Map.of("hu", translationResponse.getTranslation()))
-                        .build())
-                .readiness(CardReadiness.DRAFT)
-                .state("NEW")
-                .due(LocalDateTime.now())
-                .stability(0f)
-                .difficulty(0f)
-                .elapsedDays(0f)
-                .scheduledDays(0f)
-                .learningSteps(0)
-                .reps(0)
-                .lapses(0)
-                .build());
+    private Source getOrCreateSource(String bookTitle) {
+        final String sourceId = toSourceId(bookTitle);
+
+        return sourceService.getSourceById(sourceId)
+                .orElseGet(() -> {
+                    final Source newSource = Source.builder()
+                            .id(sourceId)
+                            .name(bookTitle)
+                            .sourceType(SourceType.EBOOK_DICTIONARY)
+                            .startPage(1)
+                            .languageLevel(LanguageLevel.B1)
+                            .cardType(CardType.VOCABULARY)
+                            .formatType(SourceFormatType.WORD_LIST_WITH_EXAMPLES)
+                            .build();
+                    return sourceService.saveSource(newSource);
+                });
+    }
+
+    private static String toSourceId(String bookTitle) {
+        return bookTitle.toLowerCase(Locale.ROOT)
+                .replaceAll("[^a-z0-9]+", "-")
+                .replaceAll("^-|-$", "");
     }
 }

--- a/test/tests/cards-table-page.spec.ts
+++ b/test/tests/cards-table-page.spec.ts
@@ -1116,12 +1116,11 @@ test('dictionary lookup creates draft card visible on cards page', async ({
 
   expect(response.status).toBe(200);
 
-  await page.goto(
-    'http://localhost:8180/sources/mein-erstes-buch/cards?draft=true'
-  );
-
-  const grid = page.getByRole('grid');
   await expect(async () => {
+    await page.goto(
+      'http://localhost:8180/sources/mein-erstes-buch/cards?draft=true'
+    );
+    const grid = page.getByRole('grid');
     const rows = await getGridData(grid);
     expect(rows.length).toBe(1);
     expect(rows[0].Readiness).toBe('DRAFT');
@@ -1165,6 +1164,15 @@ test('dictionary lookup does not duplicate draft cards', async ({ page }) => {
     }),
   });
 
+  await expect(async () => {
+    await withDbConnection(async (client) => {
+      const result = await client.query(
+        `SELECT id FROM learn_language.cards WHERE source_id = 'mein-erstes-buch'`
+      );
+      expect(result.rows.length).toBe(1);
+    });
+  }).toPass();
+
   await fetch('http://localhost:8180/api/dictionary', {
     method: 'POST',
     headers: {
@@ -1180,12 +1188,14 @@ test('dictionary lookup does not duplicate draft cards', async ({ page }) => {
     }),
   });
 
-  await withDbConnection(async (client) => {
-    const result = await client.query(
-      `SELECT id FROM learn_language.cards WHERE source_id = 'mein-erstes-buch'`
-    );
-    expect(result.rows.length).toBe(1);
-  });
+  await expect(async () => {
+    await withDbConnection(async (client) => {
+      const result = await client.query(
+        `SELECT id FROM learn_language.cards WHERE source_id = 'mein-erstes-buch'`
+      );
+      expect(result.rows.length).toBe(1);
+    });
+  }).toPass();
 });
 
 test('bulk card creation produces draft cards visible on cards page', async ({


### PR DESCRIPTION
## Summary
Refactored the draft card creation flow to be asynchronous and moved source management logic from the controller to the service layer. This improves separation of concerns and prevents blocking API responses during card creation.

## Key Changes
- **Async Processing**: Added `@Async` and `@Transactional` annotations to `DraftCardService.createDraftCard()` to process card creation asynchronously
- **Service Layer Refactoring**: Moved `getOrCreateSource()` and `toSourceId()` methods from `DictionaryController` to `DraftCardService`
- **Method Signature Update**: Changed `createDraftCard()` to accept `bookTitle` (String) instead of `Source` object, allowing the service to handle source creation internally
- **Error Handling**: Added try-catch block with logging to handle failures during async card creation
- **Controller Simplification**: Removed source management logic from `DictionaryController`, reducing its responsibilities
- **Async Configuration**: Enabled async support in `LearnLanguageApplication` with `@EnableAsync` annotation
- **Test Updates**: Updated E2E tests to use `expect().toPass()` pattern for async operations, ensuring proper polling for asynchronous card creation

## Implementation Details
- The service now handles the complete lifecycle of source and card creation, including automatic source creation if it doesn't exist
- Source IDs are generated from book titles using lowercase conversion and slug formatting
- Async execution allows the API endpoint to return immediately while card creation happens in the background
- Error logging provides visibility into any failures during the async card creation process

https://claude.ai/code/session_01BZMhf3b9ydSg6vJ9GKvh7C