### PR TITLE
Add max concurrent requests rate limiting for image and audio

### DIFF
--- a/client/src/app/environment/environment.config.ts
+++ b/client/src/app/environment/environment.config.ts
@@ -58,6 +58,8 @@ export interface EnvironmentConfig {
   mockAuth: boolean;
   imageRateLimitPerMinute: number;
   audioRateLimitPerMinute: number;
+  imageMaxConcurrentRequests: number;
+  audioMaxConcurrentRequests: number;
   chatModels: ChatModelInfo[];
   imageModels: ImageModel[];
   audioModels: AudioModel[];

--- a/client/src/app/image-model-settings/image-model-settings.component.html
+++ b/client/src/app/image-model-settings/image-model-settings.component.html
@@ -57,6 +57,15 @@
             aria-label="Image rate limit per minute"
           />
         </mat-form-field>
+        <mat-form-field>
+          <mat-label>Max concurrent requests</mat-label>
+          <input
+            matInput
+            type="number"
+            [formField]="rateLimitForm.maxConcurrentRequests"
+            aria-label="Image max concurrent requests"
+          />
+        </mat-form-field>
       </div>
     </mat-card-content>
   </mat-card>

--- a/client/src/app/image-model-settings/image-model-settings.component.ts
+++ b/client/src/app/image-model-settings/image-model-settings.component.ts
@@ -24,10 +24,13 @@ export class ImageModelSettingsComponent {
 
   readonly rateLimitModel = signal({
     rateLimitPerMinute: this.service.imageRateLimitPerMinute(),
+    maxConcurrentRequests: this.service.imageMaxConcurrentRequests(),
   });
   readonly rateLimitForm = form(this.rateLimitModel, (path) => {
     required(path.rateLimitPerMinute);
     min(path.rateLimitPerMinute, 1);
+    required(path.maxConcurrentRequests);
+    min(path.maxConcurrentRequests, 0);
   });
 
   constructor() {
@@ -36,11 +39,16 @@ export class ImageModelSettingsComponent {
         return;
       }
 
-      const { rateLimitPerMinute } = this.rateLimitModel();
+      const { rateLimitPerMinute, maxConcurrentRequests } = this.rateLimitModel();
       const currentRateLimit = untracked(() => this.service.imageRateLimitPerMinute());
+      const currentMaxConcurrent = untracked(() => this.service.imageMaxConcurrentRequests());
 
       if (rateLimitPerMinute !== currentRateLimit) {
         this.service.updateImageRateLimit(rateLimitPerMinute);
+      }
+
+      if (maxConcurrentRequests !== currentMaxConcurrent) {
+        this.service.updateImageMaxConcurrent(maxConcurrentRequests);
       }
     });
   }

