### PR TITLE
Exclude draft cards from bulk audio generation

### DIFF
--- a/client/src/app/batch-audio-creation.service.ts
+++ b/client/src/app/batch-audio-creation.service.ts
@@ -165,7 +165,7 @@ export class BatchAudioCreationService {
           ...card.data,
           audio: finalAudioList,
         },
-        readiness: card.readiness === 'DRAFT' ? 'DRAFT' : 'READY',
+        readiness: 'READY',
       };
 
       await fetchJson(this.http, `/api/card/${card.id}`, {

--- a/client/src/app/batch-audio-creation.service.ts
+++ b/client/src/app/batch-audio-creation.service.ts
@@ -165,7 +165,7 @@ export class BatchAudioCreationService {
           ...card.data,
           audio: finalAudioList,
         },
-        readiness: 'READY',
+        readiness: card.readiness === 'DRAFT' ? 'DRAFT' : 'READY',
       };
 
       await fetchJson(this.http, `/api/card/${card.id}`, {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -115,7 +115,7 @@ public class CardService {
   }
 
   public List<Card> getCardsMissingAudio(boolean frontAudioEnabled) {
-    return cardRepository.findByReadinessIn(List.of(CardReadiness.DRAFT, CardReadiness.REVIEWED, CardReadiness.READY))
+    return cardRepository.findByReadinessIn(List.of(CardReadiness.REVIEWED, CardReadiness.READY))
         .stream()
         .filter(card -> cardTypeStrategyFactory.getStrategy(card.getSource().getCardType())
             .isMissingAudio(card.getData(), frontAudioEnabled))

--- a/test/tests/bulk-audio-creation.spec.ts
+++ b/test/tests/bulk-audio-creation.spec.ts
@@ -470,7 +470,7 @@ test('bulk audio creation updates card readiness to ready', async ({ page }) => 
   });
 });
 
-test('bulk audio creation preserves draft readiness', async ({ page }) => {
+test('bulk audio creation excludes draft cards', async ({ page }) => {
   await setupVoiceConfigurations();
   await createCard({
     cardId: 'draft-card',
@@ -497,16 +497,7 @@ test('bulk audio creation preserves draft readiness', async ({ page }) => {
 
   await page.goto('http://localhost:8180/in-review-cards');
 
-  await page.getByRole('button', { name: 'Generate audio for cards' }).click();
-
-  await expect(page.getByText('Audio generated successfully for 1 card!')).toBeVisible();
-
-  await withDbConnection(async (client) => {
-    const result = await client.query("SELECT readiness FROM learn_language.cards WHERE id = 'draft-card'");
-
-    expect(result.rows.length).toBe(1);
-    expect(result.rows[0].readiness).toBe('DRAFT');
-  });
+  await expect(page.getByRole('button', { name: 'Generate audio for cards' })).not.toBeVisible();
 });
 
 test('bulk audio creation updates ui after completion', async ({ page }) => {

--- a/test/tests/bulk-audio-creation.spec.ts
+++ b/test/tests/bulk-audio-creation.spec.ts
@@ -470,6 +470,45 @@ test('bulk audio creation updates card readiness to ready', async ({ page }) => 
   });
 });
 
+test('bulk audio creation preserves draft readiness', async ({ page }) => {
+  await setupVoiceConfigurations();
+  await createCard({
+    cardId: 'draft-card',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 15,
+    data: {
+      word: 'verstehen',
+      type: 'VERB',
+      translation: { en: 'to understand', hu: 'érteni', ch: 'verstoh' },
+      forms: ['versteht', 'verstand', 'verstanden'],
+      examples: [
+        {
+          de: 'Ich verstehe Deutsch.',
+          hu: 'Értem a németet.',
+          en: 'I understand German.',
+          ch: 'Ich verstoh Tüütsch.',
+          isSelected: true,
+          images: [{ id: 'test-image-id' }],
+        },
+      ],
+    },
+    readiness: 'DRAFT',
+  });
+
+  await page.goto('http://localhost:8180/in-review-cards');
+
+  await page.getByRole('button', { name: 'Generate audio for cards' }).click();
+
+  await expect(page.getByText('Audio generated successfully for 1 card!')).toBeVisible();
+
+  await withDbConnection(async (client) => {
+    const result = await client.query("SELECT readiness FROM learn_language.cards WHERE id = 'draft-card'");
+
+    expect(result.rows.length).toBe(1);
+    expect(result.rows[0].readiness).toBe('DRAFT');
+  });
+});
+
 test('bulk audio creation updates ui after completion', async ({ page }) => {
   await setupVoiceConfigurations();
   await createCard({


### PR DESCRIPTION
## Summary
This change prevents draft cards from being included in bulk audio generation operations. Draft cards are now excluded from the audio generation workflow, and the UI reflects this by hiding the "Generate audio for cards" button when only draft cards are present.

## Key Changes
- **Backend**: Modified `CardService.getCardsMissingAudio()` to exclude `CardReadiness.DRAFT` from the query, now only including `REVIEWED` and `READY` cards
- **Tests**: Added test case `bulk audio creation excludes draft cards` to verify that:
  - Draft cards are not included in bulk audio generation
  - The "Generate audio for cards" button is not visible when viewing draft cards

## Implementation Details
The change filters cards at the service layer by removing `CardReadiness.DRAFT` from the `findByReadinessIn()` query. This ensures that only reviewed and ready cards are eligible for bulk audio generation, preventing incomplete or unapproved cards from being processed.

https://claude.ai/code/session_01C9KvBw5sMCjcHs5sf4Z1i1