### PR TITLE
Hide turn indicator when study card is revealed

### DIFF
--- a/client/src/app/study/learn-card/learn-card.component.html
+++ b/client/src/app/study/learn-card/learn-card.component.html
@@ -62,7 +62,7 @@
     (click)="toggleReveal()"
   >
     <div class="card-bottom-controls">
-      @if (isStudyingWithPartner()) {
+      @if (isStudyingWithPartner() && !isRevealed()) {
       <span class="turn-indicator" role="status" aria-label="Current turn" aria-live="polite">
         {{ currentTurn().name }}
       </span>

--- a/test/tests/learning-partners.spec.ts
+++ b/test/tests/learning-partners.spec.ts
@@ -112,6 +112,31 @@ test('study page shows turn indicator when partner is active', async ({ page }) 
   await expect(page.getByRole('status', { name: 'Current turn' })).toBeVisible();
 });
 
+test('study page hides turn indicator when card is revealed', async ({ page }) => {
+  await createLearningPartner({ name: 'Alice', isActive: true });
+  await createCard({
+    cardId: 'test-card',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 10,
+    data: {
+      word: 'lernen',
+      type: 'VERB',
+      translation: { en: 'to learn', hu: 'tanulni' },
+    },
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
+
+  const turnIndicator = page.getByRole('status', { name: 'Current turn' });
+
+  await expect(turnIndicator).toBeVisible();
+
+  await page.getByRole('heading', { name: 'tanulni' }).click();
+
+  await expect(turnIndicator).not.toBeVisible();
+});
+
 test('study page alternates between user and active partner', async ({ page }) => {
   await createLearningPartner({ name: 'Alice', isActive: true });
 


### PR DESCRIPTION
## Summary
Updated the turn indicator visibility logic in the learn card component to hide the indicator when the card is revealed, in addition to the existing partner study mode check.

## Key Changes
- Modified the conditional rendering of the turn indicator to check both `isStudyingWithPartner()` and `!isRevealed()`
- This ensures the turn indicator only displays when actively studying with a partner AND the card content is not yet revealed

## Implementation Details
The turn indicator now respects the card's revealed state, preventing it from being displayed when the user has already flipped the card to see the answer. This improves the UX by reducing visual clutter once the card content is visible.

https://claude.ai/code/session_01JAxHMUF5yhSNVQS2KETppL