### PR TITLE
Add English translation fields to vocabulary, grammar, and speech cards

### DIFF
--- a/client/src/app/parser/edit-card/edit-grammar-card/edit-grammar-card.component.html
+++ b/client/src/app/parser/edit-card/edit-grammar-card/edit-grammar-card.component.html
@@ -9,6 +9,15 @@
       rows="3"
     ></textarea>
   </mat-form-field>
+  <mat-form-field class="field">
+    <mat-label>English Translation</mat-label>
+    <textarea
+      matInput
+      [formField]="grammarForm.englishTranslation"
+      aria-label="English translation"
+      rows="3"
+    ></textarea>
+  </mat-form-field>
   <div class="gap-controls">
     <button
       mat-stroked-button

--- a/client/src/app/parser/edit-card/edit-speech-card/edit-speech-card.component.html
+++ b/client/src/app/parser/edit-card/edit-speech-card/edit-speech-card.component.html
@@ -17,6 +17,15 @@
       rows="3"
     ></textarea>
   </mat-form-field>
+  <mat-form-field class="field">
+    <mat-label>English Translation</mat-label>
+    <textarea
+      matInput
+      [formField]="speechForm.englishTranslation"
+      aria-label="English translation"
+      rows="3"
+    ></textarea>
+  </mat-form-field>
 </div>
 
 <div class="images-section">

--- a/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.html
+++ b/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.html
@@ -54,6 +54,15 @@
       aria-label="Swiss German translation"
     />
   </mat-form-field>
+  <mat-form-field class="field">
+    <mat-label>English</mat-label>
+    <input
+      matInput
+      type="text"
+      [(ngModel)]="translation['en']"
+      aria-label="English translation"
+    />
+  </mat-form-field>
 </div>
 <h2>Forms</h2>
 <div class="forms">
@@ -107,6 +116,15 @@
           type="text"
           [(ngModel)]="examplesTranslations['ch'][$index]"
           aria-label="Example in Swiss German"