--- a/client/src/app/image-model-settings/image-model-settings.service.ts
+++ b/client/src/app/image-model-settings/image-model-settings.service.ts
@@ -19,6 +19,7 @@ export class ImageModelSettingsService {
   private readonly environmentConfig = inject(ENVIRONMENT_CONFIG);
   readonly imageModels = signal(this.environmentConfig.imageModels);
   readonly imageRateLimitPerMinute = signal(this.environmentConfig.imageRateLimitPerMinute);
+  readonly imageMaxConcurrentRequests = signal(this.environmentConfig.imageMaxConcurrentRequests);
 
   updateImageCount(modelId: string, imageCount: number): void {
     this.imageModels.update((models) =>
@@ -40,6 +41,15 @@ export class ImageModelSettingsService {
     fetchJson(this.http, '/api/rate-limit-settings', {
       method: 'PUT',
       body: { type: 'image', maxPerMinute: value },
+    });
+  }
+
+  updateImageMaxConcurrent(value: number): void {
+    this.imageMaxConcurrentRequests.set(value);
+
+    fetchJson(this.http, '/api/rate-limit-settings', {
+      method: 'PUT',
+      body: { type: 'image', maxConcurrent: value },
     });
   }
 }

--- a/client/src/app/rate-limit-token.service.ts
+++ b/client/src/app/rate-limit-token.service.ts
@@ -7,10 +7,12 @@ export class RateLimitTokenService {
   private readonly environmentConfig = inject(ENVIRONMENT_CONFIG);
 
   readonly imagePool = new ToolPool(
-    this.environmentConfig.imageRateLimitPerMinute
+    this.environmentConfig.imageRateLimitPerMinute,
+    this.environmentConfig.imageMaxConcurrentRequests
   );
 
   readonly audioPool = new ToolPool(
-    this.environmentConfig.audioRateLimitPerMinute
+    this.environmentConfig.audioRateLimitPerMinute,
+    this.environmentConfig.audioMaxConcurrentRequests
   );
 }

--- a/client/src/app/voice-config/voice-config.component.html
+++ b/client/src/app/voice-config/voice-config.component.html
@@ -15,6 +15,15 @@
               aria-label="Audio rate limit per minute"
             />
           </mat-form-field>
+          <mat-form-field>
+            <mat-label>Max concurrent requests</mat-label>
+            <input
+              matInput
+              type="number"
+              [formField]="rateLimitForm.maxConcurrentRequests"
+              aria-label="Audio max concurrent requests"
+            />
+          </mat-form-field>
         </div>
       </mat-card-content>
     </mat-card>

--- a/client/src/app/voice-config/voice-config.component.ts
+++ b/client/src/app/voice-config/voice-config.component.ts
@@ -59,10 +59,13 @@ export class VoiceConfigComponent {
   readonly supportedLanguages = this.service.supportedLanguages;
   readonly rateLimitModel = signal({
     rateLimitPerMinute: this.service.audioRateLimitPerMinute(),
+    maxConcurrentRequests: this.service.audioMaxConcurrentRequests(),
   });
   readonly rateLimitForm = form(this.rateLimitModel, (path) => {
     required(path.rateLimitPerMinute);
     min(path.rateLimitPerMinute, 1);
+    required(path.maxConcurrentRequests);
+    min(path.maxConcurrentRequests, 0);
   });
 
   readonly selectedCardIndex = signal(0);
@@ -273,11 +276,16 @@ export class VoiceConfigComponent {
         return;
       }
 
-      const { rateLimitPerMinute } = this.rateLimitModel();
+      const { rateLimitPerMinute, maxConcurrentRequests } = this.rateLimitModel();
       const currentRateLimit = untracked(() => this.service.audioRateLimitPerMinute());
+      const currentMaxConcurrent = untracked(() => this.service.audioMaxConcurrentRequests());
 
       if (rateLimitPerMinute !== currentRateLimit) {
         this.service.updateAudioRateLimit(rateLimitPerMinute);
+      }
+
+      if (maxConcurrentRequests !== currentMaxConcurrent) {
+        this.service.updateAudioMaxConcurrent(maxConcurrentRequests);
       }
     });
   }

