### PR TITLE
Add remove flag functionality to edit card page

### DIFF
--- a/client/src/app/parser/edit-card/edit-card.component.css
+++ b/client/src/app/parser/edit-card/edit-card.component.css
@@ -9,7 +9,7 @@
 
 .title {
   display: grid;
-  grid-template-columns: 1fr auto auto auto;
+  grid-template-columns: 1fr auto auto auto auto;
   column-gap: 1rem;
   padding-bottom: 1rem;
 }

--- a/client/src/app/parser/edit-card/edit-card.component.css
+++ b/client/src/app/parser/edit-card/edit-card.component.css
@@ -8,10 +8,14 @@
 }
 
 .title {
-  display: grid;
-  grid-template-columns: 1fr auto auto auto auto;
-  column-gap: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
   padding-bottom: 1rem;
+}
+
+.title-spacer {
+  flex: 1;
 }
 
 .field {

--- a/client/src/app/parser/edit-card/edit-card.component.html
+++ b/client/src/app/parser/edit-card/edit-card.component.html
@@ -8,6 +8,7 @@
   </div>
   <h2 class="title">
     {{ getCardTypeTitle() }}
+    <span class="title-spacer"></span>
     @if (card.value()) {
       <button
         mat-icon-button
@@ -24,7 +25,7 @@
           (click)="removeFlag()"
           aria-label="Remove flag"
         >
-          <mat-icon>flag</mat-icon>
+          <mat-icon>flag_off</mat-icon>
           Remove flag
         </button>
       }

--- a/client/src/app/parser/edit-card/edit-card.component.html
+++ b/client/src/app/parser/edit-card/edit-card.component.html
@@ -17,6 +17,17 @@
       >
         <mat-icon>delete</mat-icon>
       </button>
+      @if (isFlagged()) {
+        <button
+          type="button"
+          mat-flat-button
+          (click)="removeFlag()"
+          aria-label="Remove flag"
+        >
+          <mat-icon>flag</mat-icon>
+          Remove flag
+        </button>
+      }
       @if (isInReview()) {
         <button
           type="button"

--- a/client/src/app/parser/edit-card/edit-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-card.component.ts
@@ -128,15 +128,17 @@ export class EditCardComponent {
       return;
     }
 
-    await fetchJson(this.http, `/api/card/${cardId}`, {
-      body: { flagged: false },
-      method: 'PUT',
-    });
-
-    this.card.reload();
-    this.showSnackBar('Flag removed successfully');
+    try {
+      await fetchJson(this.http, `/api/card/${cardId}`, {
+        body: { flagged: false },
+        method: 'PUT',
+      });
+      this.card.reload();
+      this.showSnackBar('Flag removed successfully');
+    } catch {
+      this.showSnackBar('Failed to remove flag');
+    }
   }
-
 
   private showSnackBar(message: string) {
     this.snackBar.open(message, 'Close', {

--- a/client/src/app/parser/edit-card/edit-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-card.component.ts
@@ -136,15 +136,15 @@ export class EditCardComponent {
       this.card.reload();
       this.showSnackBar('Flag removed successfully');
     } catch {
-      this.showSnackBar('Failed to remove flag');
+      this.showSnackBar('Failed to remove flag', 'error');
     }
   }
 
-  private showSnackBar(message: string) {
+  private showSnackBar(message: string, type: 'success' | 'error' = 'success') {
     this.snackBar.open(message, 'Close', {
       duration: 3000,
       verticalPosition: 'top',
-      panelClass: ['success'],
+      panelClass: [type],
     });
   }
 

--- a/client/src/app/parser/edit-card/edit-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-card.component.ts
@@ -85,6 +85,10 @@ export class EditCardComponent {
     return card?.readiness === 'IN_REVIEW';
   });
 
+  readonly isFlagged = computed(() => {
+    return this.card.value()?.flagged ?? false;
+  });
+
   readonly canMarkAsReviewed = computed(() => {
     return this.isInReview() && this.markAsReviewedAvailable();
   });
@@ -116,6 +120,21 @@ export class EditCardComponent {
 
   handleCardUpdate(cardData: any) {
     this.pendingCardEdits.set(cardData);
+  }
+
+  async removeFlag() {
+    const cardId = this.selectedCardId();
+    if (!cardId) {
+      return;
+    }
+
+    await fetchJson(this.http, `/api/card/${cardId}`, {
+      body: { flagged: false },
+      method: 'PUT',
+    });
+
+    this.card.reload();
+    this.showSnackBar('Flag removed successfully');
   }
 
 

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '../fixtures';
 import {
   createCard,
   downloadImage,
+  getCardFromDb,
   getImageColor,
   getImageContent,
   withDbConnection,
@@ -808,4 +809,71 @@ test('grammar card editing saves gaps to database', async ({ page }) => {
     const cardData = result.rows[0].data;
     expect(cardData.examples[0].de).toBe('Das Kind [spielt] im Garten.');
   });
+});
+
+test('remove flag button is visible for flagged card', async ({ page }) => {
+  await createCard({
+    cardId: 'flagged-card-visible',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'sehen',
+      type: 'VERB',
+      forms: ['sieht', 'sah', 'gesehen'],
+      translation: { en: 'to see', hu: 'látni', ch: 'gseh' },
+      examples: [
+        {
+          de: 'Ich sehe den Hund.',
+          hu: 'Látom a kutyát.',
+          en: 'I see the dog.',
+          ch: 'Ich gseh de Hund.',
+          isSelected: true,
+        },
+      ],
+    },
+    flagged: true,
+  });
+
+  await navigateToCardEditing(page);
+
+  await expect(page.getByRole('button', { name: 'Remove flag' })).toBeVisible();
+});
+
+test('remove flag button is not visible for unflagged card', async ({ page }) => {
+  await prepareCard(page);
+
+  await expect(page.getByRole('button', { name: 'Remove flag' })).not.toBeVisible();
+});
+
+test('remove flag unflags card in database', async ({ page }) => {
+  await createCard({
+    cardId: 'flagged-card-unflag',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'laufen',
+      type: 'VERB',
+      forms: ['läuft', 'lief', 'gelaufen'],
+      translation: { en: 'to run', hu: 'futni', ch: 'laufe' },
+      examples: [
+        {
+          de: 'Er läuft schnell.',
+          hu: 'Gyorsan fut.',
+          en: 'He runs fast.',
+          ch: 'Er lauft schnäll.',
+          isSelected: true,
+        },
+      ],
+    },
+    flagged: true,
+  });
+
+  await navigateToCardEditing(page);
+
+  await page.getByRole('button', { name: 'Remove flag' }).click();
+  await expect(page.getByText('Flag removed successfully')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Remove flag' })).not.toBeVisible();
+
+  const card = await getCardFromDb('flagged-card-unflag');
+  expect(card.flagged).toBe(false);
 });

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -834,7 +834,7 @@ test('remove flag button is visible for flagged card', async ({ page }) => {
     flagged: true,
   });
 
-  await navigateToCardEditing(page);
+  await page.goto('http://localhost:8180/sources/goethe-a1/page/9/cards/flagged-card-visible');
 
   await expect(page.getByRole('button', { name: 'Remove flag' })).toBeVisible();
 });
