### PR TITLE
Reorder voice config sections and filter inactive image models

### DIFF
--- a/client/src/app/image-model-settings/image-model-settings.component.html
+++ b/client/src/app/image-model-settings/image-model-settings.component.html
@@ -48,7 +48,7 @@
     </mat-card-header>
     <mat-card-content>
       <div class="rate-limit-field">
-        <mat-form-field class="count-field">
+        <mat-form-field>
           <mat-label>Requests per minute</mat-label>
           <input
             matInput

--- a/client/src/app/utils/image-generation.util.ts
+++ b/client/src/app/utils/image-generation.util.ts
@@ -15,7 +15,7 @@ export const generateExampleImages = async (
   imageModels: ReadonlyArray<{ id: string; imageCount: number }>,
   inputs: ReadonlyArray<ImageGenerationInput>
 ): Promise<ImagesByIndex> => {
-  const activeModels = imageModels.filter((m) => m.imageCount > 0);
+  const activeModels = imageModels.filter((model) => model.imageCount > 0);
   if (inputs.length === 0 || activeModels.length === 0) {
     return new Map();
   }

--- a/client/src/app/utils/image-generation.util.ts
+++ b/client/src/app/utils/image-generation.util.ts
@@ -12,16 +12,17 @@ export type ImagesByIndex = Map<number, ExampleImage[]>;
 
 export const generateExampleImages = async (
   http: HttpClient,
-  imageModels: ReadonlyArray<{ id: string }>,
+  imageModels: ReadonlyArray<{ id: string; imageCount: number }>,
   inputs: ReadonlyArray<ImageGenerationInput>
 ): Promise<ImagesByIndex> => {
-  if (inputs.length === 0 || imageModels.length === 0) {
+  const activeModels = imageModels.filter((m) => m.imageCount > 0);
+  if (inputs.length === 0 || activeModels.length === 0) {
     return new Map();
   }
 
   const results = await Promise.all(
     inputs.flatMap(input =>
-      imageModels.map(async (model) => {
+      activeModels.map(async (model) => {
         try {
           const responses = await fetchJson<ImageResponse[]>(
             http,

--- a/client/src/app/voice-config/voice-config.component.html
+++ b/client/src/app/voice-config/voice-config.component.html
@@ -2,6 +2,27 @@
   <div class="config-section">
     <mat-card>
       <mat-card-header>
+        <mat-card-title><h2>Rate Limit</h2></mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <div class="rate-limit-field">
+          <mat-form-field>
+            <mat-label>Requests per minute</mat-label>
+            <input
+              matInput
+              type="number"
+              [value]="audioRateLimitPerMinute()"
+              (change)="onAudioRateLimitChange($event)"
+              min="1"
+              aria-label="Audio rate limit per minute"
+            />
+          </mat-form-field>
+        </div>
+      </mat-card-content>
+    </mat-card>
+
+    <mat-card>
+      <mat-card-header>
         <mat-card-title><h2>Voice</h2></mat-card-title>
         <button
           mat-icon-button
@@ -145,27 +166,6 @@
           </table>
         </div>
         } } }
-      </mat-card-content>
-    </mat-card>
-
-    <mat-card>
-      <mat-card-header>
-        <mat-card-title><h2>Rate Limit</h2></mat-card-title>
-      </mat-card-header>
-      <mat-card-content>
-        <div class="rate-limit-field">
-          <mat-form-field>
-            <mat-label>Requests per minute</mat-label>
-            <input
-              matInput
-              type="number"
-              [value]="audioRateLimitPerMinute()"
-              (change)="onAudioRateLimitChange($event)"
-              min="1"
-              aria-label="Audio rate limit per minute"
-            />
-          </mat-form-field>
-        </div>
       </mat-card-content>
     </mat-card>
   </div>

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
@@ -18,6 +18,9 @@ public class ImageService {
 
   public List<byte[]> generateImages(String input, ImageGenerationModel model) {
     final int imageCount = imageModelSettingService.getImageCount(model);
+    if (imageCount == 0) {
+      return List.of();
+    }
     return switch (model) {
       case GPT_IMAGE_1_5 -> openAIImageService.generateImages(input, imageCount);
       case GEMINI_3_PRO_IMAGE_PREVIEW -> googleImageService.generateImages(input, imageCount);

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
@@ -18,7 +18,7 @@ public class ImageService {
 
   public List<byte[]> generateImages(String input, ImageGenerationModel model) {
     final int imageCount = imageModelSettingService.getImageCount(model);
-    if (imageCount == 0) {
+    if (imageCount <= 0) {
       return List.of();
     }
     return switch (model) {

--- a/test/tests/bulk-card-creation.spec.ts
+++ b/test/tests/bulk-card-creation.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../fixtures';
 import {
   createCard,
+  createImageModelSetting,
   createSource,
   createRateLimitSetting,
   selectTextRange,
@@ -417,8 +418,10 @@ test('bulk card creation includes word data', async ({ page }) => {
   });
 });
 
-test('bulk card creation skips image generation when all image counts are zero', async ({ page }) => {
+test('bulk card creation skips image generation for models with zero image count', async ({ page }) => {
   await setupDefaultChatModelSettings();
+  await createImageModelSetting({ modelName: 'gpt-image-1.5', imageCount: 2 });
+  await createRateLimitSetting({ key: 'image-per-minute', value: 60 });
   await page.goto('http://localhost:8180/sources');
   await page.getByRole('article', { name: 'Goethe A1' }).click();
   await page.getByRole('button', { name: 'Pages' }).click();
@@ -436,8 +439,10 @@ test('bulk card creation skips image generation when all image counts are zero',
     const cardData = result.rows[0].data;
 
     expect(cardData.word).toBe('abfahren');
-    expect(cardData.examples[0].images).toEqual([]);
-    expect(cardData.examples[1].images).toEqual([]);
+    expect(cardData.examples[0].images.length).toBe(2);
+    expect(cardData.examples[0].images.every((img: { model: string }) => img.model === 'GPT Image 1.5')).toBe(true);
+    expect(cardData.examples[1].images.length).toBe(2);
+    expect(cardData.examples[1].images.every((img: { model: string }) => img.model === 'GPT Image 1.5')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
This PR makes two key improvements: reorders the voice configuration UI to place the Rate Limit section first, and adds filtering logic to prevent image generation requests for models with zero configured images.

## Key Changes

- **Voice Config UI Reordering**: Moved the "Rate Limit" card to the top of the voice configuration section for better UX, as rate limiting is a foundational setting that should be configured before other voice options.

- **Image Model Filtering**: Updated the image generation utility to filter out inactive image models (those with `imageCount === 0`) before making API requests, reducing unnecessary network calls.

- **Server-side Safety Check**: Added a guard in `ImageService.generateImages()` to return an empty list when `imageCount` is 0, providing defense-in-depth against invalid requests.

- **Minor CSS Cleanup**: Removed unnecessary `count-field` class from the image model settings form field for consistency.

## Implementation Details

The image model filtering is applied at multiple levels:
1. Client-side: `generateExampleImages()` filters models before making requests
2. Server-side: `ImageService` validates imageCount before processing

This ensures that disabled image models (with count = 0) are gracefully skipped throughout the generation pipeline.

https://claude.ai/code/session_01BFZQZaXJ47D9Vz7QsMXjux