### PR TITLE
Remove back button from edit card page

### DIFF
--- a/client/src/app/parser/edit-card/edit-card.component.css
+++ b/client/src/app/parser/edit-card/edit-card.component.css
@@ -3,10 +3,6 @@
   gap: 1rem;
 }
 
-.top-actions {
-  margin-bottom: 1rem;
-}
-
 .title {
   display: flex;
   align-items: center;

--- a/client/src/app/parser/edit-card/edit-card.component.html
+++ b/client/src/app/parser/edit-card/edit-card.component.html
@@ -1,11 +1,6 @@
 @if (isLoading()) {
   <mat-spinner class="page-loading" />
 } @else {
-  <div class="top-actions">
-    <a mat-icon-button [routerLink]="backNavigationUrl()" aria-label="Go back">
-      <mat-icon>arrow_back</mat-icon>
-    </a>
-  </div>
   <h2 class="title">
     {{ getCardTypeTitle() }}
     <span class="title-spacer"></span>

--- a/client/src/app/parser/edit-card/edit-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-card.component.ts
@@ -5,7 +5,6 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatIcon } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { Router, RouterModule } from '@angular/router';
 import { HttpClient } from '@angular/common/http';
 import { resource } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
@@ -28,7 +27,6 @@ import { CardTypeRegistry } from '../../cardTypes/card-type.registry';
     MatCardModule,
     MatProgressSpinnerModule,
     MatIcon,
-    RouterModule,
     EditVocabularyCardComponent,
     EditSpeechCardComponent,
     EditGrammarCardComponent,
@@ -38,7 +36,6 @@ import { CardTypeRegistry } from '../../cardTypes/card-type.registry';
 })
 export class EditCardComponent {
   private readonly http = inject(HttpClient);
-  private readonly router = inject(Router);
   private readonly cardTypeRegistry = inject(CardTypeRegistry);
   private readonly routeSourceId = injectParams('sourceId');
   private readonly routePageNumber = injectParams('pageNumber');
@@ -66,19 +63,6 @@ export class EditCardComponent {
   });
 
   readonly isLoading = computed(() => this.card.isLoading());
-
-  readonly backNavigationUrl = computed(() => {
-    const card = this.card.value();
-    const readiness = card?.readiness;
-    const sourceId = this.selectedSourceId();
-    const pageNumber = this.selectedPageNumber();
-
-    if (readiness === 'IN_REVIEW' || readiness === 'REVIEWED') {
-      return ['/in-review-cards'];
-    }
-
-    return ['/sources', sourceId, 'page', pageNumber];
-  });
 
   readonly isInReview = computed(() => {
     const card = this.card.value();
@@ -203,7 +187,7 @@ export class EditCardComponent {
     if (result) {
       await this.deleteCard();
       this.showSnackBar('Card deleted successfully');
-      await this.router.navigate(this.backNavigationUrl());
+      window.history.back();
     }
   }
 

--- a/client/src/app/parser/edit-card/edit-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-card.component.ts
@@ -5,6 +5,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatIcon } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { Location } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { resource } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
@@ -35,6 +36,7 @@ import { CardTypeRegistry } from '../../cardTypes/card-type.registry';
   styleUrl: './edit-card.component.css',
 })
 export class EditCardComponent {
+  private readonly location = inject(Location);
   private readonly http = inject(HttpClient);
   private readonly cardTypeRegistry = inject(CardTypeRegistry);
   private readonly routeSourceId = injectParams('sourceId');
@@ -187,7 +189,7 @@ export class EditCardComponent {
     if (result) {
       await this.deleteCard();
       this.showSnackBar('Card deleted successfully');
-      window.history.back();
+      this.location.back();
     }
   }
 

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -49,14 +49,6 @@ async function prepareCard(page: Page) {
   return await navigateToCardEditing(page);
 }
 
-test('back button navigates to source page', async ({ page }) => {
-  await prepareCard(page);
-  await page.getByRole('link', { name: 'Back' }).click();
-  await expect(page.getByText('Seite 9')).toBeVisible();
-  await expect(page.getByText('die Abfahrt')).toBeVisible();
-  await expect(page.getByRole('spinbutton', { name: 'Page' })).toHaveValue('9');
-});
-
 test('card editing page', async ({ page }) => {
   await setupDefaultChatModelSettings();
   const image1 = uploadMockImage(yellowImage);
@@ -667,31 +659,6 @@ test('speech card editing updates sentence in database', async ({ page }) => {
   });
 });
 
-test('speech card back navigation works', async ({ page }) => {
-  await setupDefaultChatModelSettings();
-  const image1 = uploadMockImage(yellowImage);
-  await createCard({
-    cardId: 'i9j0k1l2',
-    sourceId: 'speech-a1',
-    sourcePageNumber: 12,
-    data: {
-      examples: [
-        {
-          de: 'Das Wetter ist schön.',
-          hu: 'Szép az idő.',
-          en: 'The weather is nice.',
-          isSelected: true,
-          images: [{ id: image1, isFavorite: true }],
-        },
-      ],
-    },
-  });
-
-  await page.goto('http://localhost:8180/sources/speech-a1/page/12/cards/i9j0k1l2');
-
-  await page.getByRole('link', { name: 'Back' }).click();
-  await expect(page.getByRole('spinbutton', { name: 'Page' })).toHaveValue('12');
-});
 
 test('grammar card editing shows complete sentence and gaps', async ({ page }) => {
   await setupDefaultChatModelSettings();

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -499,9 +499,8 @@ test('card deletion', async ({ page }) => {
   await page.getByRole('button', { name: 'Yes' }).click();
   await expect(page.getByText('Card deleted successfully')).toBeVisible();
 
-  // Verify navigation back to the source page
-  await page.waitForURL(/\/sources\/goethe-a1\/page\/9/);
-  expect(page.url()).toContain('/sources/goethe-a1/page/9');
+  await expect(page.getByText('Seite 9')).toBeVisible();
+  await expect(page.getByRole('spinbutton', { name: 'Page' })).toHaveValue('9');
 
   await withDbConnection(async (client) => {
     const result = await client.query("SELECT id FROM learn_language.cards WHERE id = 'abfahren-elindulni'");


### PR DESCRIPTION
## Summary
Removed the back button navigation functionality from the edit card page and replaced it with browser history navigation on card deletion.

## Key Changes
- Removed the back button UI element from the edit card template
- Deleted the `backNavigationUrl` computed property that determined navigation based on card readiness status
- Removed `Router` and `RouterModule` imports and dependencies
- Changed card deletion to use `window.history.back()` instead of router-based navigation
- Removed associated CSS styling for the top-actions container

## Implementation Details
The back button previously provided smart navigation that would redirect to either the in-review cards page or the source page depending on the card's readiness status. This has been replaced with a simpler browser history-based approach on card deletion, allowing users to navigate back using the browser's back button instead of an explicit UI control.

Two related test cases were also removed:
- "back button navigates to source page" test
- "speech card back navigation works" test

https://claude.ai/code/session_0194a2wzTdz7F7EYE4jLRVbt