--- a/client/src/app/voice-config/voice-config.service.ts
+++ b/client/src/app/voice-config/voice-config.service.ts
@@ -33,6 +33,7 @@ export class VoiceConfigService {
   readonly availableVoices = this.config.voices;
   readonly supportedLanguages = this.config.supportedLanguages;
   readonly audioRateLimitPerMinute = signal(this.config.audioRateLimitPerMinute);
+  readonly audioMaxConcurrentRequests = signal(this.config.audioMaxConcurrentRequests);
 
   readonly configurations = resource<VoiceConfiguration[], never>({
     injector: this.injector,
@@ -105,6 +106,15 @@ export class VoiceConfigService {
     fetchJson(this.http, '/api/rate-limit-settings', {
       method: 'PUT',
       body: { type: 'audio', maxPerMinute: value },
+    });
+  }
+
+  updateAudioMaxConcurrent(value: number): void {
+    this.audioMaxConcurrentRequests.set(value);
+
+    fetchJson(this.http, '/api/rate-limit-settings', {
+      method: 'PUT',
+      body: { type: 'audio', maxConcurrent: value },
     });
   }
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/EnvironmentController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/EnvironmentController.java
@@ -77,6 +77,8 @@ public class EnvironmentController {
         environment.matchesProfiles("test"),
         rateLimitSettingService.getImageRateLimitPerMinute(),
         rateLimitSettingService.getAudioRateLimitPerMinute(),
+        rateLimitSettingService.getImageMaxConcurrentRequests(),
+        rateLimitSettingService.getAudioMaxConcurrentRequests(),
         Arrays.stream(ChatModel.values())
             .map(model -> new ChatModelInfo(model.getModelName(), model.getProvider().getCode()))
             .toList(),
@@ -117,6 +119,8 @@ public class EnvironmentController {
       boolean mockAuth,
       int imageRateLimitPerMinute,
       int audioRateLimitPerMinute,
+      int imageMaxConcurrentRequests,
+      int audioMaxConcurrentRequests,
       List<ChatModelInfo> chatModels,
       List<ImageModelResponse> imageModels,
       List<AudioModelResponse> audioModels,

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/RateLimitSettingRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/RateLimitSettingRequest.java
@@ -17,4 +17,7 @@ public class RateLimitSettingRequest {
 
     @Min(1)
     private Integer maxPerMinute;
+
+    @Min(0)
+    private Integer maxConcurrent;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/RateLimitSettingService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/RateLimitSettingService.java
@@ -24,11 +24,21 @@ public class RateLimitSettingService {
         return getRateLimit("audio-per-minute");
     }
 
+    public int getImageMaxConcurrentRequests() {
+        return getRateLimit("image-max-concurrent");
+    }
+
+    public int getAudioMaxConcurrentRequests() {
+        return getRateLimit("audio-max-concurrent");
+    }
+
     @Transactional
     public void updateRateLimitSettings(RateLimitSettingRequest request) {
         final String type = request.getType();
         Optional.ofNullable(request.getMaxPerMinute())
                 .ifPresent(value -> updateRateLimit(type + "-per-minute", value));
+        Optional.ofNullable(request.getMaxConcurrent())
+                .ifPresent(value -> updateRateLimit(type + "-max-concurrent", value));
     }
 
     private int getRateLimit(String key) {

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -122,7 +122,8 @@ CREATE TABLE IF NOT EXISTS learn_language.rate_limit_settings (
 );
 
 INSERT INTO learn_language.rate_limit_settings (key, value)
-VALUES ('image-per-minute', 6), ('audio-per-minute', 12)
+VALUES ('image-per-minute', 6), ('audio-per-minute', 12),
+       ('image-max-concurrent', 0), ('audio-max-concurrent', 3)
 ON CONFLICT (key) DO NOTHING;
 
 CREATE TABLE IF NOT EXISTS learn_language.known_words (

--- a/test/tests/rate-limit-settings.spec.ts
+++ b/test/tests/rate-limit-settings.spec.ts
@@ -55,3 +55,57 @@ test('can update audio rate limit', async ({ page }) => {
   }).toPass();
 });
 
+test('displays image max concurrent requests from database on image models settings page', async ({ page }) => {
+  await createRateLimitSetting({ key: 'image-max-concurrent', value: 5 });
+
+  await page.goto('http://localhost:8180/settings/image-models');
+
+  const maxConcurrentInput = page.getByRole('spinbutton', { name: 'Image max concurrent requests' });
+  await expect(maxConcurrentInput).toBeVisible();
+  await expect(maxConcurrentInput).toHaveValue('5');
+});
+
+test('can update image max concurrent requests', async ({ page }) => {
+  await createRateLimitSetting({ key: 'image-max-concurrent', value: 0 });
+
+  await page.goto('http://localhost:8180/settings/image-models');
+
+  const maxConcurrentInput = page.getByRole('spinbutton', { name: 'Image max concurrent requests' });
+  await maxConcurrentInput.fill('4');
+  await maxConcurrentInput.dispatchEvent('change');
+
+  await expect(async () => {
+    const settings = await getRateLimitSettings();
+    const setting = settings.find((s) => s.key === 'image-max-concurrent');
+    expect(setting).toBeDefined();
+    expect(setting!.value).toBe(4);
+  }).toPass();
+});
+
+test('displays audio max concurrent requests from database on voices settings page', async ({ page }) => {
+  await createRateLimitSetting({ key: 'audio-max-concurrent', value: 3 });
+
+  await page.goto('http://localhost:8180/settings/voices');
+
+  const maxConcurrentInput = page.getByRole('spinbutton', { name: 'Audio max concurrent requests' });
+  await expect(maxConcurrentInput).toBeVisible();
+  await expect(maxConcurrentInput).toHaveValue('3');
+});
+
+test('can update audio max concurrent requests', async ({ page }) => {
+  await createRateLimitSetting({ key: 'audio-max-concurrent', value: 3 });
+
+  await page.goto('http://localhost:8180/settings/voices');
+
+  const maxConcurrentInput = page.getByRole('spinbutton', { name: 'Audio max concurrent requests' });
+  await maxConcurrentInput.fill('6');
+  await maxConcurrentInput.dispatchEvent('change');
+
+  await expect(async () => {
+    const settings = await getRateLimitSettings();
+    const setting = settings.find((s) => s.key === 'audio-max-concurrent');
+    expect(setting).toBeDefined();
+    expect(setting!.value).toBe(6);
+  }).toPass();
+});
+

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -900,6 +900,8 @@ export async function getRateLimitSettings(): Promise<
 export async function setupTestRateLimits(audioLimit: number = 100, imageLimit: number = 100): Promise<void> {
   await createRateLimitSetting({ key: 'audio-per-minute', value: audioLimit });
   await createRateLimitSetting({ key: 'image-per-minute', value: imageLimit });
+  await createRateLimitSetting({ key: 'image-max-concurrent', value: 0 });
+  await createRateLimitSetting({ key: 'audio-max-concurrent', value: 0 });
 }
 
 export async function getTableData<T extends Record<string, string>>(


### PR DESCRIPTION
## Summary
This PR adds support for limiting the maximum number of concurrent requests for image and audio models, complementing the existing per-minute rate limiting. Users can now configure both per-minute and concurrent request limits through the settings UI.

## Key Changes

- **ToolPool Enhancement**: Extended `ToolPool` class to support `maxConcurrent` parameter alongside existing `maxPerMinute` limit. The acquire logic now checks both constraints with intelligent polling (200ms intervals for concurrent limits vs minute-window waits for per-minute limits).

- **UI Components**: Added "Max concurrent requests" input fields to both image model settings and voice configuration pages with proper form validation (required, minimum 0).

- **Service Layer**: 
  - Added `imageMaxConcurrentRequests` and `audioMaxConcurrentRequests` signals to respective services
  - Implemented `updateImageMaxConcurrent()` and `updateAudioMaxConcurrent()` methods to persist changes via API

- **Backend API**:
  - Extended `RateLimitSettingService` with getter methods for max concurrent limits
  - Updated `RateLimitSettingRequest` to include `maxConcurrent` field with validation
  - Modified `EnvironmentController` to include concurrent limits in config response
  - Updated database schema with default values: image=0 (unlimited), audio=3

- **Rate Limit Token Service**: Updated pool initialization to pass `maxConcurrent` values from environment config

- **Tests**: Added comprehensive test coverage for displaying and updating max concurrent request limits for both image and audio models

## Implementation Details

- Concurrent limit of 0 means unlimited (backward compatible)
- When both limits are active, the acquire method intelligently waits: full minute window for per-minute exhaustion, short 200ms polls for concurrent slot availability
- Form validation ensures maxConcurrent ≥ 0 and maxPerMinute ≥ 1

https://claude.ai/code/session_015bZNxdYVBtqbLGhEteJsEa