### PR TITLE
Fix card page quick filter buttons not refreshing grid data

### DIFF
--- a/client/src/app/cards-table/cards-table.component.ts
+++ b/client/src/app/cards-table/cards-table.component.ts
@@ -165,6 +165,12 @@ export class CardsTableComponent {
         this.cardsTableService.refreshCardView().then(() => this.refreshGrid());
       }
     });
+    effect(() => {
+      this.activeQuickFilter();
+      if (this.gridApi) {
+        this.refreshGrid();
+      }
+    });
   }
 
   private gridApi: GridApi | null = null;


### PR DESCRIPTION
The quick filter buttons (Unhealthy, Flagged, Draft) updated URL query params and derived signals but never called refreshGrid(), so the ag-Grid infinite datasource never reloaded with the new filter criteria.

https://claude.ai/code/session_014t32XYNNwy1oEDSZGEtqpi