### PR TITLE
Refactor image generation into single-phase process

### DIFF
--- a/client/src/app/bulk-card-creation.service.ts
+++ b/client/src/app/bulk-card-creation.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Card, ExampleImage, CardCreatePayload } from './parser/types';
+import { CardCreatePayload } from './parser/types';
 import { fetchJson } from './utils/fetchJson';
 import { createEmptyCard } from 'ts-fsrs';
 import { FsrsGradingService } from './fsrs-grading.service';
@@ -10,29 +10,14 @@ import {
   CardCreationRequest,
   CardType,
   CardTypeStrategy,
-  ImageGenerationInfo,
   ExtractedItem,
-  ImagesByIndex,
 } from './parser/types';
 import { DotProgress, DotStatus } from './shared/types/dot-progress.types';
-import { ImageResponse, ImageSourceRequest } from './shared/types/image-generation.types';
-import { ENVIRONMENT_CONFIG } from './environment/environment.config';
 import {
   processTasksWithRateLimit,
   summarizeResults,
   BatchResult,
 } from './utils/task-processor';
-
-interface ImageGenerationTask {
-  exampleIndex: number;
-  englishTranslation: string;
-  model: string;
-}
-
-interface ImageGenerationResult {
-  exampleIndex: number;
-  image: ExampleImage;
-}
 
 @Injectable({
   providedIn: 'root',
@@ -41,9 +26,7 @@ export class BulkCardCreationService {
   private readonly http = inject(HttpClient);
   private readonly fsrsGradingService = inject(FsrsGradingService);
   private readonly strategyRegistry = inject(CardTypeRegistry);
-  private readonly environmentConfig = inject(ENVIRONMENT_CONFIG);
-  readonly phase1Progress = signal<DotProgress[]>([]);
-  readonly phase2Progress = signal<DotProgress[]>([]);
+  readonly progress = signal<DotProgress[]>([]);
   readonly isCreating = signal(false);
 
   async createCardsInBulk(
@@ -66,79 +49,44 @@ export class BulkCardCreationService {
 
     const strategy = this.strategyRegistry.getStrategy(cardType);
 
-    this.phase1Progress.set(itemsToCreate.map(item => ({
+    this.progress.set(itemsToCreate.map(item => ({
       label: strategy.getItemLabel(item),
       status: 'pending' as const,
       tooltip: `${strategy.getItemLabel(item)}: Queued`,
     })));
-    this.phase2Progress.set([]);
 
-    const phase1Tasks = itemsToCreate.map(
+    const tasks = itemsToCreate.map(
       (item, index) => () => {
         const request: CardCreationRequest = { item, sourceId, pageNumber, cardType };
         return this.createSingleCard(request, index, strategy);
       }
     );
 
-    const phase1Results = await processTasksWithRateLimit(phase1Tasks, null);
-
-    const imageItems = phase1Results.reduce<
-      Array<{ cardId: string; imageInfos: ImageGenerationInfo[]; label: string }>
-    >(
-      (acc, result, index) => {
-        if (result.status === 'fulfilled' && result.value.length > 0) {
-          return [...acc, {
-            cardId: itemsToCreate[index].id,
-            imageInfos: result.value,
-            label: strategy.getItemLabel(itemsToCreate[index]),
-          }];
-        }
-        return acc;
-      },
-      []
-    );
-
-    if (imageItems.length > 0) {
-      this.phase2Progress.set(imageItems.map(item => ({
-        label: item.label,
-        status: 'pending' as const,
-        tooltip: `${item.label}: Queued`,
-      })));
-
-      const phase2Tasks = imageItems.map(
-        (item, phase2Index) => () =>
-          this.generateImagesForCard(item.cardId, item.imageInfos, phase2Index, strategy)
-      );
-
-      await processTasksWithRateLimit(
-        phase2Tasks,
-        this.environmentConfig.imageRateLimitPerMinute
-      );
-    }
+    const results = await processTasksWithRateLimit(tasks, null);
 
     this.isCreating.set(false);
 
-    return summarizeResults(phase1Results);
+    return summarizeResults(results);
   }
 
   private async createSingleCard(
     request: CardCreationRequest,
     progressIndex: number,
     strategy: CardTypeStrategy
-  ): Promise<ImageGenerationInfo[]> {
+  ): Promise<void> {
     const { item, sourceId, pageNumber } = request;
     const label = strategy.getItemLabel(item);
 
     try {
-      this.updatePhase1(progressIndex, 'in-progress', `${label}: Translating...`);
+      this.updateProgress(progressIndex, 'in-progress', `${label}: Translating...`);
 
       const progressCallback = (_progress: number, step: string) => {
-        this.updatePhase1(progressIndex, 'in-progress', `${label}: ${step}`);
+        this.updateProgress(progressIndex, 'in-progress', `${label}: ${step}`);
       };
 
-      const { cardData, imageGenerationInfos } = await strategy.createCardData(request, progressCallback);
+      const cardData = await strategy.createCardData(request, progressCallback);
 
-      this.updatePhase1(progressIndex, 'in-progress', `${label}: Creating card...`);
+      this.updateProgress(progressIndex, 'in-progress', `${label}: Creating card...`);
 
       const emptyCard = createEmptyCard();
       const cardWithFSRS = {
@@ -155,110 +103,22 @@ export class BulkCardCreationService {
         method: 'POST',
       });
 
-      this.updatePhase1(progressIndex, 'completed', `${label}: Done`);
-
-      return imageGenerationInfos;
+      this.updateProgress(progressIndex, 'completed', `${label}: Done`);
 
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : 'Unknown error';
-      this.updatePhase1(progressIndex, 'error', `${label}: Error - ${errorMsg}`);
+      this.updateProgress(progressIndex, 'error', `${label}: Error - ${errorMsg}`);
       throw error;
     }
   }
 
-  private async generateImagesForCard(
-    cardId: string,
-    imageInfos: ImageGenerationInfo[],
-    progressIndex: number,
-    strategy: CardTypeStrategy
-  ): Promise<void> {
-    const label = this.phase2Progress()[progressIndex].label;
-
-    try {
-      this.updatePhase2(progressIndex, 'in-progress', `${label}: Starting image generation...`);
-
-      const imageModels = this.environmentConfig.imageModels;
-
-      const tasks: ImageGenerationTask[] = imageInfos.flatMap(info =>
-        imageModels.map(model => ({
-          exampleIndex: info.exampleIndex,
-          englishTranslation: info.englishTranslation,
-          model: model.id
-        }))
-      );
-
-      const totalTasks = tasks.length;
-
-      const results = await tasks.reduce<Promise<ImageGenerationResult[]>>(
-        async (accPromise, task, index) => {
-          const acc = await accPromise;
-          try {
-            const responses = await fetchJson<ImageResponse[]>(
-              this.http,
-              `/api/image`,
-              {
-                body: {
-                  input: task.englishTranslation,
-                  model: task.model
-                } satisfies ImageSourceRequest,
-                method: 'POST',
-              }
-            );
-
-            this.updatePhase2(
-              progressIndex,
-              'in-progress',
-              `${label}: Generating images (${index + 1}/${totalTasks})...`
-            );
-
-            return [...acc, ...responses.map(response => ({ exampleIndex: task.exampleIndex, image: response }))];
-          } catch {
-            return acc;
-          }
-        },
-        Promise.resolve([])
-      );
-
-      if (results.length > 0) {
-        const imagesMap = results.reduce<ImagesByIndex>(
-          (acc, result) => {
-            const existing = acc.get(result.exampleIndex) ?? [];
-            return new Map([...acc, [result.exampleIndex, [...existing, result.image]]]);
-          },
-          new Map()
-        );
-
-        const card = await fetchJson<Card>(this.http, `/api/card/${cardId}`);
-        const updatedData = strategy.updateCardDataWithImages(card.data, imagesMap);
-
-        await fetchJson(this.http, `/api/card/${cardId}`, {
-          body: { data: updatedData },
-          method: 'PUT',
-        });
-      }
-
-      this.updatePhase2(progressIndex, 'completed', `${label}: Done`);
-    } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : 'Unknown error';
-      this.updatePhase2(progressIndex, 'error', `${label}: Error - ${errorMsg}`);
-      throw error;
-    }
-  }
-
-  private updatePhase1(index: number, status: DotStatus, tooltip: string): void {
-    this.phase1Progress.update(dots =>
-      dots.map((dot, i) => i === index ? { ...dot, status, tooltip } : dot)
-    );
-  }
-
-  private updatePhase2(index: number, status: DotStatus, tooltip: string): void {
-    this.phase2Progress.update(dots =>
+  private updateProgress(index: number, status: DotStatus, tooltip: string): void {
+    this.progress.update(dots =>
       dots.map((dot, i) => i === index ? { ...dot, status, tooltip } : dot)
     );
   }
 
   clearProgress(): void {
-    this.phase1Progress.set([]);
-    this.phase2Progress.set([]);
+    this.progress.set([]);
   }
 }

--- a/client/src/app/bulk-creation-progress-dialog/bulk-creation-progress-dialog.component.html
+++ b/client/src/app/bulk-creation-progress-dialog/bulk-creation-progress-dialog.component.html
@@ -1,11 +1,7 @@
 <h2 mat-dialog-title>Creating Cards</h2>
 
 <mat-dialog-content class="dialog-content">
-  <app-dot-reporter name="Collecting data" [dots]="bulkCardService.phase1Progress()" />
-
-  @if (bulkCardService.phase2Progress().length > 0) {
-    <app-dot-reporter name="Generating images" [dots]="bulkCardService.phase2Progress()" />
-  }
+  <app-dot-reporter name="Progress" [dots]="bulkCardService.progress()" />
 </mat-dialog-content>
 
 @if (!bulkCardService.isCreating()) {

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -160,25 +160,12 @@ export type CardCreationRequest = {
   cardType: CardType;
 };
 
-export type ImageGenerationInfo = {
-  cardId: string;
-  exampleIndex: number;
-  englishTranslation: string;
-};
-
-export type CardCreationResult = {
-  cardData: CardData;
-  imageGenerationInfos: ImageGenerationInfo[];
-};
-
 export type AudioGenerationItem = {
   text: string;
   language: string;
   context?: string;
   singleWord?: boolean;
 };
-
-export type ImagesByIndex = Map<number, ExampleImage[]>;
 
 export type LanguageTexts = {
   language: string;
@@ -196,13 +183,12 @@ export type CardTypeStrategy = {
   createCardData(
     request: CardCreationRequest,
     progressCallback: (progress: number, step: string) => void
-  ): Promise<CardCreationResult>;
+  ): Promise<CardData>;
   requiredAudioLanguages(): string[];
   getCardDisplayLabel(card: Card): string;
   getCardTypeLabel(card: Card): string;
   getCardAdditionalInfo(card: Card): string | undefined;
   getAudioItems(card: Card): AudioGenerationItem[];
-  updateCardDataWithImages(cardData: CardData, images: ImagesByIndex): CardData;
   getLanguageTexts(card: Card): LanguageTexts[];
 };
 


### PR DESCRIPTION
## Summary
Refactored the bulk card creation process from a two-phase system (card creation + image generation) into a single-phase process where images are generated immediately during card creation. This simplifies the workflow and improves user experience by consolidating progress tracking.

## Key Changes

- **Unified progress tracking**: Replaced separate `phase1Progress` and `phase2Progress` signals with a single `progress` signal in `BulkCardCreationService`
- **Inline image generation**: Moved image generation logic from a separate phase into the card creation process itself via a new `generateExampleImages` utility function
- **Simplified card type strategies**: Updated `CardTypeStrategy` interface to return `CardData` directly instead of `CardCreationResult` with separate image generation info
  - Removed `updateCardDataWithImages()` method from all card type implementations
  - Removed `ImageGenerationInfo` and `CardCreationResult` types
- **New utility module**: Created `image-generation.util.ts` to handle image generation with rate limiting and error handling
- **Updated progress callbacks**: Adjusted progress percentages in vocabulary, speech, and grammar card types to reflect the new single-phase workflow
- **Simplified UI**: Updated progress dialog to display a single progress reporter instead of two separate ones

## Implementation Details

- Image generation now happens synchronously within `createCardData()` for each card type
- The `generateExampleImages` utility handles parallel image generation across multiple models with proper error handling
- Images are directly embedded in the card data before card creation, eliminating the need for a separate update step
- All card type strategies now inject `ENVIRONMENT_CONFIG` to access image model configurations

https://claude.ai/code/session_01Jxu6Z5dx4RMxB4Jubnn7hM