### PR TITLE
Fix unhealthy cards: deduplicate SQL, move logic to backend, improve …

### DIFF
--- a/client/src/app/admin/admin.component.ts
+++ b/client/src/app/admin/admin.component.ts
@@ -37,6 +37,14 @@ ModuleRegistry.registerModules([
   RowSelectionModule,
 ]);
 
+type UnhealthyCardResponse = {
+  id: string;
+  source: { id: string; name: string; cardType: string };
+  sourcePageNumber: number;
+  data: Card['data'];
+  missingFields: string;
+};
+
 type UnhealthyCardRow = {
   id: string;
   word: string;
@@ -77,11 +85,8 @@ export class AdminComponent {
 
   readonly totalFlaggedCount = computed(() => this.flaggedCards.value()?.length ?? 0);
 
-  readonly unhealthyCards = resource<Card[], unknown>({
-    loader: async () => {
-      const cards = await fetchJson<Card[]>(this.http, '/api/cards/unhealthy');
-      return cards.map(card => mapCardDatesFromISOStrings(card));
-    },
+  readonly unhealthyCards = resource<UnhealthyCardResponse[], unknown>({
+    loader: () => fetchJson<UnhealthyCardResponse[]>(this.http, '/api/cards/unhealthy'),
   });
 
   readonly unhealthyCardRows = computed<UnhealthyCardRow[]>(() => {
@@ -89,16 +94,16 @@ export class AdminComponent {
     if (!cards) return [];
     return cards.map(card => ({
       id: card.id,
-      word: this.getCardLabel(card),
-      source: card.source.name ?? '',
-      cardType: card.source.cardType ?? '',
-      missingFields: this.getMissingFields(card),
+      word: card.data?.word ?? card.id,
+      source: card.source.name,
+      cardType: card.source.cardType,
+      missingFields: card.missingFields,
     }));
   });
 
   readonly totalUnhealthyCount = computed(() => this.unhealthyCards.value()?.length ?? 0);
 
-  private unhealthyGridApi: GridApi | null = null;
+  private readonly unhealthyGridApi = signal<GridApi | null>(null);
   readonly selectedUnhealthyIds = signal<readonly string[]>([]);
 
   readonly unhealthyTheme = themeMaterial.withPart(colorSchemeDarkBlue).withParams({
@@ -144,13 +149,14 @@ export class AdminComponent {
   readonly getUnhealthyRowId = (params: GetRowIdParams) => params.data.id;
 
   onUnhealthyGridReady(event: GridReadyEvent): void {
-    this.unhealthyGridApi = event.api;
+    this.unhealthyGridApi.set(event.api);
     event.api.sizeColumnsToFit();
   }
 
   onUnhealthySelectionChanged(): void {
-    if (!this.unhealthyGridApi) return;
-    const selectedRows = this.unhealthyGridApi.getSelectedRows() as UnhealthyCardRow[];
+    const api = this.unhealthyGridApi();
+    if (!api) return;
+    const selectedRows = api.getSelectedRows() as UnhealthyCardRow[];
     this.selectedUnhealthyIds.set(selectedRows.map(row => row.id));
   }
 
@@ -268,21 +274,5 @@ export class AdminComponent {
         console.error('Error deleting source:', error);
       }
     }
-  }
-
-  private getMissingFields(card: Card): string {
-    const missing: string[] = [];
-    const translation = card.data?.translation;
-
-    if (!translation?.['en']) missing.push('English translation');
-    if (!translation?.['hu']) missing.push('Hungarian translation');
-    if (!translation?.['ch']) missing.push('Swiss German translation');
-
-    if (card.source.cardType === 'vocabulary') {
-      if (!card.data?.gender) missing.push('gender');
-      if (!card.data?.type) missing.push('word type');
-    }
-
-    return missing.join(', ');
   }
 }

--- a/client/src/app/admin/admin.component.ts
+++ b/client/src/app/admin/admin.component.ts
@@ -39,7 +39,7 @@ ModuleRegistry.registerModules([
 
 type UnhealthyCardResponse = {
   id: string;
-  word: string;
+  word: string | null;
   source: { id: string; name: string; cardType: string };
   missingFields: string;
 };

--- a/client/src/app/admin/admin.component.ts
+++ b/client/src/app/admin/admin.component.ts
@@ -39,9 +39,8 @@ ModuleRegistry.registerModules([
 
 type UnhealthyCardResponse = {
   id: string;
+  word: string;
   source: { id: string; name: string; cardType: string };
-  sourcePageNumber: number;
-  data: Card['data'];
   missingFields: string;
 };
 
@@ -94,7 +93,7 @@ export class AdminComponent {
     if (!cards) return [];
     return cards.map(card => ({
       id: card.id,
-      word: card.data?.word ?? card.id,
+      word: card.word ?? card.id,
       source: card.source.name,
       cardType: card.source.cardType,
       missingFields: card.missingFields,

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/CardController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/CardController.java
@@ -23,6 +23,7 @@ import io.github.mucsi96.learnlanguage.model.CardReadiness;
 import io.github.mucsi96.learnlanguage.model.CardResponse;
 import io.github.mucsi96.learnlanguage.model.CardTableResponse;
 import io.github.mucsi96.learnlanguage.model.CardUpdateRequest;
+import io.github.mucsi96.learnlanguage.model.UnhealthyCardResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -269,11 +270,8 @@ public class CardController {
 
   @GetMapping("/cards/unhealthy")
   @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
-  public ResponseEntity<List<CardResponse>> getUnhealthyCards() {
-    final List<CardResponse> cards = cardService.getUnhealthyCards().stream()
-        .map(CardResponse::from)
-        .toList();
-    return ResponseEntity.ok(cards);
+  public ResponseEntity<List<UnhealthyCardResponse>> getUnhealthyCards() {
+    return ResponseEntity.ok(cardService.getUnhealthyCards());
   }
 
   @PutMapping("/cards/mark-draft")

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/UnhealthyCardResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/UnhealthyCardResponse.java
@@ -10,27 +10,28 @@ import lombok.Data;
 public class UnhealthyCardResponse {
 
     private String id;
-    private CardResponse.CardSourceResponse source;
-    private Integer sourcePageNumber;
-    private CardData data;
+    private String word;
+    private UnhealthyCardSource source;
     private String missingFields;
+
+    @Data
+    @Builder
+    public static class UnhealthyCardSource {
+        private String id;
+        private String name;
+        private CardType cardType;
+    }
 
     public static UnhealthyCardResponse from(Card card, String missingFields) {
         final Source source = card.getSource();
         return UnhealthyCardResponse.builder()
                 .id(card.getId())
-                .source(CardResponse.CardSourceResponse.builder()
+                .word(card.getData() != null ? card.getData().getWord() : null)
+                .source(UnhealthyCardSource.builder()
                         .id(source.getId())
                         .name(source.getName())
-                        .sourceType(source.getSourceType())
-                        .startPage(source.getStartPage())
-                        .bookmarkedPage(source.getBookmarkedPage())
-                        .languageLevel(source.getLanguageLevel())
                         .cardType(source.getCardType())
-                        .formatType(source.getFormatType())
                         .build())
-                .sourcePageNumber(card.getSourcePageNumber())
-                .data(card.getData())
                 .missingFields(missingFields)
                 .build();
     }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/UnhealthyCardResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/UnhealthyCardResponse.java
@@ -1,0 +1,37 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import io.github.mucsi96.learnlanguage.entity.Card;
+import io.github.mucsi96.learnlanguage.entity.Source;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class UnhealthyCardResponse {
+
+    private String id;
+    private CardResponse.CardSourceResponse source;
+    private Integer sourcePageNumber;
+    private CardData data;
+    private String missingFields;
+
+    public static UnhealthyCardResponse from(Card card, String missingFields) {
+        final Source source = card.getSource();
+        return UnhealthyCardResponse.builder()
+                .id(card.getId())
+                .source(CardResponse.CardSourceResponse.builder()
+                        .id(source.getId())
+                        .name(source.getName())
+                        .sourceType(source.getSourceType())
+                        .startPage(source.getStartPage())
+                        .bookmarkedPage(source.getBookmarkedPage())
+                        .languageLevel(source.getLanguageLevel())
+                        .cardType(source.getCardType())
+                        .formatType(source.getFormatType())
+                        .build())
+                .sourcePageNumber(card.getSourcePageNumber())
+                .data(card.getData())
+                .missingFields(missingFields)
+                .build();
+    }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
@@ -54,9 +54,6 @@ public interface CardRepository
     @Modifying
     void deleteBySource(Source source);
 
-    @Query(value = "SELECT id, ARRAY_TO_STRING(missing_fields, ', ') AS missing_fields FROM learn_language.unhealthy_cards ORDER BY due ASC", nativeQuery = true)
-    List<Object[]> findUnhealthyCardIdsWithMissingFields();
-
-    @Query(value = "SELECT source_id, COUNT(*) FROM learn_language.unhealthy_cards GROUP BY source_id", nativeQuery = true)
-    List<Object[]> countUnhealthyCardsBySourceGroupBySource();
+    @Query(value = "SELECT source_id AS sourceId, COUNT(*) AS count FROM learn_language.unhealthy_cards GROUP BY source_id", nativeQuery = true)
+    List<SourceCardCountProjection> countUnhealthyCardsBySourceGroupBySource();
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
@@ -54,39 +54,9 @@ public interface CardRepository
     @Modifying
     void deleteBySource(Source source);
 
-    @Query(value = """
-        SELECT c.*
-        FROM learn_language.cards c
-        JOIN learn_language.sources s ON c.source_id = s.id
-        WHERE c.readiness IN ('READY', 'REVIEWED', 'KNOWN')
-        AND (
-            c.data->'translation'->>'en' IS NULL OR TRIM(c.data->'translation'->>'en') = ''
-            OR c.data->'translation'->>'hu' IS NULL OR TRIM(c.data->'translation'->>'hu') = ''
-            OR c.data->'translation'->>'ch' IS NULL OR TRIM(c.data->'translation'->>'ch') = ''
-            OR (s.card_type = 'VOCABULARY' AND (
-                c.data->>'gender' IS NULL OR TRIM(c.data->>'gender') = ''
-                OR c.data->>'type' IS NULL OR TRIM(c.data->>'type') = ''
-            ))
-        )
-        ORDER BY c.due ASC
-        """, nativeQuery = true)
-    List<Card> findUnhealthyCards();
+    @Query(value = "SELECT id, ARRAY_TO_STRING(missing_fields, ', ') AS missing_fields FROM learn_language.unhealthy_cards ORDER BY due ASC", nativeQuery = true)
+    List<Object[]> findUnhealthyCardIdsWithMissingFields();
 
-    @Query(value = """
-        SELECT c.source_id, COUNT(*)
-        FROM learn_language.cards c
-        JOIN learn_language.sources s ON c.source_id = s.id
-        WHERE c.readiness IN ('READY', 'REVIEWED', 'KNOWN')
-        AND (
-            c.data->'translation'->>'en' IS NULL OR TRIM(c.data->'translation'->>'en') = ''
-            OR c.data->'translation'->>'hu' IS NULL OR TRIM(c.data->'translation'->>'hu') = ''
-            OR c.data->'translation'->>'ch' IS NULL OR TRIM(c.data->'translation'->>'ch') = ''
-            OR (s.card_type = 'VOCABULARY' AND (
-                c.data->>'gender' IS NULL OR TRIM(c.data->>'gender') = ''
-                OR c.data->>'type' IS NULL OR TRIM(c.data->>'type') = ''
-            ))
-        )
-        GROUP BY c.source_id
-        """, nativeQuery = true)
+    @Query(value = "SELECT source_id, COUNT(*) FROM learn_language.unhealthy_cards GROUP BY source_id", nativeQuery = true)
     List<Object[]> countUnhealthyCardsBySourceGroupBySource();
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepositoryCustom.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepositoryCustom.java
@@ -1,9 +1,11 @@
 package io.github.mucsi96.learnlanguage.repository;
 
 import io.github.mucsi96.learnlanguage.model.CardReadiness;
+import io.github.mucsi96.learnlanguage.model.UnhealthyCardResponse;
 
 import java.util.List;
 
 public interface CardRepositoryCustom {
     void updateReadinessByIds(List<String> ids, CardReadiness readiness);
+    List<UnhealthyCardResponse> findUnhealthyCards();
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepositoryCustomImpl.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepositoryCustomImpl.java
@@ -3,11 +3,13 @@ package io.github.mucsi96.learnlanguage.repository;
 import io.github.mucsi96.learnlanguage.entity.Card;
 import io.github.mucsi96.learnlanguage.entity.Card_;
 import io.github.mucsi96.learnlanguage.model.CardReadiness;
+import io.github.mucsi96.learnlanguage.model.UnhealthyCardResponse;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaUpdate;
 import jakarta.persistence.criteria.Root;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.Session;
 
 import java.util.List;
 
@@ -25,5 +27,23 @@ public class CardRepositoryCustomImpl implements CardRepositoryCustom {
         update.where(root.get(Card_.id).in(ids));
 
         entityManager.createQuery(update).executeUpdate();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<UnhealthyCardResponse> findUnhealthyCards() {
+        final Session session = entityManager.unwrap(Session.class);
+
+        final List<Object[]> results = session
+                .createNativeQuery(
+                        "SELECT {c.*}, ARRAY_TO_STRING(missing_fields, ', ') AS missing_fields FROM learn_language.unhealthy_cards c ORDER BY c.due ASC",
+                        Object[].class)
+                .addEntity("c", Card.class)
+                .addScalar("missing_fields", String.class)
+                .getResultList();
+
+        return results.stream()
+                .map(row -> UnhealthyCardResponse.from((Card) row[0], (String) row[1]))
+                .toList();
     }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepositoryCustomImpl.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepositoryCustomImpl.java
@@ -47,7 +47,7 @@ public class CardRepositoryCustomImpl implements CardRepositoryCustom {
                 .getResultList();
 
         return results.stream()
-                .map(row -> UnhealthyCardResponse.from((Card) row[0], (String) row[2]))
+                .map(row -> UnhealthyCardResponse.from((Card) row[0], (String) row[1]))
                 .toList();
     }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepositoryCustomImpl.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepositoryCustomImpl.java
@@ -36,14 +36,18 @@ public class CardRepositoryCustomImpl implements CardRepositoryCustom {
 
         final List<Object[]> results = session
                 .createNativeQuery(
-                        "SELECT {c.*}, ARRAY_TO_STRING(missing_fields, ', ') AS missing_fields FROM learn_language.unhealthy_cards c ORDER BY c.due ASC",
+                        "SELECT {c.*}, {s.*}, ARRAY_TO_STRING(c.missing_fields, ', ') AS missing_fields " +
+                        "FROM learn_language.unhealthy_cards c " +
+                        "JOIN learn_language.sources s ON c.source_id = s.id " +
+                        "ORDER BY c.due ASC",
                         Object[].class)
                 .addEntity("c", Card.class)
+                .addJoin("s", "c.source")
                 .addScalar("missing_fields", String.class)
                 .getResultList();
 
         return results.stream()
-                .map(row -> UnhealthyCardResponse.from((Card) row[0], (String) row[1]))
+                .map(row -> UnhealthyCardResponse.from((Card) row[0], (String) row[2]))
                 .toList();
     }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/SourceCardCountProjection.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/SourceCardCountProjection.java
@@ -1,0 +1,6 @@
+package io.github.mucsi96.learnlanguage.repository;
+
+public interface SourceCardCountProjection {
+    String getSourceId();
+    Long getCount();
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -138,31 +138,15 @@ public class CardService {
   }
 
   public List<UnhealthyCardResponse> getUnhealthyCards() {
-    final List<Object[]> rows = cardRepository.findUnhealthyCardIdsWithMissingFields();
-    final List<String> ids = rows.stream().map(row -> (String) row[0]).toList();
-
-    if (ids.isEmpty()) {
-      return List.of();
-    }
-
-    final var cardsById = cardRepository.findByIdInOrderByIdAsc(ids).stream()
-        .collect(Collectors.toMap(Card::getId, card -> card));
-
-    return rows.stream()
-        .map(row -> {
-          final String id = (String) row[0];
-          final String missingFields = (String) row[1];
-          return UnhealthyCardResponse.from(cardsById.get(id), missingFields);
-        })
-        .toList();
+    return cardRepository.findUnhealthyCards();
   }
 
   public List<SourceCardCount> getUnhealthyCardCountsBySource() {
     return cardRepository.countUnhealthyCardsBySourceGroupBySource()
         .stream()
-        .map(record -> new SourceCardCount(
-            (String) record[0],
-            ((Long) record[1]).intValue())
+        .map(projection -> new SourceCardCount(
+            projection.getSourceId(),
+            projection.getCount().intValue())
         )
         .toList();
   }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -11,6 +11,7 @@ import io.github.mucsi96.learnlanguage.model.CardTableRow;
 import io.github.mucsi96.learnlanguage.model.AudioData;
 import io.github.mucsi96.learnlanguage.model.CardReadiness;
 import io.github.mucsi96.learnlanguage.model.SourceDueCardCountResponse;
+import io.github.mucsi96.learnlanguage.model.UnhealthyCardResponse;
 import io.github.mucsi96.learnlanguage.repository.CardRepository;
 import io.github.mucsi96.learnlanguage.repository.CardViewRepository;
 import io.github.mucsi96.learnlanguage.repository.ReviewLogRepository;
@@ -136,8 +137,24 @@ public class CardService {
     return cardRepository.findByFlaggedTrueOrderByDueAsc();
   }
 
-  public List<Card> getUnhealthyCards() {
-    return cardRepository.findUnhealthyCards();
+  public List<UnhealthyCardResponse> getUnhealthyCards() {
+    final List<Object[]> rows = cardRepository.findUnhealthyCardIdsWithMissingFields();
+    final List<String> ids = rows.stream().map(row -> (String) row[0]).toList();
+
+    if (ids.isEmpty()) {
+      return List.of();
+    }
+
+    final var cardsById = cardRepository.findByIdInOrderByIdAsc(ids).stream()
+        .collect(Collectors.toMap(Card::getId, card -> card));
+
+    return rows.stream()
+        .map(row -> {
+          final String id = (String) row[0];
+          final String missingFields = (String) row[1];
+          return UnhealthyCardResponse.from(cardsById.get(id), missingFields);
+        })
+        .toList();
   }
 
   public List<SourceCardCount> getUnhealthyCardCountsBySource() {

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -248,3 +248,25 @@ LEFT JOIN LATERAL (
 ) rs ON true;
 
 CREATE UNIQUE INDEX IF NOT EXISTS card_view_id_idx ON learn_language.card_view (id);
+
+CREATE OR REPLACE VIEW learn_language.unhealthy_cards AS
+SELECT c.*,
+    ARRAY_REMOVE(ARRAY[
+        CASE WHEN c.data->'translation'->>'en' IS NULL OR TRIM(c.data->'translation'->>'en') = '' THEN 'English translation' END,
+        CASE WHEN c.data->'translation'->>'hu' IS NULL OR TRIM(c.data->'translation'->>'hu') = '' THEN 'Hungarian translation' END,
+        CASE WHEN c.data->'translation'->>'ch' IS NULL OR TRIM(c.data->'translation'->>'ch') = '' THEN 'Swiss German translation' END,
+        CASE WHEN s.card_type = 'VOCABULARY' AND (c.data->>'gender' IS NULL OR TRIM(c.data->>'gender') = '') THEN 'gender' END,
+        CASE WHEN s.card_type = 'VOCABULARY' AND (c.data->>'type' IS NULL OR TRIM(c.data->>'type') = '') THEN 'word type' END
+    ], NULL) AS missing_fields
+FROM learn_language.cards c
+JOIN learn_language.sources s ON c.source_id = s.id
+WHERE c.readiness IN ('READY', 'REVIEWED', 'KNOWN')
+AND (
+    c.data->'translation'->>'en' IS NULL OR TRIM(c.data->'translation'->>'en') = ''
+    OR c.data->'translation'->>'hu' IS NULL OR TRIM(c.data->'translation'->>'hu') = ''
+    OR c.data->'translation'->>'ch' IS NULL OR TRIM(c.data->'translation'->>'ch') = ''
+    OR (s.card_type = 'VOCABULARY' AND (
+        c.data->>'gender' IS NULL OR TRIM(c.data->>'gender') = ''
+        OR c.data->>'type' IS NULL OR TRIM(c.data->>'type') = ''
+    ))
+);

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -250,23 +250,17 @@ LEFT JOIN LATERAL (
 CREATE UNIQUE INDEX IF NOT EXISTS card_view_id_idx ON learn_language.card_view (id);
 
 CREATE OR REPLACE VIEW learn_language.unhealthy_cards AS
-SELECT c.*,
-    ARRAY_REMOVE(ARRAY[
-        CASE WHEN c.data->'translation'->>'en' IS NULL OR TRIM(c.data->'translation'->>'en') = '' THEN 'English translation' END,
-        CASE WHEN c.data->'translation'->>'hu' IS NULL OR TRIM(c.data->'translation'->>'hu') = '' THEN 'Hungarian translation' END,
-        CASE WHEN c.data->'translation'->>'ch' IS NULL OR TRIM(c.data->'translation'->>'ch') = '' THEN 'Swiss German translation' END,
-        CASE WHEN s.card_type = 'VOCABULARY' AND (c.data->>'gender' IS NULL OR TRIM(c.data->>'gender') = '') THEN 'gender' END,
-        CASE WHEN s.card_type = 'VOCABULARY' AND (c.data->>'type' IS NULL OR TRIM(c.data->>'type') = '') THEN 'word type' END
-    ], NULL) AS missing_fields
-FROM learn_language.cards c
-JOIN learn_language.sources s ON c.source_id = s.id
-WHERE c.readiness IN ('READY', 'REVIEWED', 'KNOWN')
-AND (
-    c.data->'translation'->>'en' IS NULL OR TRIM(c.data->'translation'->>'en') = ''
-    OR c.data->'translation'->>'hu' IS NULL OR TRIM(c.data->'translation'->>'hu') = ''
-    OR c.data->'translation'->>'ch' IS NULL OR TRIM(c.data->'translation'->>'ch') = ''
-    OR (s.card_type = 'VOCABULARY' AND (
-        c.data->>'gender' IS NULL OR TRIM(c.data->>'gender') = ''
-        OR c.data->>'type' IS NULL OR TRIM(c.data->>'type') = ''
-    ))
-);
+WITH computed AS (
+    SELECT c.*,
+        ARRAY_REMOVE(ARRAY[
+            CASE WHEN c.data->'translation'->>'en' IS NULL OR TRIM(c.data->'translation'->>'en') = '' THEN 'English translation' END,
+            CASE WHEN c.data->'translation'->>'hu' IS NULL OR TRIM(c.data->'translation'->>'hu') = '' THEN 'Hungarian translation' END,
+            CASE WHEN c.data->'translation'->>'ch' IS NULL OR TRIM(c.data->'translation'->>'ch') = '' THEN 'Swiss German translation' END,
+            CASE WHEN s.card_type = 'VOCABULARY' AND (c.data->>'gender' IS NULL OR TRIM(c.data->>'gender') = '') THEN 'gender' END,
+            CASE WHEN s.card_type = 'VOCABULARY' AND (c.data->>'type' IS NULL OR TRIM(c.data->>'type') = '') THEN 'word type' END
+        ], NULL) AS missing_fields
+    FROM learn_language.cards c
+    JOIN learn_language.sources s ON c.source_id = s.id
+    WHERE c.readiness IN ('READY', 'REVIEWED', 'KNOWN')
+)
+SELECT * FROM computed WHERE ARRAY_LENGTH(missing_fields, 1) > 0;

--- a/test/tests/unhealthy-cards.spec.ts
+++ b/test/tests/unhealthy-cards.spec.ts
@@ -176,8 +176,7 @@ test('move selected unhealthy cards to draft', async ({ page }) => {
     expect(rows.length).toBeGreaterThanOrEqual(1);
   }).toPass();
 
-  const firstCheckbox = grid.locator('.ag-selection-checkbox').first();
-  await firstCheckbox.click();
+  await grid.getByRole('checkbox').first().click();
 
   const draftButton = section.getByRole('button', { name: /Move .* to draft/ });
   await expect(draftButton).toBeVisible();


### PR DESCRIPTION
…code quality

- Extract unhealthy card detection into a PostgreSQL view (learn_language.unhealthy_cards) with a missing_fields column, eliminating duplicated WHERE clauses between the two repository queries
- Move missingFields computation to the backend via UnhealthyCardResponse, removing the duplicated detection logic from the frontend
- Remove fallback values (name ?? '', cardType ?? '') that hide missing data
- Replace mutable GridApi field with signal<GridApi | null> for consistency
- Replace CSS class selector in test with getByRole('checkbox')

https://claude.ai/code/session_01Farf4NykQnyMsyYgHTWXjK