### PR TITLE
Add English translation fields to card edit pages to fix stuck cards

### DIFF
--- a/client/src/app/parser/edit-card/edit-grammar-card/edit-grammar-card.component.html
+++ b/client/src/app/parser/edit-card/edit-grammar-card/edit-grammar-card.component.html
@@ -9,6 +9,15 @@
       rows="3"
     ></textarea>
   </mat-form-field>
+  <mat-form-field class="field">
+    <mat-label>English Translation</mat-label>
+    <textarea
+      matInput
+      [formField]="grammarForm.englishTranslation"
+      aria-label="English translation"
+      rows="3"
+    ></textarea>
+  </mat-form-field>
   <div class="gap-controls">
     <button
       mat-stroked-button
@@ -50,8 +59,8 @@
     mat-icon-button
     (click)="addImage()"
     aria-label="Add image"
-    [disabled]="areImagesLoading() || dailyUsageService.isImageLimitReached()"
-    [matTooltip]="dailyUsageService.imageLimitTooltip()"
+    [disabled]="isImageButtonDisabled()"
+    [matTooltip]="imageButtonTooltip()"
   >
     <mat-icon>add_photo_alternate</mat-icon>
   </button>

--- a/client/src/app/parser/edit-card/edit-grammar-card/edit-grammar-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-grammar-card/edit-grammar-card.component.ts
@@ -185,6 +185,21 @@ export class EditGrammarCardComponent {
     return imgs.some((image) => image.isLoading());
   }
 
