### PR TITLE
Hide draft card actions and prevent navigation on draft rows

### DIFF
--- a/client/src/app/cards-table/cards-table.component.html
+++ b/client/src/app/cards-table/cards-table.component.html
@@ -108,26 +108,28 @@
         <mat-icon>delete</mat-icon>
         Delete {{ selectedCount() }}
       </button>
-      <button
-        mat-fab
-        extended
-        class="action-fab delete-audio-fab"
-        (click)="deleteSelectedAudio()"
-      >
-        <mat-icon>volume_off</mat-icon>
-        Delete audio {{ selectedCount() }}
-      </button>
-      <button
-        mat-fab
-        extended
-        color="primary"
-        class="action-fab"
-        (click)="markSelectedAsKnown()"
-      >
-        <mat-icon>check_circle</mat-icon>
-        Mark {{ selectedCount() }} as known
-      </button>
-      @if (isDraftMode() && sourceCardType()) {
+      @if (!selectionContainsDrafts()) {
+        <button
+          mat-fab
+          extended
+          class="action-fab delete-audio-fab"
+          (click)="deleteSelectedAudio()"
+        >
+          <mat-icon>volume_off</mat-icon>
+          Delete audio {{ selectedCount() }}
+        </button>
+        <button
+          mat-fab
+          extended
+          color="primary"
+          class="action-fab"
+          (click)="markSelectedAsKnown()"
+        >
+          <mat-icon>check_circle</mat-icon>
+          Mark {{ selectedCount() }} as known
+        </button>
+      }
+      @if (selectionContainsDrafts() && sourceCardType()) {
         <button
           mat-fab
           extended


### PR DESCRIPTION
## Summary
This PR restricts certain actions on draft cards to prevent unintended modifications. Draft cards now hide the "Delete audio" and "Mark as known" buttons, and clicking on a draft card row no longer navigates to its detail page.

## Key Changes
- **Hide audio and known actions for drafts**: The "Delete audio" and "Mark as known" buttons are now conditionally hidden when any selected card is in DRAFT status
- **Prevent draft card navigation**: Clicking on a draft card row no longer triggers navigation to the card detail page
- **Track card readiness**: Added `loadedRowReadiness` signal to maintain a map of card IDs to their readiness status for efficient lookup
- **New computed signal**: `selectionContainsDrafts()` determines if any selected cards are drafts by checking the readiness map
- **Updated row click handler**: Modified to check if a row is a draft before allowing navigation

## Implementation Details
- The readiness map is populated whenever grid data is loaded from the server, ensuring it stays in sync with displayed rows
- The conditional visibility uses the new `selectionContainsDrafts()` computed signal to determine which action buttons to show
- The "Complete draft cards" button remains visible when drafts are selected (only in draft mode with source card type)
- Added comprehensive test coverage for draft card behavior in different modes

https://claude.ai/code/session_019e5vFoHem2YnSdUfFxRBdN