### PR TITLE
Hide bulk audio FAB for cards with known readiness

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -115,10 +115,8 @@ public class CardService {
   }
 
   public List<Card> getCardsMissingAudio(boolean frontAudioEnabled) {
-    return cardRepository.findAll()
+    return cardRepository.findByReadinessIn(List.of(CardReadiness.DRAFT, CardReadiness.REVIEWED, CardReadiness.READY))
         .stream()
-        .filter(card -> card.getReadiness() != CardReadiness.IN_REVIEW
-            && card.getReadiness() != CardReadiness.KNOWN)
         .filter(card -> cardTypeStrategyFactory.getStrategy(card.getSource().getCardType())
             .isMissingAudio(card.getData(), frontAudioEnabled))
         .toList();

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -117,7 +117,8 @@ public class CardService {
   public List<Card> getCardsMissingAudio(boolean frontAudioEnabled) {
     return cardRepository.findAll()
         .stream()
-        .filter(card -> !card.isInReview())
+        .filter(card -> card.getReadiness() != CardReadiness.IN_REVIEW
+            && card.getReadiness() != CardReadiness.KNOWN)
         .filter(card -> cardTypeStrategyFactory.getStrategy(card.getSource().getCardType())
             .isMissingAudio(card.getData(), frontAudioEnabled))
         .toList();

--- a/test/tests/bulk-audio-creation.spec.ts
+++ b/test/tests/bulk-audio-creation.spec.ts
@@ -1137,6 +1137,35 @@ test('bulk audio creation does not fail when no session exists', async ({ page }
   expect(sessionCards.length).toBe(0);
 });
 
+test('bulk audio fab hides for cards with known readiness', async ({ page }) => {
+  await createCard({
+    cardId: 'verstehen-erteni',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 15,
+    data: {
+      word: 'verstehen',
+      type: 'VERB',
+      translation: { en: 'to understand', hu: 'érteni', ch: 'verstoh' },
+      forms: ['versteht', 'verstand', 'verstanden'],
+      examples: [
+        {
+          de: 'Ich verstehe Deutsch.',
+          hu: 'Értem a németet.',
+          en: 'I understand German.',
+          ch: 'Ich verstoh Tüütsch.',
+          isSelected: true,
+          images: [{ id: 'test-image-id' }],
+        },
+      ],
+    },
+    readiness: 'KNOWN',
+  });
+
+  await page.goto('http://localhost:8180/in-review-cards');
+
+  await expect(page.getByRole('button', { name: 'Generate audio for cards' })).not.toBeVisible();
+});
+
 test('bulk audio fab hides when front audio disabled and only front audio missing', async ({ page }) => {
   await createAudioSetting({ key: 'front-enabled', value: 0 });
   await createCard({


### PR DESCRIPTION
## Summary
Updated the bulk audio generation feature to exclude cards marked as "KNOWN" from the audio generation workflow, in addition to cards already in review.

## Key Changes
- Modified `CardService.getCardsMissingAudio()` to filter out cards with `CardReadiness.KNOWN` status, preventing them from appearing in the bulk audio generation list
- Replaced the `isInReview()` check with explicit readiness status comparisons for better clarity and to handle both IN_REVIEW and KNOWN states
- Added test case to verify the bulk audio FAB (floating action button) is hidden when viewing cards with known readiness

## Implementation Details
The change ensures that cards marked as "KNOWN" are treated similarly to cards "IN_REVIEW" - they are excluded from the bulk audio generation feature since they don't require audio generation. This is enforced at the service layer, preventing these cards from being included in the missing audio query results.

https://claude.ai/code/session_01QBmMtQ1owt3qXH54c2y26s