### PR TITLE
Replace review grade filter with correct streak tracking

### DIFF
--- a/client/src/app/cards-table/cards-table.component.html
+++ b/client/src/app/cards-table/cards-table.component.html
@@ -67,20 +67,6 @@
     </mat-form-field>
 
     <mat-form-field appearance="outline" class="filter-field">
-      <mat-label>Last review grade</mat-label>
-      <mat-select
-        [value]="lastReviewRatingFilter()"
-        (selectionChange)="onRatingFilterChange($event.value)"
-        aria-label="Filter by last review grade"
-      >
-        <mat-option value="">All</mat-option>
-        @for (option of ratingOptions; track option.value) {
-          <mat-option [value]="option.value">{{ option.label }}</mat-option>
-        }
-      </mat-select>
-    </mat-form-field>
-
-    <mat-form-field appearance="outline" class="filter-field">
       <mat-label>Last review</mat-label>
       <mat-select
         [value]="lastReviewDaysAgoFilter()"

--- a/client/src/app/cards-table/cards-table.component.ts
+++ b/client/src/app/cards-table/cards-table.component.ts
@@ -44,20 +44,6 @@ import { injectQueryParams } from '../utils/inject-query-params';
 
 type QuickFilter = 'unhealthy' | 'flagged' | 'draft';
 
