### PR TITLE
Add "Review cards" link to bulk creation progress dialog

### DIFF
--- a/client/src/app/bulk-creation-progress-dialog/bulk-creation-progress-dialog.component.html
+++ b/client/src/app/bulk-creation-progress-dialog/bulk-creation-progress-dialog.component.html
@@ -6,6 +6,7 @@
 
 @if (!bulkCardService.isCreating()) {
 <mat-dialog-actions align="end">
+  <a mat-button [routerLink]="['/in-review-cards']" [mat-dialog-close]="true">Review cards</a>
   <button mat-button [mat-dialog-close]="true">Close</button>
 </mat-dialog-actions>
 }

--- a/client/src/app/bulk-creation-progress-dialog/bulk-creation-progress-dialog.component.ts
+++ b/client/src/app/bulk-creation-progress-dialog/bulk-creation-progress-dialog.component.ts
@@ -4,6 +4,7 @@ import {
   MatDialogModule,
 } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
+import { RouterLink } from '@angular/router';
 import { BulkCardCreationService } from '../bulk-card-creation.service';
 import { DotReporterComponent } from '../shared/dot-reporter/dot-reporter.component';
 
@@ -13,6 +14,7 @@ import { DotReporterComponent } from '../shared/dot-reporter/dot-reporter.compon
   imports: [
     MatDialogModule,
     MatButtonModule,
+    RouterLink,
     DotReporterComponent,
   ],
   templateUrl: './bulk-creation-progress-dialog.component.html',

--- a/test/tests/bulk-card-creation.spec.ts
+++ b/test/tests/bulk-card-creation.spec.ts
@@ -479,6 +479,29 @@ test('bulk card creation updates ui after completion', async ({ page }) => {
   await expect(page.getByRole('link', { name: 'die Abfahrt' })).toHaveAccessibleDescription('Card exists');
 });
 
+test('bulk card creation dialog shows review cards link', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await setupDefaultImageModelSettings();
+  await createRateLimitSetting({ key: 'image-per-minute', value: 60 });
+  await page.goto('http://localhost:8180/sources');
+  await page.getByRole('article', { name: 'Goethe A1' }).click();
+  await page.getByRole('button', { name: 'Pages' }).click();
+
+  await selectTextRange(page, 'aber', 'Vor der Abfahrt rufe ich an.');
+
+  await page.getByRole('button', { name: 'Create cards in bulk' }).click();
+
+  await expect(page.getByRole('dialog').getByRole('button', { name: 'Close' })).toBeVisible();
+
+  const reviewLink = page.getByRole('dialog').getByRole('link', { name: 'Review cards' });
+  await expect(reviewLink).toBeVisible();
+
+  await reviewLink.click();
+
+  await expect(page.getByRole('heading', { name: 'Cards In Review' })).toBeVisible();
+  await expect(page).toHaveURL(/\/in-review-cards$/);
+});
+
 test('bulk card creation fsrs attributes', async ({ page }) => {
   await setupDefaultChatModelSettings();
   await setupDefaultImageModelSettings();


### PR DESCRIPTION
## Summary
Added a "Review cards" link to the bulk card creation progress dialog that navigates users to the in-review-cards page after cards have been created.

## Key Changes
- **bulk-creation-progress-dialog.component.html**: Added a "Review cards" link button that routes to `/in-review-cards` and closes the dialog
- **bulk-creation-progress-dialog.component.ts**: Imported `RouterLink` module to enable routing functionality in the template
- **bulk-card-creation.spec.ts**: Added test case to verify the "Review cards" link is visible in the dialog and navigates to the correct page

## Implementation Details
- The "Review cards" link appears in the dialog actions alongside the existing "Close" button
- The link only displays after card creation is complete (when `!bulkCardService.isCreating()`)
- Clicking the link both navigates to the review page and closes the dialog via `[mat-dialog-close]="true"`

https://claude.ai/code/session_01KWDgS1kig7d6i8Y7qjqEFi