### PR TITLE
Fix review log queries to select first review of last day

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/ReviewLogRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/ReviewLogRepository.java
@@ -22,11 +22,17 @@ public interface ReviewLogRepository
         SELECT card_id,
                (4.0 - rating) * GREATEST(EXTRACT(EPOCH FROM NOW() - review) / 86400, 1) as complexity
         FROM (
-            SELECT DISTINCT ON (card_id) card_id, rating, review
-            FROM learn_language.review_logs
-            WHERE card_id IN :cardIds AND learning_partner_id IS NULL
-            ORDER BY card_id, review DESC
-        ) latest_reviews
+            SELECT DISTINCT ON (rl.card_id) rl.card_id, rl.rating, rl.review
+            FROM learn_language.review_logs rl
+            INNER JOIN (
+                SELECT card_id, MAX(review::date) as last_review_date
+                FROM learn_language.review_logs
+                WHERE card_id IN :cardIds AND learning_partner_id IS NULL
+                GROUP BY card_id
+            ) latest ON rl.card_id = latest.card_id AND rl.review::date = latest.last_review_date
+            WHERE rl.learning_partner_id IS NULL
+            ORDER BY rl.card_id, rl.review ASC
+        ) first_review_on_last_day
         """, nativeQuery = true)
     List<Object[]> findCardComplexitiesWithoutPartner(@Param("cardIds") List<String> cardIds);
 
@@ -34,11 +40,17 @@ public interface ReviewLogRepository
         SELECT card_id,
                (4.0 - rating) * GREATEST(EXTRACT(EPOCH FROM NOW() - review) / 86400, 1) as complexity
         FROM (
-            SELECT DISTINCT ON (card_id) card_id, rating, review
-            FROM learn_language.review_logs
-            WHERE card_id IN :cardIds AND learning_partner_id = :learningPartnerId
-            ORDER BY card_id, review DESC
-        ) latest_reviews
+            SELECT DISTINCT ON (rl.card_id) rl.card_id, rl.rating, rl.review
+            FROM learn_language.review_logs rl
+            INNER JOIN (
+                SELECT card_id, MAX(review::date) as last_review_date
+                FROM learn_language.review_logs
+                WHERE card_id IN :cardIds AND learning_partner_id = :learningPartnerId
+                GROUP BY card_id
+            ) latest ON rl.card_id = latest.card_id AND rl.review::date = latest.last_review_date
+            WHERE rl.learning_partner_id = :learningPartnerId
+            ORDER BY rl.card_id, rl.review ASC
+        ) first_review_on_last_day
         """, nativeQuery = true)
     List<Object[]> findCardComplexitiesWithPartner(
         @Param("cardIds") List<String> cardIds,

--- a/test/tests/smart-card-assignment.spec.ts
+++ b/test/tests/smart-card-assignment.spec.ts
@@ -527,6 +527,72 @@ test('smart assignment: hardest cards for each person at front of their queue', 
   expect(sessionCards[3].learningPartnerId).toBe(partnerId);
 });
 
+test('smart assignment: uses first grading of the day instead of last corrected review', async ({
+  page,
+}) => {
+  const partnerId = await createLearningPartner({ name: 'Partner', isActive: true });
+  const yesterday = new Date(Date.now() - 86400000);
+  const twoDaysAgo = new Date(Date.now() - 2 * 86400000);
+  const twoDaysAgoMorning = new Date(twoDaysAgo);
+  twoDaysAgoMorning.setHours(9, 0, 0, 0);
+  const twoDaysAgoLater = new Date(twoDaysAgo);
+  twoDaysAgoLater.setHours(9, 10, 0, 0);
+
+  await createCard({
+    cardId: 'corrected-javitott',
+    sourceId: 'goethe-a1',
+    data: { word: 'korrigiert', type: 'VERB', translation: { hu: 'javított' } },
+    due: yesterday,
+  });
+  await createCard({
+    cardId: 'easy-konnyu',
+    sourceId: 'goethe-a1',
+    data: { word: 'leicht', type: 'ADJECTIVE', translation: { hu: 'könnyű' } },
+    due: yesterday,
+  });
+
+  await createReviewLog({
+    cardId: 'corrected-javitott',
+    learningPartnerId: null,
+    rating: 1,
+    review: twoDaysAgoMorning,
+  });
+  await createReviewLog({
+    cardId: 'corrected-javitott',
+    learningPartnerId: null,
+    rating: 4,
+    review: twoDaysAgoLater,
+  });
+
+  await createReviewLog({
+    cardId: 'easy-konnyu',
+    learningPartnerId: null,
+    rating: 4,
+    review: twoDaysAgoMorning,
+  });
+
+  await createReviewLog({
+    cardId: 'corrected-javitott',
+    learningPartnerId: partnerId,
+    rating: 4,
+    review: twoDaysAgoMorning,
+  });
+  await createReviewLog({
+    cardId: 'easy-konnyu',
+    learningPartnerId: partnerId,
+    rating: 4,
+    review: twoDaysAgoMorning,
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
+
+  const sessionCards = await getStudySessionCards(page);
+
+  const correctedCard = sessionCards.find((c) => c.cardId === 'corrected-javitott');
+  expect(correctedCard?.learningPartnerId).toBeNull();
+});
+
 test('smart assignment: session limited to 50 most complex cards', async ({ page }) => {
   await page.reload();
   const partnerId = await createLearningPartner({ name: 'Partner', isActive: true });


### PR DESCRIPTION
## Summary
Updated the review log complexity queries to correctly select the first review of the last review date for each card, rather than the most recent review regardless of time.

## Key Changes
- Modified `findCardComplexitiesWithoutPartner()` query to use an INNER JOIN that groups reviews by date and selects only reviews from the last review date
- Modified `findCardComplexitiesWithPartner()` query with the same logic for partner-specific reviews
- Changed ordering from `review DESC` to `review ASC` to get the first review of the day instead of the last
- Added explicit table aliases (`rl`) for clarity and to support the subquery join
- Renamed result alias from `latest_reviews` to `first_review_on_last_day` to better reflect the query intent

## Implementation Details
- Both queries now use a subquery that finds the maximum review date (cast to date type) for each card
- The INNER JOIN ensures only reviews matching both the card_id and the last_review_date are selected
- The `review::date` cast ensures date-level grouping, handling multiple reviews on the same day
- This change ensures consistent behavior when multiple reviews exist for a card on the same day

https://claude.ai/code/session_01SsCYUnPe1TMZvYyf8FyNxx