### PR TITLE
Display card state counts only for ready cards

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -133,7 +133,7 @@ public class CardService {
             SourceCardStatsProjection::getSourceId,
             Collectors.collectingAndThen(Collectors.toList(), rows -> {
               final Predicate<SourceCardStatsProjection> isDraft =
-                  row -> "DRAFT".equals(row.getReadiness());
+                  row -> CardReadiness.DRAFT.name().equals(row.getReadiness());
 
               final int cardCount = rows.stream()
                   .filter(isDraft.negate())
@@ -156,7 +156,7 @@ public class CardService {
                   .sum();
 
               final Predicate<SourceCardStatsProjection> isReady =
-                  row -> "READY".equals(row.getReadiness());
+                  row -> CardReadiness.READY.name().equals(row.getReadiness());
 
               final Map<String, Integer> stateCounts = rows.stream()
                   .filter(isReady)

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -155,8 +155,11 @@ public class CardService {
                   .mapToInt(row -> row.getCount().intValue())
                   .sum();
 
+              final Predicate<SourceCardStatsProjection> isReady =
+                  row -> "READY".equals(row.getReadiness());
+
               final Map<String, Integer> stateCounts = rows.stream()
-                  .filter(isDraft.negate())
+                  .filter(isReady)
                   .collect(Collectors.groupingBy(
                       SourceCardStatsProjection::getState,
                       Collectors.summingInt(row -> row.getCount().intValue())));

--- a/test/tests/sources.spec.ts
+++ b/test/tests/sources.spec.ts
@@ -129,7 +129,7 @@ test('displays card count for sources', async ({ page }) => {
   await expect(page.getByRole('article', { name: 'Goethe B1' }).getByText('0')).toBeVisible();
 });
 
-test('displays card state counts for sources', async ({ page }) => {
+test('displays card state counts only for ready cards', async ({ page }) => {
   await createCard({
     cardId: 'test-new-1',
     sourceId: 'goethe-a1',
@@ -163,10 +163,23 @@ test('displays card state counts for sources', async ({ page }) => {
       translation: { en: 'review1' },
     },
   });
+  await createCard({
+    cardId: 'test-known-new',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    state: 'NEW',
+    readiness: 'KNOWN',
+    data: {
+      word: 'known1',
+      type: 'NOUN',
+      translation: { en: 'known1' },
+    },
+  });
 
   await page.goto('http://localhost:8180/sources');
   const source = page.getByRole('article', { name: 'Goethe A1' });
   await expect(source.getByText('Ready 3')).toBeVisible();
+  await expect(source.getByText('Known 1')).toBeVisible();
   await expect(source.getByTitle('New')).toContainText('2');
   await expect(source.getByTitle('Review')).toContainText('1');
 });

--- a/test/tests/sources.spec.ts
+++ b/test/tests/sources.spec.ts
@@ -175,11 +175,24 @@ test('displays card state counts only for ready cards', async ({ page }) => {
       translation: { en: 'known1' },
     },
   });
+  await createCard({
+    cardId: 'test-in-review-new',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    state: 'NEW',
+    readiness: 'IN_REVIEW',
+    data: {
+      word: 'inreview1',
+      type: 'NOUN',
+      translation: { en: 'inreview1' },
+    },
+  });
 
   await page.goto('http://localhost:8180/sources');
   const source = page.getByRole('article', { name: 'Goethe A1' });
   await expect(source.getByText('Ready 3')).toBeVisible();
   await expect(source.getByText('Known 1')).toBeVisible();
+  await expect(source.getByLabel('IN_REVIEW: 1')).toBeVisible();
   await expect(source.getByTitle('New')).toContainText('2');
   await expect(source.getByTitle('Review')).toContainText('1');
 });


### PR DESCRIPTION
## Summary
Updated the card statistics display to only show state counts (New, Review, etc.) for cards with "READY" readiness status, rather than all non-draft cards.

## Key Changes
- Modified `CardService.getSourceStats()` to filter cards by readiness status "READY" instead of excluding only draft cards
- Introduced an explicit `isReady` predicate for clarity and maintainability
- Updated test to verify that state counts are displayed only for ready cards
- Added test coverage for cards with "KNOWN" readiness status to ensure they are excluded from state counts but still counted in the total card count

## Implementation Details
- The change replaces the `isDraft.negate()` filter with an explicit `isReady` predicate that checks `readiness == "READY"`
- This ensures that only cards in the READY state contribute to the state count breakdown (New, Review, etc.)
- Cards with other readiness statuses (like KNOWN) are still included in the total card count but not in the state-specific counts

https://claude.ai/code/session_0189c1ABn4T3d1TRwnF9hwBq