### PR TITLE
Update Gemini model versions from 3 Pro to 3.1 Pro

### DIFF
--- a/mock_google_ai_server/src/index.ts
+++ b/mock_google_ai_server/src/index.ts
@@ -32,7 +32,7 @@ app.post('/configure', (req, res) => {
 });
 
 app.post(
-  '/v1beta/models/gemini-3-pro-image-preview:generateContent',
+  '/v1beta/models/gemini-3.1-pro-image-preview:generateContent',
   (req, res) => {
     try {
       const prompt = req.body.contents[0].parts[0].text;
@@ -63,7 +63,7 @@ app.post(
 app.post(/\/v1beta\/models\/([^/]+):generateContent/, async (req, res) => {
   try {
     const model = req.params[0];
-    if (model === 'gemini-3-pro-image-preview') {
+    if (model === 'gemini-3.1-pro-image-preview') {
       return res.status(404).json({ error: { message: 'Use specific image endpoint' } });
     }
     console.log(`Gemini chat request for model: ${model}`);

--- a/mock_google_ai_server/src/utils.ts
+++ b/mock_google_ai_server/src/utils.ts
@@ -22,7 +22,7 @@ export const messagesMatch = (
 
 export const createGeminiResponse = (
   content: string | object,
-  model: string = 'gemini-3-pro-preview'
+  model: string = 'gemini-3.1-pro-preview'
 ) => {
   const messageContent =
     typeof content === 'object' ? JSON.stringify(content) : content;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/config/ModelPricingConfig.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/config/ModelPricingConfig.java
@@ -34,7 +34,7 @@ public class ModelPricingConfig {
         Map.entry("claude-sonnet-4-5", new ChatModelPricing(new BigDecimal("3.00"), new BigDecimal("15.00"))),
         Map.entry("claude-haiku-4-5", new ChatModelPricing(new BigDecimal("0.80"), new BigDecimal("4.00"))),
         // Google Gemini
-        Map.entry("gemini-3-pro-preview", new ChatModelPricing(new BigDecimal("2.00"), new BigDecimal("12.00"))),
+        Map.entry("gemini-3.1-pro-preview", new ChatModelPricing(new BigDecimal("2.00"), new BigDecimal("12.00"))),
         Map.entry("gemini-3-flash-preview", new ChatModelPricing(new BigDecimal("0.50"), new BigDecimal("3.00")))
     );
 
@@ -42,7 +42,7 @@ public class ModelPricingConfig {
         // OpenAI image models (1024x1024 high quality)
         "gpt-image-1.5", new ImageModelPricing(new BigDecimal("0.133")),
         // Gemini Developer API: 1,290 output tokens per 1024x1024 image at $30/M tokens
-        "gemini-3-pro-image-preview", new ImageModelPricing(new BigDecimal("0.039"))
+        "gemini-3.1-pro-image-preview", new ImageModelPricing(new BigDecimal("0.039"))
     );
 
     private static final Map<String, AudioModelPricing> AUDIO_MODEL_PRICING = Map.of(

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ChatModel.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ChatModel.java
@@ -20,7 +20,7 @@ public enum ChatModel {
   GPT_5_NANO("gpt-5-nano", ModelProvider.OPENAI),
   CLAUDE_SONNET_4_5("claude-sonnet-4-5", ModelProvider.ANTHROPIC),
   CLAUDE_HAIKU_4_5("claude-haiku-4-5", ModelProvider.ANTHROPIC),
-  GEMINI_3_PRO_PREVIEW("gemini-3-pro-preview", ModelProvider.GOOGLE),
+  GEMINI_3_1_PRO_PREVIEW("gemini-3.1-pro-preview", ModelProvider.GOOGLE),
   GEMINI_3_FLASH_PREVIEW("gemini-3-flash-preview", ModelProvider.GOOGLE);
 
   private final String modelName;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationModel.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationModel.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ImageGenerationModel {
     GPT_IMAGE_1_5("gpt-image-1.5", "GPT Image 1.5"),
-    GEMINI_3_PRO_IMAGE_PREVIEW("gemini-3-pro-image-preview", "Gemini 3 Pro");
+    GEMINI_3_1_PRO_IMAGE_PREVIEW("gemini-3.1-pro-image-preview", "Gemini 3.1 Pro");
 
     private final String modelName;
     private final String displayName;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ChatClientService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ChatClientService.java
@@ -56,8 +56,8 @@ public class ChatClientService {
       case CLAUDE_HAIKU_4_5 -> ChatClient.builder(anthropicChatModel)
           .defaultOptions(AnthropicChatOptions.builder().model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5).build())
           .build();
-      case GEMINI_3_PRO_PREVIEW -> ChatClient.builder(googleGenAiChatModel)
-          .defaultOptions(GoogleGenAiChatOptions.builder().model(GoogleGenAiChatModel.ChatModel.GEMINI_3_PRO_PREVIEW).build())
+      case GEMINI_3_1_PRO_PREVIEW -> ChatClient.builder(googleGenAiChatModel)
+          .defaultOptions(GoogleGenAiChatOptions.builder().model("gemini-3.1-pro-preview").build())
           .build();
       case GEMINI_3_FLASH_PREVIEW -> ChatClient.builder(googleGenAiChatModel)
           .defaultOptions(GoogleGenAiChatOptions.builder().model("gemini-3-flash-preview").build())

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/GoogleImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/GoogleImageService.java
@@ -18,7 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class GoogleImageService {
 
-  private static final String MODEL_NAME = "gemini-3-pro-image-preview";
+  private static final String MODEL_NAME = "gemini-3.1-pro-image-preview";
   private final Client googleAiClient;
   private final ModelUsageLoggingService usageLoggingService;
 
@@ -45,7 +45,7 @@ public class GoogleImageService {
           .toList();
 
       if (images.isEmpty()) {
-        throw new RuntimeException("No images found in Gemini 3 Pro Image response");
+        throw new RuntimeException("No images found in Gemini 3.1 Pro Image response");
       }
 
       final long processingTime = System.currentTimeMillis() - startTime;
@@ -54,8 +54,8 @@ public class GoogleImageService {
       return images;
 
     } catch (Exception e) {
-      log.error("Failed to generate images with Gemini 3 Pro Image", e);
-      throw new RuntimeException("Failed to generate images with Gemini 3 Pro Image: " + e.getMessage(), e);
+      log.error("Failed to generate images with Gemini 3.1 Pro Image", e);
+      throw new RuntimeException("Failed to generate images with Gemini 3.1 Pro Image: " + e.getMessage(), e);
     }
   }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
@@ -20,7 +20,7 @@ public class ImageService {
     final int imageCount = imageModelSettingService.getImageCount(model);
     return switch (model) {
       case GPT_IMAGE_1_5 -> openAIImageService.generateImages(input, imageCount);
-      case GEMINI_3_PRO_IMAGE_PREVIEW -> googleImageService.generateImages(input, imageCount);
+      case GEMINI_3_1_PRO_IMAGE_PREVIEW -> googleImageService.generateImages(input, imageCount);
     };
   }
 }

--- a/test/tests/bulk-card-creation.spec.ts
+++ b/test/tests/bulk-card-creation.spec.ts
@@ -393,14 +393,14 @@ test('bulk card creation includes word data', async ({ page }) => {
     expect(await getImageColor(page, image2)).toBe('red');
 
     expect(cardData.examples[0].images[0].model).toBe('GPT Image 1.5');
-    expect(cardData.examples[0].images[1].model).toBe('Gemini 3 Pro');
-    expect(cardData.examples[0].images[2].model).toBe('Gemini 3 Pro');
-    expect(cardData.examples[0].images[3].model).toBe('Gemini 3 Pro');
+    expect(cardData.examples[0].images[1].model).toBe('Gemini 3.1 Pro');
+    expect(cardData.examples[0].images[2].model).toBe('Gemini 3.1 Pro');
+    expect(cardData.examples[0].images[3].model).toBe('Gemini 3.1 Pro');
     expect(cardData.examples[1].images[0].model).toBe('GPT Image 1.5');
 
-    expect(cardData.translationModel).toBe('gemini-3-pro-preview');
-    expect(cardData.classificationModel).toBe('gemini-3-pro-preview');
-    expect(cardData.extractionModel).toBe('gemini-3-pro-preview');
+    expect(cardData.translationModel).toBe('gemini-3.1-pro-preview');
+    expect(cardData.classificationModel).toBe('gemini-3.1-pro-preview');
+    expect(cardData.extractionModel).toBe('gemini-3.1-pro-preview');
 
     const result2 = await client.query("SELECT data FROM learn_language.cards WHERE id = 'abfahrt-indulas'");
     expect(result2.rows.length).toBe(1);
@@ -411,9 +411,9 @@ test('bulk card creation includes word data', async ({ page }) => {
     expect(cardData2.type).toBe('NOUN');
     expect(cardData2.gender).toBe('FEMININE');
     expect(cardData2.forms).toEqual(['die Abfahrten']);
-    expect(cardData2.translationModel).toBe('gemini-3-pro-preview');
-    expect(cardData2.classificationModel).toBe('gemini-3-pro-preview');
-    expect(cardData2.extractionModel).toBe('gemini-3-pro-preview');
+    expect(cardData2.translationModel).toBe('gemini-3.1-pro-preview');
+    expect(cardData2.classificationModel).toBe('gemini-3.1-pro-preview');
+    expect(cardData2.extractionModel).toBe('gemini-3.1-pro-preview');
   });
 });
 
@@ -624,15 +624,15 @@ test('bulk speech card creation includes sentence data', async ({ page }) => {
     expect(card1?.data.examples[0].de).toBe('Wie heißt das Lied?');
     expect(card1?.data.examples[0].hu).toBe('Hogy hívják a dalt?');
     expect(card1?.data.examples[0].en).toBe('What is the name of the song?');
-    expect(card1?.data.translationModel).toBe('gemini-3-pro-preview');
-    expect(card1?.data.extractionModel).toBe('gemini-3-pro-preview');
+    expect(card1?.data.translationModel).toBe('gemini-3.1-pro-preview');
+    expect(card1?.data.extractionModel).toBe('gemini-3.1-pro-preview');
 
     const card2 = result.rows.find((row) => row.data.examples?.[0]?.de === 'Hören Sie.');
     expect(card2).toBeDefined();
     expect(card2?.data.examples[0].hu).toBe('Hallgasson.');
     expect(card2?.data.examples[0].en).toBe('Listen.');
-    expect(card2?.data.translationModel).toBe('gemini-3-pro-preview');
-    expect(card2?.data.extractionModel).toBe('gemini-3-pro-preview');
+    expect(card2?.data.translationModel).toBe('gemini-3.1-pro-preview');
+    expect(card2?.data.extractionModel).toBe('gemini-3.1-pro-preview');
   });
 });
 
@@ -790,13 +790,13 @@ test('bulk grammar card creation extracts sentences with gaps', async ({ page })
     expect(card1?.data.examples[0].en).toBe('This is Paco.');
     expect(card1?.data.examples[0].de).toContain('[ist]');
 
-    expect(card1?.data.translationModel).toBe('gemini-3-pro-preview');
-    expect(card1?.data.extractionModel).toBe('gemini-3-pro-preview');
+    expect(card1?.data.translationModel).toBe('gemini-3.1-pro-preview');
+    expect(card1?.data.extractionModel).toBe('gemini-3.1-pro-preview');
 
     const card2 = result.rows.find((row) => row.data.examples?.[0]?.de === 'Und [das] ist Frau Wachter.');
     expect(card2).toBeDefined();
     expect(card2?.data.examples[0].de).toContain('[das]');
-    expect(card2?.data.translationModel).toBe('gemini-3-pro-preview');
-    expect(card2?.data.extractionModel).toBe('gemini-3-pro-preview');
+    expect(card2?.data.translationModel).toBe('gemini-3.1-pro-preview');
+    expect(card2?.data.extractionModel).toBe('gemini-3.1-pro-preview');
   });
 });

--- a/test/tests/chat-model-settings.spec.ts
+++ b/test/tests/chat-model-settings.spec.ts
@@ -14,7 +14,7 @@ test('displays matrix with all chat models and operation types', async ({ page }
   await expect(page.getByRole('heading', { name: 'Data Models' })).toBeVisible();
 
   await expect(page.getByText('gpt-4o', { exact: true })).toBeVisible();
-  await expect(page.getByText('gemini-3-pro-preview')).toBeVisible();
+  await expect(page.getByText('gemini-3.1-pro-preview')).toBeVisible();
 
   await expect(page.getByText('Translation')).toBeVisible();
   await expect(page.getByText('Extraction')).toBeVisible();
@@ -29,7 +29,7 @@ test('can set primary model for operation type', async ({ page }) => {
     isPrimary: false,
   });
   await createChatModelSetting({
-    modelName: 'gemini-3-pro-preview',
+    modelName: 'gemini-3.1-pro-preview',
     operationType: 'TRANSLATION',
     isEnabled: true,
     isPrimary: true,
@@ -38,7 +38,7 @@ test('can set primary model for operation type', async ({ page }) => {
   await page.goto('http://localhost:8180/settings/data-models');
 
   const gptRow = page.getByRole('row', { name: /gpt-4o(?!\S)/ });
-  const geminiRow = page.getByRole('row', { name: 'gemini-3-pro-preview' });
+  const geminiRow = page.getByRole('row', { name: 'gemini-3.1-pro-preview' });
   const gptPrimaryRadio = gptRow.getByRole('radio').first();
   const geminiPrimaryRadio = geminiRow.getByRole('radio').first();
 
@@ -54,7 +54,7 @@ test('can set primary model for operation type', async ({ page }) => {
     const settings = await getChatModelSettings();
     const gptSetting = settings.find((s) => s.modelName === 'gpt-4o' && s.operationType === 'TRANSLATION');
     const geminiSetting = settings.find(
-      (s) => s.modelName === 'gemini-3-pro-preview' && s.operationType === 'TRANSLATION'
+      (s) => s.modelName === 'gemini-3.1-pro-preview' && s.operationType === 'TRANSLATION'
     );
 
     expect(gptSetting?.isPrimary).toBe(true);

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -178,7 +178,7 @@ test('card editing in db', async ({ page }) => {
   await expect(page.getByRole('img')).toHaveCount(6);
 
   await expect(page.getByText('GPT Image 1.5')).toHaveCount(1);
-  await expect(page.getByText('Gemini 3 Pro')).toHaveCount(3);
+  await expect(page.getByText('Gemini 3.1 Pro')).toHaveCount(3);
 
   await page.evaluate(() => {
     window.scrollTo(0, document.body.scrollHeight);
@@ -215,9 +215,9 @@ test('card editing in db', async ({ page }) => {
     expect(cardData.examples[0].images).toHaveLength(1);
     expect(cardData.examples[1].images).toHaveLength(5);
     expect(cardData.examples[1].images[1].model).toBe('GPT Image 1.5');
-    expect(cardData.examples[1].images[2].model).toBe('Gemini 3 Pro');
-    expect(cardData.examples[1].images[3].model).toBe('Gemini 3 Pro');
-    expect(cardData.examples[1].images[4].model).toBe('Gemini 3 Pro');
+    expect(cardData.examples[1].images[2].model).toBe('Gemini 3.1 Pro');
+    expect(cardData.examples[1].images[3].model).toBe('Gemini 3.1 Pro');
+    expect(cardData.examples[1].images[4].model).toBe('Gemini 3.1 Pro');
   });
 });
 
@@ -452,7 +452,7 @@ test('example image addition', async ({ page }) => {
   await expect(page.getByRole('img')).toHaveCount(5);
 
   await expect(page.getByText('GPT Image 1.5')).toHaveCount(1);
-  await expect(page.getByText('Gemini 3 Pro')).toHaveCount(3);
+  await expect(page.getByText('Gemini 3.1 Pro')).toHaveCount(3);
 
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
 

--- a/test/tests/enabled-models-filtering.spec.ts
+++ b/test/tests/enabled-models-filtering.spec.ts
@@ -8,7 +8,7 @@ async function setupChatModelsForAllOperations(config: {
 }): Promise<void> {
   await clearChatModelSettings();
 
-  const defaultModel = 'gemini-3-pro-preview';
+  const defaultModel = 'gemini-3.1-pro-preview';
   const operations = [
     'EXTRACTION',
     'CLASSIFICATION',
@@ -29,7 +29,7 @@ test('word extraction only uses enabled models for extraction operation', async 
   await setupDefaultImageModelSettings();
   await createRateLimitSetting({ key: 'image-per-minute', value: 60 });
   await setupChatModelsForAllOperations({
-    EXTRACTION: ['gpt-4o', 'gemini-3-pro-preview'],
+    EXTRACTION: ['gpt-4o', 'gemini-3.1-pro-preview'],
   });
 
   await page.goto('http://localhost:8180/sources');
@@ -47,7 +47,7 @@ test('word extraction only uses enabled models for extraction operation', async 
 
   const modelNames = wordExtractionLogs.map((log) => log.modelName);
   expect(modelNames).toContain('gpt-4o');
-  expect(modelNames).toContain('gemini-3-pro-preview');
+  expect(modelNames).toContain('gemini-3.1-pro-preview');
   expect(modelNames).not.toContain('claude-sonnet-4-5');
   expect(modelNames).not.toContain('gpt-4.1');
 });
@@ -56,7 +56,7 @@ test('bulk card creation only uses enabled models for classification operation',
   await setupDefaultImageModelSettings();
   await createRateLimitSetting({ key: 'image-per-minute', value: 60 });
   await setupChatModelsForAllOperations({
-    CLASSIFICATION: ['gpt-4o', 'gemini-3-pro-preview'],
+    CLASSIFICATION: ['gpt-4o', 'gemini-3.1-pro-preview'],
   });
 
   await page.goto('http://localhost:8180/sources');
@@ -76,7 +76,7 @@ test('bulk card creation only uses enabled models for classification operation',
 
   const modelNames = [...new Set(wordTypeLogs.map((log) => log.modelName))];
   expect(modelNames).toContain('gpt-4o');
-  expect(modelNames).toContain('gemini-3-pro-preview');
+  expect(modelNames).toContain('gemini-3.1-pro-preview');
   expect(modelNames).not.toContain('claude-sonnet-4-5');
   expect(modelNames).not.toContain('gpt-4.1');
 });
@@ -85,7 +85,7 @@ test('bulk card creation only uses enabled models for translation operations', a
   await setupDefaultImageModelSettings();
   await createRateLimitSetting({ key: 'image-per-minute', value: 60 });
   await setupChatModelsForAllOperations({
-    TRANSLATION: ['gpt-4o', 'gemini-3-pro-preview'],
+    TRANSLATION: ['gpt-4o', 'gemini-3.1-pro-preview'],
   });
 
   await page.goto('http://localhost:8180/sources');
@@ -106,7 +106,7 @@ test('bulk card creation only uses enabled models for translation operations', a
   const modelNames = [...new Set(translationLogs.map((log) => log.modelName))];
 
   expect(modelNames).toContain('gpt-4o');
-  expect(modelNames).toContain('gemini-3-pro-preview');
+  expect(modelNames).toContain('gemini-3.1-pro-preview');
   expect(modelNames).not.toContain('claude-sonnet-4-5');
 });
 
@@ -114,8 +114,8 @@ test('different operation types can have different enabled models', async ({ pag
   await setupDefaultImageModelSettings();
   await createRateLimitSetting({ key: 'image-per-minute', value: 60 });
   await setupChatModelsForAllOperations({
-    CLASSIFICATION: ['gpt-4o', 'gemini-3-pro-preview'],
-    TRANSLATION: ['gemini-3-pro-preview'],
+    CLASSIFICATION: ['gpt-4o', 'gemini-3.1-pro-preview'],
+    TRANSLATION: ['gemini-3.1-pro-preview'],
   });
 
   await page.goto('http://localhost:8180/sources');
@@ -136,6 +136,6 @@ test('different operation types can have different enabled models', async ({ pag
   const classificationModels = [...new Set(classificationLogs.map((log) => log.modelName))];
   const translationEnModels = [...new Set(translationLogs.map((log) => log.modelName))];
   expect(classificationModels).toContain('gpt-4o');
-  expect(classificationModels).toContain('gemini-3-pro-preview');
-  expect(translationEnModels).toEqual(['gemini-3-pro-preview']);
+  expect(classificationModels).toContain('gemini-3.1-pro-preview');
+  expect(translationEnModels).toEqual(['gemini-3.1-pro-preview']);
 });

--- a/test/tests/image-model-settings.spec.ts
+++ b/test/tests/image-model-settings.spec.ts
@@ -14,10 +14,10 @@ test('displays all image models with default image counts', async ({ page }) => 
   await expect(page.getByRole('heading', { name: 'Image Models' })).toBeVisible();
 
   await expect(page.getByText('GPT Image 1.5')).toBeVisible();
-  await expect(page.getByText('Gemini 3 Pro')).toBeVisible();
+  await expect(page.getByText('Gemini 3.1 Pro')).toBeVisible();
 
   const gptInput = page.getByRole('spinbutton', { name: 'Image count for GPT Image 1.5' });
-  const geminiInput = page.getByRole('spinbutton', { name: 'Image count for Gemini 3 Pro' });
+  const geminiInput = page.getByRole('spinbutton', { name: 'Image count for Gemini 3.1 Pro' });
 
   await expect(gptInput).toHaveValue('0');
   await expect(geminiInput).toHaveValue('0');
@@ -25,12 +25,12 @@ test('displays all image models with default image counts', async ({ page }) => 
 
 test('displays image counts from database settings', async ({ page }) => {
   await createImageModelSetting({ modelName: 'gpt-image-1.5', imageCount: 2 });
-  await createImageModelSetting({ modelName: 'gemini-3-pro-image-preview', imageCount: 5 });
+  await createImageModelSetting({ modelName: 'gemini-3.1-pro-image-preview', imageCount: 5 });
 
   await page.goto('http://localhost:8180/settings/image-models');
 
   const gptInput = page.getByRole('spinbutton', { name: 'Image count for GPT Image 1.5' });
-  const geminiInput = page.getByRole('spinbutton', { name: 'Image count for Gemini 3 Pro' });
+  const geminiInput = page.getByRole('spinbutton', { name: 'Image count for Gemini 3.1 Pro' });
 
   await expect(gptInput).toHaveValue('2');
   await expect(geminiInput).toHaveValue('5');

--- a/test/tests/model-usage-page.spec.ts
+++ b/test/tests/model-usage-page.spec.ts
@@ -75,7 +75,7 @@ test('displays chat model usage logs', async ({ page }) => {
   });
 
   await createModelUsageLog({
-    modelName: 'gemini-3-pro-preview',
+    modelName: 'gemini-3.1-pro-preview',
     modelType: 'CHAT',
     operationType: 'CLASSIFICATION',
     operationId: 'op-chat-2',
@@ -97,7 +97,7 @@ test('displays chat model usage logs', async ({ page }) => {
 
     expect(gridData.map(({ Time, Rating, Diff, ...rest }) => rest)).toEqual([
       {
-        Model: 'gemini-3-pro-preview',
+        Model: 'gemini-3.1-pro-preview',
         Type: 'CHAT',
         Operation: 'classification',
         Usage: '100 / 25 tokens',
@@ -414,7 +414,7 @@ test('displays model summary tab', async ({ page }) => {
   });
 
   await createModelUsageLog({
-    modelName: 'gemini-3-pro-preview',
+    modelName: 'gemini-3.1-pro-preview',
     modelType: 'CHAT',
     operationType: 'TRANSLATION',
     operationId: 'op-summary-3',
@@ -439,7 +439,7 @@ test('displays model summary tab', async ({ page }) => {
 
     expect(summaryData).toEqual([
       {
-        Model: 'gemini-3-pro-preview',
+        Model: 'gemini-3.1-pro-preview',
         'Total Calls': '1',
         'Rated Calls': '1',
         'Avg Rating': '4.00',
@@ -577,7 +577,7 @@ test('groups logs with same operation id and shows diff summary', async ({ page 
   });
 
   await createModelUsageLog({
-    modelName: 'gemini-3-pro-preview',
+    modelName: 'gemini-3.1-pro-preview',
     modelType: 'CHAT',
     operationType: 'TRANSLATION',
     operationId,
@@ -617,7 +617,7 @@ test('shows primary badge on fastest model in group', async ({ page }) => {
   });
 
   await createModelUsageLog({
-    modelName: 'gemini-3-pro-preview',
+    modelName: 'gemini-3.1-pro-preview',
     modelType: 'CHAT',
     operationType: 'TRANSLATION',
     operationId,
@@ -649,7 +649,7 @@ test('shows diff view in expanded state for non-primary logs', async ({ page }) 
   });
 
   await createModelUsageLog({
-    modelName: 'gemini-3-pro-preview',
+    modelName: 'gemini-3.1-pro-preview',
     modelType: 'CHAT',
     operationType: 'TRANSLATION',
     operationId,
@@ -747,7 +747,7 @@ test('shows identical label when grouped logs have same response', async ({ page
   });
 
   await createModelUsageLog({
-    modelName: 'gemini-3-pro-preview',
+    modelName: 'gemini-3.1-pro-preview',
     modelType: 'CHAT',
     operationType: 'TRANSLATION',
     operationId,

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -778,7 +778,7 @@ const ALL_OPERATION_TYPES = [
   'CLASSIFICATION',
 ];
 
-const DEFAULT_CHAT_MODEL = 'gemini-3-pro-preview';
+const DEFAULT_CHAT_MODEL = 'gemini-3.1-pro-preview';
 
 export async function setupDefaultChatModelSettings(): Promise<void> {
   for (const operationType of ALL_OPERATION_TYPES) {
@@ -837,7 +837,7 @@ export async function createImageModelSetting(params: {
 
 const DEFAULT_IMAGE_MODEL_SETTINGS = [
   { modelName: 'gpt-image-1.5', imageCount: 1 },
-  { modelName: 'gemini-3-pro-image-preview', imageCount: 3 },
+  { modelName: 'gemini-3.1-pro-image-preview', imageCount: 3 },
 ];
 
 export async function setupDefaultImageModelSettings(): Promise<void> {


### PR DESCRIPTION
## Summary
This PR updates all references to Google's Gemini model from version 3 Pro to version 3.1 Pro across the codebase, including both chat and image generation models.

## Key Changes
- **Chat Model**: Updated `gemini-3-pro-preview` to `gemini-3.1-pro-preview` in:
  - Model enum definition (`ChatModel.java`)
  - Model pricing configuration
  - Chat client service configuration
  - All test fixtures and test expectations
  
- **Image Generation Model**: Updated `gemini-3-pro-image-preview` to `gemini-3.1-pro-image-preview` in:
  - Image model enum definition (`ImageGenerationModel.java`)
  - Display name from "Gemini 3 Pro" to "Gemini 3.1 Pro"
  - Google Image Service implementation
  - Model pricing configuration
  - All test fixtures and test expectations

- **Mock Server**: Updated the mock Google AI server endpoint from `/gemini-3-pro-image-preview:generateContent` to `/gemini-3.1-pro-image-preview:generateContent`

- **Test Updates**: Updated all test assertions and setup utilities to expect the new model names and display names across:
  - Bulk card creation tests
  - Model usage page tests
  - Chat model settings tests
  - Image model settings tests
  - Edit card page tests
  - Enabled models filtering tests

## Implementation Details
- The model name change follows Google's versioning scheme (3 Pro → 3.1 Pro)
- Display names in the UI were updated to reflect the new version
- All pricing configurations remain the same, only the model identifiers changed
- The change is backward compatible in terms of functionality, only updating model references

https://claude.ai/code/session_01L6ioEYtucQ2yTAzyig8zg8