### PR TITLE
Strip all images from known cards during cleanup

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/FileStorageCleanupService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/FileStorageCleanupService.java
@@ -25,7 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class FileStorageCleanupService {
 
-  private static final List<CardReadiness> REVIEWED_READINESS = List.of(CardReadiness.REVIEWED, CardReadiness.READY, CardReadiness.KNOWN);
+  private static final List<CardReadiness> REVIEWED_READINESS = List.of(CardReadiness.REVIEWED, CardReadiness.READY);
 
   private final FileStorageService fileStorageService;
   private final CardRepository cardRepository;
@@ -34,10 +34,26 @@ public class FileStorageCleanupService {
   @EventListener(ApplicationReadyEvent.class)
   @Transactional
   public void cleanupUnreferencedFiles() {
+    stripAllImagesFromKnownCards();
     stripNonFavoriteImagesFromReviewedCards();
     cleanupAudioFiles();
     cleanupImageFiles();
     cleanupSourceDocuments();
+  }
+
+  private void stripAllImagesFromKnownCards() {
+    final var cards = cardRepository.findByReadinessIn(List.of(CardReadiness.KNOWN)).stream()
+        .filter(card -> Optional.ofNullable(card.getData().getExamples())
+            .map(examples -> examples.stream()
+                .anyMatch(example -> example.getImages() != null && !example.getImages().isEmpty()))
+            .orElse(false))
+        .toList();
+
+    cards.forEach(card -> card.getData().getExamples()
+        .forEach(example -> example.setImages(null)));
+
+    cardRepository.saveAll(cards);
+    log.info("Stripped all images from {} known cards", cards.size());
   }
 
   private void stripNonFavoriteImagesFromReviewedCards() {

--- a/test/tests/file-storage-cleanup.spec.ts
+++ b/test/tests/file-storage-cleanup.spec.ts
@@ -156,6 +156,51 @@ test('strips non-favorite images from reviewed cards and deletes their files', a
   });
 });
 
+test('strips all images from known cards including favorites', async ({ page }) => {
+  const favoriteImageId = 'fav-image-known-1';
+  const nonFavoriteImageId = 'non-fav-image-known-1';
+
+  await createCard({
+    cardId: 'known-card-with-images',
+    sourceId: 'goethe-a1',
+    readiness: 'KNOWN',
+    data: {
+      word: 'Tisch',
+      type: 'NOUN',
+      translation: { en: 'table', hu: 'asztal' },
+      forms: [],
+      examples: [
+        {
+          de: 'Der Tisch ist rund.',
+          en: 'The table is round.',
+          hu: 'Az asztal kerek.',
+          isSelected: true,
+          images: [
+            { id: favoriteImageId, isFavorite: true },
+            { id: nonFavoriteImageId },
+          ],
+        },
+      ],
+    },
+  });
+
+  writeStorageFile(`images/${favoriteImageId}.webp`, yellowImage);
+  writeStorageFile(`images/${nonFavoriteImageId}.webp`, redImage);
+
+  await triggerCleanup();
+
+  expect(storageFileExists(`images/${favoriteImageId}.webp`)).toBe(false);
+  expect(storageFileExists(`images/${nonFavoriteImageId}.webp`)).toBe(false);
+
+  await withDbConnection(async (client) => {
+    const result = await client.query(
+      "SELECT data FROM learn_language.cards WHERE id = 'known-card-with-images'"
+    );
+    const cardData = result.rows[0].data;
+    expect(cardData.examples[0].images).toBeNull();
+  });
+});
+
 test('preserves non-favorite images on in-review cards', async ({ page }) => {
   const favoriteImageId = 'fav-image-2';
   const nonFavoriteImageId = 'non-fav-image-2';


### PR DESCRIPTION
## Summary
This change modifies the file storage cleanup service to remove all images (including favorites) from cards marked as "KNOWN", while preserving the existing behavior for reviewed cards.

## Key Changes
- **Updated cleanup logic**: Added `stripAllImagesFromKnownCards()` method that removes all images from known cards regardless of favorite status
- **Adjusted readiness filter**: Removed `CardReadiness.KNOWN` from the `REVIEWED_READINESS` list so known cards are handled separately with different cleanup rules
- **Execution order**: Known card cleanup now runs before reviewed card cleanup to ensure proper sequencing

## Implementation Details
- The new `stripAllImagesFromKnownCards()` method filters cards by readiness status and checks if they contain examples with images
- For each matching card, all images in examples are set to null (completely removed)
- Added corresponding test case to verify that both favorite and non-favorite images are stripped from known cards and their files are deleted
- The cleanup maintains the existing behavior for reviewed/ready cards, which only strip non-favorite images

https://claude.ai/code/session_01Vtj6iJvt5utEip1sC7xaNb