+  isImageButtonDisabled(): boolean {
+    return (
+      this.areImagesLoading() ||
+      this.dailyUsageService.isImageLimitReached() ||
+      !this.formModel().englishTranslation
+    );
+  }
+
+  imageButtonTooltip(): string {
+    if (!this.formModel().englishTranslation) {
+      return 'English translation required for image generation';
+    }
+    return this.dailyUsageService.imageLimitTooltip();
+  }
+
   onFavoriteToggled(imageIdx: number) {
     const imgs = this.images();
     if (!imgs?.length) return;

--- a/client/src/app/parser/edit-card/edit-speech-card/edit-speech-card.component.html
+++ b/client/src/app/parser/edit-card/edit-speech-card/edit-speech-card.component.html
@@ -9,6 +9,15 @@
     ></textarea>
   </mat-form-field>
   <mat-form-field class="field">
+    <mat-label>English Translation</mat-label>
+    <textarea
+      matInput
+      [formField]="speechForm.englishTranslation"
+      aria-label="English translation"
+      rows="3"
+    ></textarea>
+  </mat-form-field>
+  <mat-form-field class="field">
     <mat-label>Hungarian Translation</mat-label>
     <textarea
       matInput
@@ -25,8 +34,8 @@
     mat-icon-button
     (click)="addImage()"
     aria-label="Add image"
-    [disabled]="areImagesLoading() || dailyUsageService.isImageLimitReached()"
-    [matTooltip]="dailyUsageService.imageLimitTooltip()"
+    [disabled]="isImageButtonDisabled()"
+    [matTooltip]="imageButtonTooltip()"
   >
     <mat-icon>add_photo_alternate</mat-icon>
   </button>

--- a/client/src/app/parser/edit-card/edit-speech-card/edit-speech-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-speech-card/edit-speech-card.component.ts
@@ -126,6 +126,21 @@ export class EditSpeechCardComponent {
     return imgs.some((image) => image.isLoading());
   }
 
+  isImageButtonDisabled(): boolean {
+    return (
+      this.areImagesLoading() ||
+      this.dailyUsageService.isImageLimitReached() ||
+      !this.formModel().englishTranslation
+    );
+  }
+
+  imageButtonTooltip(): string {
+    if (!this.formModel().englishTranslation) {
+      return 'English translation required for image generation';
+    }
+    return this.dailyUsageService.imageLimitTooltip();
+  }
+
   onFavoriteToggled(imageIdx: number) {
     const imgs = this.images();
     if (!imgs?.length) return;

--- a/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.css
+++ b/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.css
@@ -24,6 +24,12 @@
   column-gap: 1rem;
 }
 
+.translations {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  column-gap: 1rem;
+}
+
 .example {
   display: grid;
   gap: 1rem;
@@ -38,7 +44,7 @@
 
 .example-fields {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   column-gap: 1rem;
 }
 

--- a/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.html
+++ b/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.html
@@ -26,7 +26,7 @@
   </mat-form-field>
   }
 </div>
-<div class="word">
+<div class="translations">
   <mat-form-field class="field">
     <mat-label>German</mat-label>
     <input
@@ -34,6 +34,15 @@
       type="text"
       [(ngModel)]="word"
       aria-label="German translation"
+    />
+  </mat-form-field>
+  <mat-form-field class="field">
+    <mat-label>English</mat-label>
+    <input
+      matInput
+      type="text"
+      [(ngModel)]="translation['en']"
+      aria-label="English translation"
     />
   </mat-form-field>
   <mat-form-field class="field">
@@ -74,8 +83,8 @@
         mat-icon-button
         (click)="addImage($index)"
         aria-label="Add example image"
-        [disabled]="areImagesLoading($index) || dailyUsageService.isImageLimitReached()"
-        [matTooltip]="dailyUsageService.imageLimitTooltip()"
+        [disabled]="isImageButtonDisabled($index)"
+        [matTooltip]="imageButtonTooltip($index)"
       >
         <mat-icon>add_photo_alternate</mat-icon>
       </button>
@@ -91,6 +100,15 @@
         />
       </mat-form-field>
       @if(examplesTranslations(); as examplesTranslations) {
+      <mat-form-field class="field">
+        <mat-label>English</mat-label>
+        <input
+          matInput
+          type="text"
+          [(ngModel)]="examplesTranslations['en'][$index]"
+          aria-label="Example in English"
+        />
+      </mat-form-field>
       <mat-form-field class="field">
         <mat-label>Hungarian</mat-label>
         <input

--- a/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.ts
@@ -183,6 +183,21 @@ export class EditVocabularyCardComponent {
     return images.some((image) => image.isLoading());
   }
 
+  isImageButtonDisabled(exampleIdx: number): boolean {
+    return (
+      this.areImagesLoading(exampleIdx) ||
+      this.dailyUsageService.isImageLimitReached() ||
+      !this.examplesTranslations()?.['en'][exampleIdx]()
+    );
+  }
+
+  imageButtonTooltip(exampleIdx: number): string {
+    if (!this.examplesTranslations()?.['en'][exampleIdx]()) {
+      return 'English translation required for image generation';
+    }
+    return this.dailyUsageService.imageLimitTooltip();
+  }
+
   onFavoriteToggled(exampleIdx: number, imageIdx: number) {
     const images = this.exampleImages()?.[exampleIdx];
     if (!images?.length) return;

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -809,3 +809,166 @@ test('grammar card editing saves gaps to database', async ({ page }) => {
     expect(cardData.examples[0].de).toBe('Das Kind [spielt] im Garten.');
   });
 });
+
+test('vocabulary card shows english translation fields', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  const image1 = uploadMockImage(yellowImage);
+  await createCard({
+    cardId: 'abfahren-elindulni',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'abfahren',
+      type: 'VERB',
+      forms: ['fährt ab', 'fuhr ab', 'abgefahren'],
+      translation: {
+        en: 'to leave',
+        hu: 'elindulni, elhagyni',
+        ch: 'abfahra, verlah',
+      },
+      examples: [
+        {
+          de: 'Wir fahren um zwölf Uhr ab.',
+          hu: 'Tizenkét órakor indulunk.',
+          en: "We leave at twelve o'clock.",
+          ch: 'Mir fahred am zwöufi ab.',
+          images: [{ id: image1 }],
+        },
+      ],
+    },
+  });
+  await navigateToCardEditing(page);
+
+  await expect(page.getByLabel('English translation', { exact: true })).toHaveValue('to leave');
+  await expect(page.getByLabel('Example in English', { exact: true })).toHaveValue(
+    "We leave at twelve o'clock."
+  );
+});
+
+test('vocabulary card without english translation disables image button', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await setupDefaultImageModelSettings();
+  await createCard({
+    cardId: 'haus-haz',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'Haus',
+      type: 'NOUN',
+      gender: 'NEUTER',
+      forms: [],
+      translation: {
+        hu: 'ház',
+        ch: 'Huus',
+      },
+      examples: [
+        {
+          de: 'Das Haus ist groß.',
+          hu: 'A ház nagy.',
+          ch: 'S Huus isch gross.',
+        },
+      ],
+    },
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/page/9/cards/haus-haz');
+
+  await expect(page.getByLabel('English translation', { exact: true })).toHaveValue('');
+  await expect(page.getByLabel('Example in English', { exact: true })).toHaveValue('');
+  await expect(page.getByRole('button', { name: 'Add example image' })).toBeDisabled();
+
+  await page.getByLabel('English translation', { exact: true }).fill('house');
+  await page.getByLabel('Example in English', { exact: true }).fill('The house is big.');
+
+  await page.getByRole('button', { name: 'Add example image' }).click();
+  await expect(page.getByRole('img')).toHaveCount(4);
+
+  await page.getByRole('button', { name: 'Update' }).click();
+  await expect(page.getByText('Card updated successfully')).toBeVisible();
+
+  await withDbConnection(async (client) => {
+    const result = await client.query("SELECT data FROM learn_language.cards WHERE id = 'haus-haz'");
+    expect(result.rows.length).toBe(1);
+    const cardData = result.rows[0].data;
+    expect(cardData.translation.en).toBe('house');
+    expect(cardData.examples[0].en).toBe('The house is big.');
+    expect(cardData.examples[0].images).toHaveLength(4);
+  });
+});
+
+test('speech card shows english translation field', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await setupDefaultImageModelSettings();
+  await createCard({
+    cardId: 'speech-missing-en',
+    sourceId: 'speech-a1',
+    sourcePageNumber: 10,
+    data: {
+      examples: [
+        {
+          de: 'Wie heißen Sie?',
+          hu: 'Hogy hívják Önt?',
+          isSelected: true,
+        },
+      ],
+    },
+  });
+
+  await page.goto('http://localhost:8180/sources/speech-a1/page/10/cards/speech-missing-en');
+
+  await expect(page.getByLabel('English translation', { exact: true })).toHaveValue('');
+  await expect(page.getByRole('button', { name: 'Add image' })).toBeDisabled();
+
+  await page.getByLabel('English translation', { exact: true }).fill('What is your name?');
+  await page.getByRole('button', { name: 'Add image' }).click();
+  await expect(page.getByRole('img')).toHaveCount(4);
+
+  await page.getByRole('button', { name: 'Update' }).click();
+  await expect(page.getByText('Card updated successfully')).toBeVisible();
+
+  await withDbConnection(async (client) => {
+    const result = await client.query("SELECT data FROM learn_language.cards WHERE id = 'speech-missing-en'");
+    expect(result.rows.length).toBe(1);
+    const cardData = result.rows[0].data;
+    expect(cardData.examples[0].en).toBe('What is your name?');
+    expect(cardData.examples[0].images).toHaveLength(4);
+  });
+});
+
+test('grammar card shows english translation field', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await setupDefaultImageModelSettings();
+  await createCard({
+    cardId: 'grammar-missing-en',
+    sourceId: 'grammar-a1',
+    sourcePageNumber: 1,
+    data: {
+      examples: [
+        {
+          de: 'Er [geht] zur Schule.',
+          isSelected: true,
+        },
+      ],
+    },
+  });
+
+  await page.goto('http://localhost:8180/sources/grammar-a1/page/1/cards/grammar-missing-en');
+
+  await expect(page.getByLabel('English translation', { exact: true })).toHaveValue('');
+  await expect(page.getByRole('button', { name: 'Add image' })).toBeDisabled();
+
+  await page.getByLabel('English translation', { exact: true }).fill('He goes to school.');
+  await page.getByRole('button', { name: 'Add image' }).click();
+  await expect(page.getByRole('img')).toHaveCount(4);
+
+  await page.getByRole('button', { name: 'Update' }).click();
+  await expect(page.getByText('Card updated successfully')).toBeVisible();
+
+  await withDbConnection(async (client) => {
+    const result = await client.query("SELECT data FROM learn_language.cards WHERE id = 'grammar-missing-en'");
+    expect(result.rows.length).toBe(1);
+    const cardData = result.rows[0].data;
+    expect(cardData.examples[0].en).toBe('He goes to school.');
+    expect(cardData.examples[0].images).toHaveLength(4);
+  });
+});


### PR DESCRIPTION
When bulk card creation fails mid-way, cards can end up without English translations. Since image generation requires the English translation, users were stuck with no way to generate images from the edit page.

- Add English translation field to vocabulary, grammar, and speech card edit pages
- Disable image generation button with tooltip when English translation is missing
- Add E2E tests for editing cards with missing translations

https://claude.ai/code/session_01CnbZbpsayGXVS2oVLYFX1L