@@ -868,7 +868,7 @@ test('remove flag unflags card in database', async ({ page }) => {
     flagged: true,
   });
 
-  await navigateToCardEditing(page);
+  await page.goto('http://localhost:8180/sources/goethe-a1/page/9/cards/flagged-card-unflag');
 
   await page.getByRole('button', { name: 'Remove flag' }).click();
   await expect(page.getByText('Flag removed successfully')).toBeVisible();


### PR DESCRIPTION
## Summary
Added the ability to remove flags from cards on the edit card page. Users can now see a "Remove flag" button for flagged cards and click it to unflag the card, which updates the database and displays a success message.

## Key Changes
- **Component Logic**: Added `isFlagged` computed property to track whether a card is flagged
- **Remove Flag Method**: Implemented `removeFlag()` method that sends a PUT request to update the card's `flagged` status to false, reloads the card data, and shows a success notification
- **UI Updates**: Added conditional "Remove flag" button that appears only when a card is flagged
- **Layout Adjustment**: Updated grid template columns in CSS to accommodate the new button in the title section
- **Test Coverage**: Added three comprehensive tests:
  - Verify "Remove flag" button is visible for flagged cards
  - Verify "Remove flag" button is hidden for unflagged cards
  - Verify clicking "Remove flag" updates the database and UI correctly

## Implementation Details
- The `removeFlag()` method uses the existing `fetchJson` utility for API communication
- The button uses Angular Material icon and styling consistent with other action buttons
- The card data is reloaded after the flag is removed to ensure UI consistency
- A snackbar notification confirms successful flag removal to the user

https://claude.ai/code/session_01QH1zRyX5u78nSaquiJgrkk