-const RATING_LABELS: Record<number, string> = {
-  1: '1 - Again',
-  2: '2 - Hard',
-  3: '3 - Good',
-  4: '4 - Easy',
-};
-
-const RATING_COLORS: Record<number, string> = {
-  1: '#dc3545',
-  2: '#fd7e14',
-  3: '#28a745',
-  4: '#0d6efd',
-};
-
 const STATE_COLORS: Record<string, string> = {
   NEW: '#2196F3',
   LEARNING: '#4CAF50',
@@ -190,7 +176,6 @@ export class CardsTableComponent {
 
   readonly cardFilter = signal<string>('');
   readonly stateFilter = signal<string>('');
-  readonly lastReviewRatingFilter = signal<string>('');
   readonly lastReviewDaysAgoFilter = signal<string>('');
   readonly reviewScoreFilter = signal<string>('');
 
@@ -220,9 +205,6 @@ export class CardsTableComponent {
         state: this.stateFilter() || undefined,
         lastReviewDaysAgo: this.lastReviewDaysAgoFilter()
           ? Number(this.lastReviewDaysAgoFilter())
-          : undefined,
-        lastReviewRating: this.lastReviewRatingFilter()
-          ? Number(this.lastReviewRatingFilter())
           : undefined,
         minReviewScore: reviewScoreRange?.min,
         maxReviewScore: reviewScoreRange?.max,
@@ -257,12 +239,6 @@ export class CardsTableComponent {
 
   readonly readinessOptions = CARD_READINESS_VALUES;
   readonly stateOptions = ['NEW', 'LEARNING', 'REVIEW', 'RELEARNING'];
-  readonly ratingOptions = [
-    { value: '1', label: '1 - Again' },
-    { value: '2', label: '2 - Hard' },
-    { value: '3', label: '3 - Good' },
-    { value: '4', label: '4 - Easy' },
-  ];
   readonly lastReviewDaysAgoOptions = [
     { value: '0', label: 'Today' },
     { value: '3', label: 'Last 3 days' },
@@ -326,6 +302,12 @@ export class CardsTableComponent {
       sortable: true,
     },
     {
+      headerName: 'Streak',
+      field: 'correctStreak',
+      width: 100,
+      sortable: true,
+    },
+    {
       headerName: 'Last review',
       field: 'lastReviewDaysAgo',
       width: 150,
@@ -334,30 +316,12 @@ export class CardsTableComponent {
         params.value != null ? formatDaysAgo(params.value) : '',
     },
     {
-      headerName: 'Grade',
-      field: 'lastReviewRating',
-      width: 110,
-      sortable: false,
-      cellRenderer: (params: { value: number | null }) => {
-        if (params.value == null) return '';
-        const label = RATING_LABELS[params.value] ?? String(params.value);
-        return badgeHtml(label, RATING_COLORS[params.value] ?? '#666');
-      },
-    },
-    {
       headerName: 'Score',
       field: 'reviewScore',
       width: 100,
       sortable: true,
       valueFormatter: (params) =>
         params.value != null ? `${params.value}%` : '',
-    },
-    {
-      headerName: 'Person',
-      field: 'lastReviewPerson',
-      width: 120,
-      sortable: false,
-      valueFormatter: (params) => params.value ?? 'Me',
     },
   ];
 
@@ -426,11 +390,6 @@ export class CardsTableComponent {
 
   onStateFilterChange(value: string): void {
     this.stateFilter.set(value);
-    this.refreshGrid();
-  }
-
-  onRatingFilterChange(value: string): void {
-    this.lastReviewRatingFilter.set(value);
     this.refreshGrid();
   }
 
@@ -586,9 +545,6 @@ export class CardsTableComponent {
         state: this.stateFilter() || undefined,
         lastReviewDaysAgo: this.lastReviewDaysAgoFilter()
           ? Number(this.lastReviewDaysAgoFilter())
-          : undefined,
-        lastReviewRating: this.lastReviewRatingFilter()
-          ? Number(this.lastReviewRatingFilter())
           : undefined,
         minReviewScore: reviewScoreRange?.min,
         maxReviewScore: reviewScoreRange?.max,

--- a/client/src/app/cards-table/cards-table.service.ts
+++ b/client/src/app/cards-table/cards-table.service.ts
@@ -8,9 +8,8 @@ export type CardTableRow = {
   readiness: CardReadiness;
   state: string;
   reps: number;
+  correctStreak: number | null;
   lastReviewDaysAgo: number | null;
-  lastReviewRating: number | null;
-  lastReviewPerson: string | null;
   reviewScore: number | null;
   sourcePageNumber: number;
 };
@@ -31,7 +30,6 @@ export type CardTableParams = {
   minReps?: number;
   maxReps?: number;
   lastReviewDaysAgo?: number;
-  lastReviewRating?: number;
   minReviewScore?: number;
   maxReviewScore?: number;
   cardFilter?: string;
@@ -55,9 +53,6 @@ export class CardsTableService {
       ...(params.maxReps !== undefined ? { maxReps: params.maxReps } : {}),
       ...(params.lastReviewDaysAgo !== undefined
         ? { lastReviewDaysAgo: params.lastReviewDaysAgo }
-        : {}),
-      ...(params.lastReviewRating !== undefined
-        ? { lastReviewRating: params.lastReviewRating }
         : {}),
       ...(params.minReviewScore !== undefined
         ? { minReviewScore: params.minReviewScore }
@@ -86,7 +81,6 @@ export class CardsTableService {
     readiness?: string;
     state?: string;
     lastReviewDaysAgo?: number;
-    lastReviewRating?: number;
     minReviewScore?: number;
     maxReviewScore?: number;
     cardFilter?: string;
@@ -98,9 +92,6 @@ export class CardsTableService {
       ...(params.state ? { state: params.state } : {}),
       ...(params.lastReviewDaysAgo !== undefined
         ? { lastReviewDaysAgo: params.lastReviewDaysAgo }
-        : {}),
-      ...(params.lastReviewRating !== undefined
-        ? { lastReviewRating: params.lastReviewRating }
         : {}),
       ...(params.minReviewScore !== undefined
         ? { minReviewScore: params.minReviewScore }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/CardController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/CardController.java
@@ -63,7 +63,6 @@ public class CardController {
       @RequestParam(required = false) Integer minReps,
       @RequestParam(required = false) Integer maxReps,
       @RequestParam(required = false) Integer lastReviewDaysAgo,
-      @RequestParam(required = false) Integer lastReviewRating,
       @RequestParam(required = false) Integer minReviewScore,
       @RequestParam(required = false) Integer maxReviewScore,
       @RequestParam(required = false) String cardFilter,
@@ -72,7 +71,7 @@ public class CardController {
 
     final CardTableResponse response = cardService.getCardTable(
         sourceId, startRow, endRow, sortField, sortDirection,
-        readiness, state, minReps, maxReps, lastReviewDaysAgo, lastReviewRating,
+        readiness, state, minReps, maxReps, lastReviewDaysAgo,
         minReviewScore, maxReviewScore, cardFilter, flagged, unhealthy,
         startOfDayUtc(parseTimezone(timezone)));
 
@@ -89,7 +88,6 @@ public class CardController {
       @RequestParam(required = false) Integer minReps,
       @RequestParam(required = false) Integer maxReps,
       @RequestParam(required = false) Integer lastReviewDaysAgo,
-      @RequestParam(required = false) Integer lastReviewRating,
       @RequestParam(required = false) Integer minReviewScore,
       @RequestParam(required = false) Integer maxReviewScore,
       @RequestParam(required = false) String cardFilter,
@@ -98,7 +96,7 @@ public class CardController {
 
     final List<String> ids = cardService.getFilteredCardIds(
         sourceId, readiness, state, minReps, maxReps,
-        lastReviewDaysAgo, lastReviewRating,
+        lastReviewDaysAgo,
         minReviewScore, maxReviewScore, cardFilter, flagged, unhealthy,
         startOfDayUtc(parseTimezone(timezone)));
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/entity/CardView.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/entity/CardView.java
@@ -63,14 +63,11 @@ public class CardView {
     @Column(name = "card_type")
     private CardType cardType;
 
-    @Column(name = "last_review_rating")
-    private Integer lastReviewRating;
-
-    @Column(name = "last_review_learning_partner_name")
-    private String lastReviewLearningPartnerName;
-
     @Column(name = "review_score")
     private Integer reviewScore;
+
+    @Column(name = "correct_streak")
+    private Integer correctStreak;
 
     @Column(name = "is_unhealthy", nullable = false)
     private Boolean isUnhealthy;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardTableRow.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardTableRow.java
@@ -15,8 +15,7 @@ public class CardTableRow {
     private String state;
     private Integer reps;
     private Integer lastReviewDaysAgo;
-    private Integer lastReviewRating;
-    private String lastReviewPerson;
+    private Integer correctStreak;
     private Integer reviewScore;
     private Integer sourcePageNumber;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/specification/CardViewSpecifications.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/specification/CardViewSpecifications.java
@@ -41,10 +41,6 @@ public class CardViewSpecifications {
         };
     }
 
-    public static PredicateSpecification<CardView> hasLastReviewRating(int rating) {
-        return (root, cb) -> cb.equal(root.get(CardView_.lastReviewRating), rating);
-    }
-
     public static PredicateSpecification<CardView> hasMinReviewScore(int minScore) {
         return (root, cb) -> cb.greaterThanOrEqualTo(root.get(CardView_.reviewScore), minScore);
     }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -193,14 +193,14 @@ public class CardService {
       String sourceId,
       String readiness, String state,
       Integer minReps, Integer maxReps,
-      Integer lastReviewDaysAgo, Integer lastReviewRating,
+      Integer lastReviewDaysAgo,
       Integer minReviewScore, Integer maxReviewScore,
       String cardFilter, Boolean flagged, Boolean unhealthy,
       LocalDateTime startOfDayUtc) {
 
     final PredicateSpecification<CardView> spec = buildCardTableSpec(
         sourceId, readiness, state, minReps, maxReps,
-        lastReviewDaysAgo, lastReviewRating,
+        lastReviewDaysAgo,
         minReviewScore, maxReviewScore, cardFilter, flagged, unhealthy, startOfDayUtc);
 
     return cardViewRepository.findAll(spec).stream()
@@ -213,14 +213,14 @@ public class CardService {
       String sortField, String sortDirection,
       String readiness, String state,
       Integer minReps, Integer maxReps,
-      Integer lastReviewDaysAgo, Integer lastReviewRating,
+      Integer lastReviewDaysAgo,
       Integer minReviewScore, Integer maxReviewScore,
       String cardFilter, Boolean flagged, Boolean unhealthy,
       LocalDateTime startOfDayUtc) {
 
     final PredicateSpecification<CardView> spec = buildCardTableSpec(
         sourceId, readiness, state, minReps, maxReps,
-        lastReviewDaysAgo, lastReviewRating,
+        lastReviewDaysAgo,
         minReviewScore, maxReviewScore, cardFilter, flagged, unhealthy, startOfDayUtc);
 
     final int pageSize = Math.max(1, endRow - startRow);
@@ -273,7 +273,7 @@ public class CardService {
   private PredicateSpecification<CardView> buildCardTableSpec(
       String sourceId, String readiness, String state,
       Integer minReps, Integer maxReps,
-      Integer lastReviewDaysAgo, Integer lastReviewRating,
+      Integer lastReviewDaysAgo,
       Integer minReviewScore, Integer maxReviewScore,
       String cardFilter, Boolean flagged, Boolean unhealthy,
       LocalDateTime startOfDayUtc) {
@@ -297,9 +297,6 @@ public class CardService {
     }
     if (lastReviewDaysAgo != null) {
       spec = spec.and(hasLastReviewAfter(lastReviewDaysAgo, startOfDayUtc));
-    }
-    if (lastReviewRating != null) {
-      spec = spec.and(hasLastReviewRating(lastReviewRating));
     }
     if (minReviewScore != null) {
       spec = spec.and(hasMinReviewScore(minReviewScore));
@@ -331,6 +328,7 @@ public class CardService {
 
     final String mappedField = switch (sortField) {
       case "reps" -> "reps";
+      case "correctStreak" -> "correctStreak";
       case "lastReviewDaysAgo" -> "lastReview";
       case "state" -> "state";
       case "readiness" -> "readiness";
@@ -352,8 +350,7 @@ public class CardService {
         .state(view.getState())
         .reps(view.getReps())
         .lastReviewDaysAgo(reviewDaysAgo)
-        .lastReviewRating(view.getLastReviewRating())
-        .lastReviewPerson(view.getLastReviewLearningPartnerName())
+        .correctStreak(view.getCorrectStreak())
         .reviewScore(view.getReviewScore())
         .sourcePageNumber(view.getSourcePageNumber())
         .build();

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -231,9 +231,8 @@ SELECT
     c.last_review,
     c.flagged,
     s.card_type,
-    lr.rating AS last_review_rating,
-    lp.name AS last_review_learning_partner_name,
     rs.review_score,
+    cs.correct_streak,
     CASE WHEN c.readiness IN ('READY', 'REVIEWED', 'KNOWN') AND (
         (c.data->'translation'->>'en' IS NULL OR TRIM(c.data->'translation'->>'en') = '') OR
         (c.data->'translation'->>'hu' IS NULL OR TRIM(c.data->'translation'->>'hu') = '') OR
@@ -244,13 +243,14 @@ SELECT
 FROM learn_language.cards c
 JOIN learn_language.sources s ON c.source_id = s.id
 LEFT JOIN LATERAL (
-    SELECT rating, learning_partner_id
-    FROM learn_language.review_logs
-    WHERE card_id = c.id
-    ORDER BY review DESC
-    LIMIT 1
-) lr ON true
-LEFT JOIN learn_language.learning_partners lp ON lr.learning_partner_id = lp.id
+    SELECT COALESCE(MIN(rn) FILTER (WHERE rating < 3) - 1,
+                    MAX(rn))::integer AS correct_streak
+    FROM (
+        SELECT rating, ROW_NUMBER() OVER (ORDER BY review DESC) AS rn
+        FROM learn_language.review_logs
+        WHERE card_id = c.id
+    ) ranked
+) cs ON true
 LEFT JOIN LATERAL (
     SELECT
         CASE

--- a/test/tests/cards-table-page.spec.ts
+++ b/test/tests/cards-table-page.spec.ts
@@ -5,7 +5,6 @@ import {
   createCard,
   createRateLimitSetting,
   createReviewLog,
-  createLearningPartner,
   getGridData,
   withDbConnection,
   STORAGE_DIR,
@@ -159,8 +158,6 @@ test('marks selected cards as known', async ({ page }) => {
 });
 
 test('displays review information in table', async ({ page }) => {
-  const partnerId = await createLearningPartner({ name: 'Anna', isActive: true });
-
   await createCard({
     cardId: 'reviewed-card',
     sourceId: 'goethe-a1',
@@ -174,7 +171,6 @@ test('displays review information in table', async ({ page }) => {
   await createReviewLog({
     cardId: 'reviewed-card',
     rating: 3,
-    learningPartnerId: partnerId,
     review: new Date(),
   });
 
@@ -186,8 +182,7 @@ test('displays review information in table', async ({ page }) => {
       expect.objectContaining({
         ID: 'reviewed-card',
         Reviews: '3',
-        Grade: '3 - Good',
-        Person: 'Anna',
+        Streak: '1',
       }),
     ]);
   }).toPass();
@@ -215,56 +210,6 @@ test('navigates to card editing on row click', async ({ page }) => {
   await page.getByRole('row', { name: /click-card/ }).click();
 
   await expect(page).toHaveTitle('Edit Card');
-});
-
-test('filters cards by last review grade', async ({ page }) => {
-  await createCard({
-    cardId: 'easy-card',
-    sourceId: 'goethe-a1',
-    sourcePageNumber: 9,
-    data: { word: 'einfach', type: 'ADJECTIVE', translation: { en: 'easy' } },
-    state: 'REVIEW',
-    reps: 5,
-    lastReview: new Date(),
-  });
-
-  await createReviewLog({
-    cardId: 'easy-card',
-    rating: 4,
-    review: new Date(),
-  });
-
-  await createCard({
-    cardId: 'hard-card',
-    sourceId: 'goethe-a1',
-    sourcePageNumber: 10,
-    data: { word: 'schwer', type: 'ADJECTIVE', translation: { en: 'hard' } },
-    state: 'REVIEW',
-    reps: 2,
-    lastReview: new Date(),
-  });
-
-  await createReviewLog({
-    cardId: 'hard-card',
-    rating: 2,
-    review: new Date(),
-  });
-
-  await page.goto('http://localhost:8180/sources/goethe-a1/cards');
-
-  const grid = page.getByRole('grid');
-  await expect(async () => {
-    const before = await getGridData(grid);
-    expect(before.map((r) => r.ID)).toEqual(expect.arrayContaining(['easy-card', 'hard-card']));
-  }).toPass();
-
-  await page.getByLabel('Filter by last review grade').click();
-  await page.getByRole('option', { name: '4 - Easy' }).click();
-
-  await expect(async () => {
-    const after = await getGridData(grid);
-    expect(after.map((r) => r.ID)).toEqual(['easy-card']);
-  }).toPass();
 });
 
 test('filters cards by last review time', async ({ page }) => {

--- a/test/tests/cards-table-page.spec.ts
+++ b/test/tests/cards-table-page.spec.ts
@@ -188,6 +188,90 @@ test('displays review information in table', async ({ page }) => {
   }).toPass();
 });
 
+test('displays streak of 0 when last review is incorrect', async ({ page }) => {
+  await createCard({
+    cardId: 'incorrect-streak-card',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: { word: 'schwer', type: 'ADJECTIVE', translation: { en: 'hard' } },
+    state: 'REVIEW',
+    reps: 2,
+    lastReview: new Date(),
+  });
+
+  await createReviewLog({
+    cardId: 'incorrect-streak-card',
+    rating: 3,
+    review: new Date(Date.now() - 60000),
+  });
+
+  await createReviewLog({
+    cardId: 'incorrect-streak-card',
+    rating: 1,
+    review: new Date(),
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/cards');
+
+  await expect(async () => {
+    const rows = await getGridData(page.getByRole('grid'));
+    expect(rows).toEqual([
+      expect.objectContaining({
+        ID: 'incorrect-streak-card',
+        Streak: '0',
+      }),
+    ]);
+  }).toPass();
+});
+
+test('displays correct streak count for multiple consecutive correct reviews', async ({ page }) => {
+  await createCard({
+    cardId: 'multi-streak-card',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: { word: 'gut', type: 'ADJECTIVE', translation: { en: 'good' } },
+    state: 'REVIEW',
+    reps: 4,
+    lastReview: new Date(),
+  });
+
+  await createReviewLog({
+    cardId: 'multi-streak-card',
+    rating: 1,
+    review: new Date(Date.now() - 240000),
+  });
+
+  await createReviewLog({
+    cardId: 'multi-streak-card',
+    rating: 3,
+    review: new Date(Date.now() - 180000),
+  });
+
+  await createReviewLog({
+    cardId: 'multi-streak-card',
+    rating: 4,
+    review: new Date(Date.now() - 120000),
+  });
+
+  await createReviewLog({
+    cardId: 'multi-streak-card',
+    rating: 3,
+    review: new Date(Date.now() - 60000),
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/cards');
+
+  await expect(async () => {
+    const rows = await getGridData(page.getByRole('grid'));
+    expect(rows).toEqual([
+      expect.objectContaining({
+        ID: 'multi-streak-card',
+        Streak: '3',
+      }),
+    ]);
+  }).toPass();
+});
+
 test('navigates to card editing on row click', async ({ page }) => {
   await createCard({
     cardId: 'click-card',


### PR DESCRIPTION
## Summary
This PR removes the review grade filtering feature and replaces it with a correct streak counter that tracks consecutive correct reviews. The learning partner association with reviews has also been removed.

## Key Changes

- **Removed review grade filter**: Eliminated the "Filter by last review grade" dropdown and all associated filtering logic from the UI and backend
- **Replaced Grade column with Streak column**: The "Grade" column displaying last review ratings is replaced with a "Streak" column showing `correctStreak` values
- **Removed Person column**: Eliminated the "Person" column that displayed the learning partner name associated with each review
- **Updated database schema**: Modified the card view query to calculate `correct_streak` using a window function that counts consecutive correct reviews (rating >= 3) from the most recent review backwards
- **Simplified CardView entity**: Removed `lastReviewRating` and `lastReviewLearningPartnerName` fields, added `correctStreak` field
- **Updated service layer**: Removed `lastReviewRating` parameter from card filtering methods and specifications
- **Updated tests**: Modified test expectations to verify the new Streak column instead of Grade and Person columns; removed the dedicated test for grade filtering

## Implementation Details

The correct streak calculation uses a SQL window function that:
1. Ranks reviews by date (most recent first)
2. Finds the first review with rating < 3 (incorrect)
3. Returns the count of reviews before that point, or all reviews if none are incorrect

This provides a more meaningful metric for tracking learning progress compared to the single last review grade.

https://claude.ai/code/session_01LETRxeo3vXf5t2ZTpVruWm