### PR TITLE
Track all review attempts per card for accurate struggle detection

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/StudySessionPdfService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/StudySessionPdfService.java
@@ -73,15 +73,15 @@ public class StudySessionPdfService {
         final List<ReviewLog> allReviews = reviewLogRepository
                 .findByCardIdInAndReviewGreaterThanEqualOrderByIdAsc(cardIds, startOfDay);
 
-        final Map<String, ReviewLog> firstReviewPerCard = allReviews.stream()
-                .collect(Collectors.toMap(
+        final Map<String, List<ReviewLog>> reviewsPerCard = allReviews.stream()
+                .collect(Collectors.groupingBy(
                         rl -> rl.getCard().getId() + ":" + (rl.getLearningPartner() != null ? rl.getLearningPartner().getId() : "self"),
-                        rl -> rl,
-                        (first, second) -> first,
-                        LinkedHashMap::new));
+                        LinkedHashMap::new,
+                        Collectors.toList()));
 
-        final List<ReviewLog> struggledReviews = firstReviewPerCard.values().stream()
-                .filter(rl -> rl.getRating() < 3)
+        final List<ReviewLog> struggledReviews = reviewsPerCard.values().stream()
+                .filter(reviews -> reviews.stream().anyMatch(rl -> rl.getRating() < 3))
+                .map(reviews -> reviews.getFirst())
                 .toList();
 
         if (struggledReviews.isEmpty()) {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/StudySessionService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/StudySessionService.java
@@ -311,14 +311,20 @@ public class StudySessionService {
         final List<ReviewLog> allReviews = reviewLogRepository
                 .findByCardIdInAndReviewGreaterThanEqualOrderByIdAsc(cardIds, startOfDay);
 
-        final Map<String, ReviewLog> firstReviewPerCard = allReviews.stream()
-                .collect(Collectors.toMap(
+        final Map<String, List<ReviewLog>> reviewsPerCard = allReviews.stream()
+                .collect(Collectors.groupingBy(
                         rl -> rl.getCard().getId() + ":" + (rl.getLearningPartner() != null ? rl.getLearningPartner().getId() : "self"),
-                        rl -> rl,
-                        (first, second) -> first,
-                        LinkedHashMap::new));
+                        LinkedHashMap::new,
+                        Collectors.toList()));
 
-        final List<ReviewLog> firstReviews = firstReviewPerCard.values().stream().toList();
+        final Set<String> strugglingKeys = reviewsPerCard.entrySet().stream()
+                .filter(entry -> entry.getValue().stream().anyMatch(rl -> rl.getRating() < 3))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
+
+        final List<ReviewLog> firstReviews = reviewsPerCard.values().stream()
+                .map(reviews -> reviews.getFirst())
+                .toList();
 
         final long totalDurationMs = firstReviews.stream()
                 .mapToLong(rl -> rl.getReviewDuration() != null ? rl.getReviewDuration() : 0)
@@ -327,35 +333,44 @@ public class StudySessionService {
         final int reviewCount = firstReviews.size();
         final long averageDurationMs = reviewCount > 0 ? totalDurationMs / reviewCount : 0;
 
-        final int goodCount = (int) firstReviews.stream()
-                .filter(rl -> rl.getRating() >= 3)
+        final int badCount = (int) reviewsPerCard.keySet().stream()
+                .filter(strugglingKeys::contains)
                 .count();
 
-        final int badCount = (int) firstReviews.stream()
-                .filter(rl -> rl.getRating() < 3)
+        final int goodCount = (int) reviewsPerCard.keySet().stream()
+                .filter(key -> !strugglingKeys.contains(key))
                 .count();
 
         final List<SessionStatsResponse.PersonStats> personStats;
         if ("WITH_PARTNER".equals(session.getStudyMode())) {
             final String userName = getCurrentUserFirstName();
 
-            final Map<String, List<ReviewLog>> byPerson = firstReviews.stream()
+            final Map<String, List<Map.Entry<String, List<ReviewLog>>>> byPerson = reviewsPerCard.entrySet().stream()
                     .collect(Collectors.groupingBy(
-                            rl -> rl.getLearningPartner() != null ? rl.getLearningPartner().getName() : userName));
+                            entry -> {
+                                final ReviewLog first = entry.getValue().getFirst();
+                                return first.getLearningPartner() != null ? first.getLearningPartner().getName() : userName;
+                            }));
 
             personStats = byPerson.entrySet().stream()
                     .map(entry -> {
-                        final List<ReviewLog> reviews = entry.getValue();
-                        final long personTotal = reviews.stream()
-                                .mapToLong(rl -> rl.getReviewDuration() != null ? rl.getReviewDuration() : 0)
+                        final List<Map.Entry<String, List<ReviewLog>>> cardEntries = entry.getValue();
+                        final long personTotal = cardEntries.stream()
+                                .mapToLong(ce -> {
+                                    final ReviewLog first = ce.getValue().getFirst();
+                                    return first.getReviewDuration() != null ? first.getReviewDuration() : 0;
+                                })
                                 .sum();
-                        final int personReviewCount = reviews.size();
+                        final int personReviewCount = cardEntries.size();
+                        final int personBadCount = (int) cardEntries.stream()
+                                .filter(ce -> strugglingKeys.contains(ce.getKey()))
+                                .count();
                         return SessionStatsResponse.PersonStats.builder()
                                 .name(entry.getKey())
                                 .totalDurationMs(personTotal)
                                 .averageDurationMs(personReviewCount > 0 ? personTotal / personReviewCount : 0)
-                                .goodCount((int) reviews.stream().filter(rl -> rl.getRating() >= 3).count())
-                                .badCount((int) reviews.stream().filter(rl -> rl.getRating() < 3).count())
+                                .goodCount(personReviewCount - personBadCount)
+                                .badCount(personBadCount)
                                 .build();
                     })
                     .toList();


### PR DESCRIPTION
## Summary
Refactored review log aggregation logic to track all review attempts per card instead of just the first one. This enables more accurate detection of struggling cards by checking if any attempt had a low rating, rather than only checking the first attempt.

## Key Changes
- Changed `firstReviewPerCard` map from storing single `ReviewLog` to storing `List<ReviewLog>` per card in both `StudySessionService` and `StudySessionPdfService`
- Introduced `strugglingKeys` set to identify cards where any review attempt had a rating < 3
- Updated good/bad count calculations to use the struggling keys set instead of filtering individual review logs
- Modified person stats calculation to properly handle multiple review attempts per card while maintaining accurate duration and count metrics
- Simplified good/bad count logic by using set membership checks instead of stream filtering

## Implementation Details
- The card key format remains unchanged: `cardId:partnerId` (or `cardId:self` for solo reviews)
- First review from each card is still used for duration calculations and person attribution
- Struggle detection now considers the entire review history for a card, not just the initial attempt
- Person stats correctly aggregate metrics across all their card reviews while using the new struggle detection logic

https://claude.ai/code/session_01UtoHtjtBP8mJzxxWEuynvd