### PR TITLE
Separate draft card counts from regular card counts

### DIFF
--- a/client/src/app/admin/admin.component.css
+++ b/client/src/app/admin/admin.component.css
@@ -86,6 +86,12 @@ p {
   font-size: 0.9rem;
 }
 
+.draft-card-count {
+  color: var(--mat-sys-tertiary);
+  margin: 0.25rem 0 0 0;
+  font-size: 0.85rem;
+}
+
 .source-actions {
   position: fixed;
   bottom: 24px;

--- a/client/src/app/admin/admin.component.html
+++ b/client/src/app/admin/admin.component.html
@@ -36,6 +36,11 @@
         <p class="card-count">
           {{ source.cardCount || 0 }} cards
         </p>
+        @if (source.draftCardCount) {
+        <p class="draft-card-count">
+          {{ source.draftCardCount }} drafts
+        </p>
+        }
       </mat-card-content>
     </mat-card>
   </article>
@@ -70,8 +75,7 @@
     <mat-icon>style</mat-icon>
     Cards
   </button>
-  @let iconText = isEbookDictionary() ? 'drafts' : 'menu_book';
-  @let label = isEbookDictionary() ? 'Draft Cards' : 'Pages';
+  @if (!isEbookDictionary()) {
   <button
     mat-fab
     extended
@@ -79,9 +83,10 @@
     class="action-fab"
     (click)="navigateToPages()"
   >
-    <mat-icon>{{ iconText }}</mat-icon>
-    {{ label }}
+    <mat-icon>menu_book</mat-icon>
+    Pages
   </button>
+  }
 </nav>
 }
 } @else {

--- a/client/src/app/admin/admin.component.ts
+++ b/client/src/app/admin/admin.component.ts
@@ -49,11 +49,7 @@ export class AdminComponent {
     const source = this.selectedSource();
     if (!source) return;
 
-    if (source.sourceType === 'ebookDictionary') {
-      this.router.navigate(['/sources', source.id, 'cards'], { queryParams: { draft: true } });
-    } else {
-      this.router.navigate(['/sources', source.id, 'page', source.startPage]);
-    }
+    this.router.navigate(['/sources', source.id, 'page', source.startPage]);
   }
 
   navigateToCards(): void {

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -203,6 +203,7 @@ export type Source = {
   startPage: number;
   pageCount?: number;
   cardCount?: number;
+  draftCardCount?: number;
   languageLevel?: LanguageLevel;
   cardType?: CardType;
   formatType?: SourceFormatType;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
@@ -68,9 +68,16 @@ public class SourceController {
   public List<SourceResponse> getSources() {
     var sources = sourceService.getAllSources();
     var cardCounts = cardService.getCardCountsBySource();
+    var draftCardCounts = cardService.getDraftCardCountsBySource();
 
     return sources.stream().map(source -> {
       var cardCount = cardCounts.stream()
+          .filter(count -> count.sourceId().equals(source.getId()))
+          .findFirst()
+          .map(SourceCardCount::count)
+          .orElse(0);
+
+      var draftCardCount = draftCardCounts.stream()
           .filter(count -> count.sourceId().equals(source.getId()))
           .findFirst()
           .map(SourceCardCount::count)
@@ -89,6 +96,7 @@ public class SourceController {
           .startPage(source.getBookmarkedPage() != null ? source.getBookmarkedPage() : source.getStartPage())
           .pageCount(pageCount)
           .cardCount(cardCount)
+          .draftCardCount(draftCardCount)
           .languageLevel(source.getLanguageLevel())
           .formatType(source.getFormatType())
           .build();

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceResponse.java
@@ -13,6 +13,7 @@ public class SourceResponse {
     private Integer startPage;
     private Integer pageCount;
     private Integer cardCount;
+    private Integer draftCardCount;
     private LanguageLevel languageLevel;
     private SourceFormatType formatType;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
@@ -25,8 +25,11 @@ public interface CardRepository
     @Query("SELECT c FROM Card c ORDER BY c.lastReview DESC")
     List<Card> findTopByOrderByLastReviewDesc(Pageable pageable);
 
-    @Query("SELECT c.source.id, COUNT(c) FROM Card c GROUP BY c.source.id")
+    @Query("SELECT c.source.id, COUNT(c) FROM Card c WHERE c.readiness <> io.github.mucsi96.learnlanguage.model.CardReadiness.DRAFT GROUP BY c.source.id")
     List<Object[]> countCardsBySourceGroupBySource();
+
+    @Query("SELECT c.source.id, COUNT(c) FROM Card c WHERE c.readiness = io.github.mucsi96.learnlanguage.model.CardReadiness.DRAFT GROUP BY c.source.id")
+    List<Object[]> countDraftCardsBySourceGroupBySource();
 
     @Query(value = """
         SELECT source_id, state, COUNT(*) AS card_count

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -122,6 +122,16 @@ public class CardService {
         .toList();
   }
 
+  public List<SourceCardCount> getDraftCardCountsBySource() {
+    return cardRepository.countDraftCardsBySourceGroupBySource()
+        .stream()
+        .map(record -> new SourceCardCount(
+            (String) record[0],
+            ((Long) record[1]).intValue())
+        )
+        .toList();
+  }
+
   public List<String> getFilteredCardIds(
       String sourceId,
       String readiness, String state,

--- a/test/tests/sources.spec.ts
+++ b/test/tests/sources.spec.ts
@@ -53,7 +53,7 @@ test('cards button navigates to cards table', async ({ page }) => {
   await expect(page).toHaveURL(/\/sources\/goethe-a1\/cards/);
 });
 
-test('displays card counts', async ({ page }) => {
+test('displays card counts excluding drafts', async ({ page }) => {
   await createCard({
     cardId: 'test-card-1',
     sourceId: 'goethe-a1',
@@ -74,8 +74,20 @@ test('displays card counts', async ({ page }) => {
       translation: { en: 'test2' },
     },
   });
+  await createCard({
+    cardId: 'test-card-draft',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'draft1',
+      type: 'NOUN',
+      translation: { en: 'draft1' },
+    },
+    readiness: 'DRAFT',
+  });
   await page.goto('http://localhost:8180/sources');
-  await expect(page.getByText('2 cards')).toBeVisible();
+  await expect(page.getByRole('article', { name: 'Goethe A1' }).getByText('2 cards')).toBeVisible();
+  await expect(page.getByRole('article', { name: 'Goethe A1' }).getByText('1 drafts')).toBeVisible();
 });
 
 test('displays card count for sources', async ({ page }) => {


### PR DESCRIPTION
## Summary
This PR separates the display and tracking of draft cards from regular cards throughout the application. Draft cards are now counted and displayed independently, allowing users to see both the number of published cards and draft cards for each source.

## Key Changes

**Backend (Java)**
- Modified `CardRepository.countCardsBySourceGroupBySource()` to exclude draft cards from the count
- Added new `CardRepository.countDraftCardsBySourceGroupBySource()` method to count only draft cards
- Added `CardService.getDraftCardCountsBySource()` method to retrieve draft card counts
- Updated `SourceController.getSources()` to fetch and include draft card counts in the response
- Added `draftCardCount` field to `SourceResponse` model

**Frontend (TypeScript/Angular)**
- Added `draftCardCount` optional field to the `Source` type definition
- Updated `AdminComponent` to display draft card counts separately with distinct styling
- Removed the conditional logic that navigated to draft cards for ebook dictionaries
- Simplified `navigateToPages()` to always navigate to the start page (removed ebook dictionary special case)
- Removed the "Draft Cards" button for ebook dictionaries, keeping only the "Pages" button

**Styling**
- Added `.draft-card-count` CSS class with tertiary color and smaller font size to visually distinguish draft counts

**Tests**
- Updated test to verify both regular card counts and draft card counts are displayed correctly
- Added test data with a draft card to validate the separation of counts
- Improved test selectors to be more specific using article role and name

https://claude.ai/code/session_01BMkADKiSjHcYYEcbuqWYc3