### PR TITLE
Clear selected card IDs after refresh operation

### DIFF
--- a/client/src/app/cards-table/cards-table.component.ts
+++ b/client/src/app/cards-table/cards-table.component.ts
@@ -411,6 +411,7 @@ export class CardsTableComponent {
       duration: 3000,
       verticalPosition: 'top',
     });
+    this.selectedIds.set([]);
     await this.cardsTableService.refreshCardView();
     this.refreshGrid();
   }


### PR DESCRIPTION
## Summary
Added logic to clear the selected card IDs after a successful card view refresh operation.

## Key Changes
- Clear the `selectedIds` array by setting it to an empty array after displaying the success toast notification and before refreshing the card view
- This ensures that no cards remain in the selected state after the refresh completes

## Implementation Details
The `selectedIds.set([])` call is placed strategically after the toast notification is shown but before the `refreshCardView()` and `refreshGrid()` calls, ensuring a clean state for the refreshed card data.

https://claude.ai/code/session_01PytBLohBZCCrjbTCtQh7LP