### PR TITLE
Allow zero rate limit to disable per-minute throttling

### DIFF
--- a/client/src/app/image-model-settings/image-model-settings.component.ts
+++ b/client/src/app/image-model-settings/image-model-settings.component.ts
@@ -28,7 +28,7 @@ export class ImageModelSettingsComponent {
   });
   readonly rateLimitForm = form(this.rateLimitModel, (path) => {
     required(path.rateLimitPerMinute);
-    min(path.rateLimitPerMinute, 1);
+    min(path.rateLimitPerMinute, 0);
     required(path.maxConcurrentRequests);
     min(path.maxConcurrentRequests, 0);
   });

--- a/client/src/app/utils/tool-pool.ts
+++ b/client/src/app/utils/tool-pool.ts
@@ -29,6 +29,7 @@ export class ToolPool {
         this.refreshMinuteWindow();
 
         const withinMinuteLimit =
+          this.maxPerMinute === 0 ||
           this.distributedThisMinute < this.maxPerMinute;
         const withinConcurrentLimit =
           this.maxConcurrent === 0 ||
@@ -61,7 +62,9 @@ export class ToolPool {
 
   isAvailable(): boolean {
     this.refreshMinuteWindow();
-    const withinMinuteLimit = this.distributedThisMinute < this.maxPerMinute;
+    const withinMinuteLimit =
+      this.maxPerMinute === 0 ||
+      this.distributedThisMinute < this.maxPerMinute;
     const withinConcurrentLimit =
       this.maxConcurrent === 0 || this._activeCount() < this.maxConcurrent;
     return withinMinuteLimit && withinConcurrentLimit;
@@ -69,7 +72,7 @@ export class ToolPool {
 
   async waitForAvailability(): Promise<void> {
     while (!this.isAvailable()) {
-      if (this.distributedThisMinute >= this.maxPerMinute) {
+      if (this.maxPerMinute > 0 && this.distributedThisMinute >= this.maxPerMinute) {
         const waitTime = MINUTE_MS - (Date.now() - this.minuteWindowStart);
         if (waitTime > 0) {
           await delay(waitTime);

--- a/client/src/app/voice-config/voice-config.component.ts
+++ b/client/src/app/voice-config/voice-config.component.ts
@@ -63,7 +63,7 @@ export class VoiceConfigComponent {
   });
   readonly rateLimitForm = form(this.rateLimitModel, (path) => {
     required(path.rateLimitPerMinute);
-    min(path.rateLimitPerMinute, 1);
+    min(path.rateLimitPerMinute, 0);
     required(path.maxConcurrentRequests);
     min(path.maxConcurrentRequests, 0);
   });

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/RateLimitSettingRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/RateLimitSettingRequest.java
@@ -15,7 +15,7 @@ public class RateLimitSettingRequest {
     @NotNull
     private String type;
 
-    @Min(1)
+    @Min(0)
     private Integer maxPerMinute;
 
     @Min(0)

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -122,7 +122,7 @@ CREATE TABLE IF NOT EXISTS learn_language.rate_limit_settings (
 );
 
 INSERT INTO learn_language.rate_limit_settings (key, value)
-VALUES ('image-per-minute', 6), ('audio-per-minute', 12),
+VALUES ('image-per-minute', 6), ('audio-per-minute', 0),
        ('image-max-concurrent', 0), ('audio-max-concurrent', 3)
 ON CONFLICT (key) DO NOTHING;
 


### PR DESCRIPTION
## Summary
This PR updates the rate limiting system to allow a value of 0 for `maxPerMinute` to disable per-minute throttling, while still respecting concurrent request limits.

## Key Changes
- **ToolPool logic**: Updated `canDistribute()`, `isAvailable()`, and `waitForAvailability()` methods to treat `maxPerMinute === 0` as "no limit" rather than blocking all requests
- **Validation constraints**: Changed minimum allowed value for `rateLimitPerMinute` from 1 to 0 in both client components (ImageModelSettings and VoiceConfig) and server validation (RateLimitSettingRequest)
- **Default configuration**: Updated audio rate limit default from 12 per minute to 0 (unlimited) in the database schema

## Implementation Details
The changes follow the existing pattern used for `maxConcurrent`, where a value of 0 means unlimited. The logic now checks `maxPerMinute === 0` before comparing against `distributedThisMinute`, allowing requests to proceed without per-minute restrictions when disabled.

https://claude.ai/code/session_01UMcc9iUSLcQQzJc2DfgeVa