### PR TITLE
Swap learning partner assignment for new cards after grading

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/CardController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/CardController.java
@@ -181,6 +181,7 @@ public class CardController {
         .orElseThrow(() -> new ResourceNotFoundException("Card not found with id: " + cardId));
 
     boolean isGrading = request.getRating() != null;
+    final String previousState = existingCard.getState();
 
     if (request.getData() != null) existingCard.setData(request.getData());
     if (request.getReadiness() != null) existingCard.setReadiness(request.getReadiness());
@@ -229,7 +230,7 @@ public class CardController {
           .build();
 
       reviewLogRepository.save(reviewLog);
-      studySessionService.moveCardToBack(cardId, existingCard.getSource().getId(), startOfDayUtc(parseTimezone(timezone)));
+      studySessionService.moveCardToBack(cardId, existingCard.getSource().getId(), startOfDayUtc(parseTimezone(timezone)), previousState);
     }
 
     Map<String, String> response = new HashMap<>();


### PR DESCRIPTION
## Summary
This change implements smart learning partner assignment swapping for new cards in study sessions. When a new card is graded in a "WITH_PARTNER" study mode, the learning partner assignment is swapped - if the card was unassigned, it gets assigned to the active partner, and vice versa. Learning cards (cards being reviewed) maintain their partner assignment and do not swap.

## Key Changes
- **Test Coverage**: Added two new test cases to verify the swapping behavior:
  - `smart assignment: new card assignee swaps after grading` - Verifies that new cards swap partner assignment after grading
  - `smart assignment: learning card assignee does not swap after grading` - Verifies that learning cards maintain their partner assignment
  
- **StudySessionService**: Modified `moveCardToBack()` method to accept the previous card state and implement the swapping logic:
  - Only applies swapping for cards in "NEW" state within "WITH_PARTNER" study mode
  - Toggles the learning partner: removes assignment if present, assigns active partner if absent
  
- **CardController**: Updated the card update endpoint to capture the card's previous state before modification and pass it to `moveCardToBack()`

- **Test Utilities**: Added `getStudySessionCardsBySource()` helper function to retrieve study session cards by source ID for test assertions

## Implementation Details
The swapping logic is applied only when:
1. The card's previous state was "NEW"
2. The study session is in "WITH_PARTNER" mode
3. The card is being moved to the back of the session queue after grading

This ensures that new cards are distributed between the user and their learning partner, while cards already in learning (with higher complexity) maintain their current assignment.

https://claude.ai/code/session_01HyGYN5gR4gyiSbLQr5kK49