+        />
+      </mat-form-field>
+      <mat-form-field class="field">
+        <mat-label>English</mat-label>
+        <input
+          matInput
+          type="text"
+          [(ngModel)]="examplesTranslations['en'][$index]"
+          aria-label="Example in English"
         />
       </mat-form-field>
       }

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -97,11 +97,12 @@ test('card editing page', async ({ page }) => {
   await navigateToCardEditing(page);
 
   // Word section
-  await expect(page.getByRole('combobox', { name: 'Word type' })).toHaveText('Főnév');
-  await expect(page.getByRole('combobox', { name: 'Gender' })).toHaveText('Feminine');
   await expect(page.getByLabel('German translation', { exact: true })).toHaveValue('abfahren');
   await expect(page.getByLabel('Hungarian translation', { exact: true })).toHaveValue('elindulni, elhagyni');
   await expect(page.getByLabel('Swiss German translation', { exact: true })).toHaveValue('abfahra, verlah');
+  await expect(page.getByLabel('English translation', { exact: true })).toHaveValue('to leave');
+  await expect(page.getByRole('combobox', { name: 'Word type' })).toHaveText('Főnév');
+  await expect(page.getByRole('combobox', { name: 'Gender' })).toHaveText('Feminine');
 
   // Forms section
   await expect(page.getByLabel('Form', { exact: true }).nth(0)).toHaveValue('fährt ab');
@@ -115,6 +116,9 @@ test('card editing page', async ({ page }) => {
   );
   await expect(page.getByLabel('Example in Swiss German', { exact: true }).nth(0)).toHaveValue(
     'Mir fahred am zwöufi ab.'
+  );
+  await expect(page.getByLabel('Example in English', { exact: true }).nth(0)).toHaveValue(
+    "We leave at twelve o'clock."
   );
 
   // Images
@@ -163,6 +167,7 @@ test('card editing in db', async ({ page }) => {
   });
   await navigateToCardEditing(page);
   await page.getByLabel('Hungarian translation').fill('elindulni, elutazni');
+  await page.getByLabel('English translation', { exact: true }).fill('to depart');
 
   await expect(page.getByRole('img')).toHaveCount(2);
 
@@ -200,6 +205,7 @@ test('card editing in db', async ({ page }) => {
     const cardData = result.rows[0].data;
 
     expect(cardData.translation.hu).toBe('elindulni, elutazni');
+    expect(cardData.translation.en).toBe('to depart');
     expect(cardData.examples[0].isSelected).toBeUndefined();
     expect(cardData.examples[1].isSelected).toBe(true);
     expect(cardData.word).toBe('abfahren');
@@ -619,6 +625,7 @@ test('speech card editing page displays sentence and translations', async ({ pag
 
   await expect(page.getByLabel('German Sentence')).toHaveValue('Guten Morgen, wie geht es Ihnen?');
   await expect(page.getByLabel('Hungarian translation', { exact: true })).toHaveValue('Jó reggelt, hogy van?');
+  await expect(page.getByLabel('English translation', { exact: true })).toHaveValue('Good morning, how are you?');
   const imageContent = await getImageContent(page.getByRole('img', { name: 'Guten Morgen, wie geht es Ihnen?' }));
   expect(await getImageColor(page, imageContent)).toBe('yellow');
 });
@@ -646,6 +653,7 @@ test('speech card editing updates sentence in database', async ({ page }) => {
   await page.goto('http://localhost:8180/sources/speech-a1/page/11/cards/e5f6g7h8');
 
   await page.getByLabel('Hungarian translation', { exact: true }).fill('Busszal utazom.');
+  await page.getByLabel('English translation', { exact: true }).fill('I ride the bus.');
   await page.getByRole('button', { name: 'Update' }).click();
   await expect(page.getByText('Card updated successfully')).toBeVisible();
 
@@ -655,6 +663,7 @@ test('speech card editing updates sentence in database', async ({ page }) => {
     const cardData = result.rows[0].data;
     expect(cardData.examples[0].de).toBe('Ich fahre mit dem Bus.');
     expect(cardData.examples[0].hu).toBe('Busszal utazom.');
+    expect(cardData.examples[0].en).toBe('I ride the bus.');
   });
 });
 
@@ -707,6 +716,7 @@ test('grammar card editing shows complete sentence and gaps', async ({ page }) =
   await page.goto('http://localhost:8180/in-review-cards');
 
   await expect(page.getByLabel('German sentence', { exact: true })).toHaveValue('Der Hund [läuft] schnell.');
+  await expect(page.getByLabel('English translation', { exact: true })).toHaveValue('The dog runs fast.');
   await expect(page.locator('.sentence-preview')).toContainText('Der Hund _____ schnell.');
 });
 
@@ -801,6 +811,7 @@ test('grammar card editing saves gaps to database', async ({ page }) => {
   });
 
   await page.getByRole('button', { name: 'Add Gap from Selection' }).click();
+  await page.getByLabel('English translation', { exact: true }).fill('The child is playing in the garden.');
   await page.getByRole('button', { name: 'Save card' }).click();
 
   await withDbConnection(async (client) => {
@@ -808,6 +819,7 @@ test('grammar card editing saves gaps to database', async ({ page }) => {
     expect(result.rows.length).toBe(1);
     const cardData = result.rows[0].data;
     expect(cardData.examples[0].de).toBe('Das Kind [spielt] im Garten.');
+    expect(cardData.examples[0].en).toBe('The child is playing in the garden.');
   });
 });
 


### PR DESCRIPTION
## Summary
This PR adds English translation input fields across multiple card editing components to support English language translations alongside existing language options.

## Key Changes
- **Vocabulary Card**: Added English translation field in the translations section and English example field in the examples section
- **Grammar Card**: Added English translation textarea field to the grammar form
- **Speech Card**: Added English translation textarea field to the speech form

## Implementation Details
- All new fields follow the existing component patterns and styling conventions
- English translation fields are bound to form controls using `[(ngModel)]` for vocabulary examples and `[formField]` for grammar and speech cards
- Each field includes appropriate Material Design form field wrappers, labels, and ARIA labels for accessibility
- The implementation maintains consistency with existing Swiss German and other language translation fields

https://claude.ai/code/session_01TfNmo9vgqm81nhXEajTRaB