### PR TITLE
Add "suggested known" quick filter for cards

### DIFF
--- a/client/src/app/cards-table/cards-table.component.html
+++ b/client/src/app/cards-table/cards-table.component.html
@@ -1,5 +1,5 @@
 <div class="container">
-  @if (unhealthyCount() || flaggedCount() || draftCount()) {
+  @if (unhealthyCount() || flaggedCount() || draftCount() || suggestedKnownCount()) {
     <div class="quick-filters" role="group" aria-label="Quick filters">
       @if (unhealthyCount()) {
         <button
@@ -21,6 +21,17 @@
         >
           <mat-icon>flag</mat-icon>
           Flagged ({{ flaggedCount() }})
+        </button>
+      }
+      @if (suggestedKnownCount()) {
+        <button
+          mat-stroked-button
+          [class.active]="activeQuickFilter() === 'suggestedKnown'"
+          (click)="onQuickFilterChange('suggestedKnown')"
+          aria-label="Filter suggested known cards"
+        >
+          <mat-icon>check_circle</mat-icon>
+          Suggested known ({{ suggestedKnownCount() }})
         </button>
       }
       @if (draftCount()) {

--- a/client/src/app/cards-table/cards-table.component.ts
+++ b/client/src/app/cards-table/cards-table.component.ts
@@ -42,7 +42,7 @@ import { SelectAllHeaderComponent } from './select-all-header.component';
 import { SelectionCheckboxComponent } from './selection-checkbox.component';
 import { injectQueryParams } from '../utils/inject-query-params';
 
-type QuickFilter = 'unhealthy' | 'flagged' | 'draft';
+type QuickFilter = 'unhealthy' | 'flagged' | 'draft' | 'suggestedKnown';
 
 const STATE_COLORS: Record<string, string> = {
   NEW: '#2196F3',
@@ -72,7 +72,7 @@ const formatDaysAgo = (days: number): string => {
   return `${Math.floor(days / 365)} years ago`;
 };
 
-const VALID_QUICK_FILTERS: readonly QuickFilter[] = ['unhealthy', 'flagged', 'draft'];
+const VALID_QUICK_FILTERS: readonly QuickFilter[] = ['unhealthy', 'flagged', 'draft', 'suggestedKnown'];
 
 const parseQuickFilter = (value: string | null): QuickFilter | null =>
   VALID_QUICK_FILTERS.includes(value as QuickFilter) ? (value as QuickFilter) : null;
@@ -126,6 +126,7 @@ export class CardsTableComponent {
   readonly unhealthyCount = computed(() => this.currentSource()?.unhealthyCardCount ?? 0);
   readonly flaggedCount = computed(() => this.currentSource()?.flaggedCardCount ?? 0);
   readonly draftCount = computed(() => this.currentSource()?.draftCardCount ?? 0);
+  readonly suggestedKnownCount = computed(() => this.currentSource()?.suggestedKnownCardCount ?? 0);
   readonly isCompletingDrafts = this.bulkCreationService.isProcessing;
   private readonly loadedRowReadiness = signal<ReadonlyMap<string, CardReadiness>>(new Map());
 
@@ -139,7 +140,7 @@ export class CardsTableComponent {
     source: this.activeQuickFilter,
     computation: (quickFilter): readonly CardReadiness[] => {
       if (quickFilter === 'draft') return ['DRAFT'];
-      if (quickFilter === 'flagged' || quickFilter === 'unhealthy') return [];
+      if (quickFilter === 'flagged' || quickFilter === 'unhealthy' || quickFilter === 'suggestedKnown') return [];
       return ['READY', 'IN_REVIEW', 'REVIEWED'];
     },
   });
@@ -194,6 +195,10 @@ export class CardsTableComponent {
     this.activeQuickFilter() === 'unhealthy' ? true : undefined
   );
 
+  private readonly suggestedKnownParam = computed(() =>
+    this.activeQuickFilter() === 'suggestedKnown' ? true : undefined
+  );
+
   readonly allFilteredIds = resource({
     params: () => {
       const sourceId = this.sourceId();
@@ -211,6 +216,7 @@ export class CardsTableComponent {
         cardFilter: this.cardFilter() || undefined,
         flagged: this.flaggedParam(),
         unhealthy: this.unhealthyParam(),
+        suggestedKnown: this.suggestedKnownParam(),
       };
     },
     loader: ({ params }) =>
@@ -551,6 +557,7 @@ export class CardsTableComponent {
         cardFilter: this.cardFilter() || undefined,
         flagged: this.flaggedParam(),
         unhealthy: this.unhealthyParam(),
+        suggestedKnown: this.suggestedKnownParam(),
       });
 
       const updatedMap = new Map(this.loadedRowReadiness());

--- a/client/src/app/cards-table/cards-table.service.ts
+++ b/client/src/app/cards-table/cards-table.service.ts
@@ -35,6 +35,7 @@ export type CardTableParams = {
   cardFilter?: string;
   flagged?: boolean;
   unhealthy?: boolean;
+  suggestedKnown?: boolean;
 };
 
 @Injectable({ providedIn: 'root' })
@@ -63,6 +64,7 @@ export class CardsTableService {
       ...(params.cardFilter ? { cardFilter: params.cardFilter } : {}),
       ...(params.flagged ? { flagged: params.flagged } : {}),
       ...(params.unhealthy ? { unhealthy: params.unhealthy } : {}),
+      ...(params.suggestedKnown ? { suggestedKnown: params.suggestedKnown } : {}),
     }).reduce(
       (acc, [key, value]) => acc.set(key, String(value)),
       new HttpParams()
@@ -86,6 +88,7 @@ export class CardsTableService {
     cardFilter?: string;
     flagged?: boolean;
     unhealthy?: boolean;
+    suggestedKnown?: boolean;
   }): Promise<string[]> {
     const httpParams = Object.entries({
       ...(params.readiness ? { readiness: params.readiness } : {}),
@@ -102,6 +105,7 @@ export class CardsTableService {
       ...(params.cardFilter ? { cardFilter: params.cardFilter } : {}),
       ...(params.flagged ? { flagged: params.flagged } : {}),
       ...(params.unhealthy ? { unhealthy: params.unhealthy } : {}),
+      ...(params.suggestedKnown ? { suggestedKnown: params.suggestedKnown } : {}),
     }).reduce(
       (acc, [key, value]) => acc.set(key, String(value)),
       new HttpParams()

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -225,6 +225,7 @@ export type Source = {
   draftCardCount?: number;
   flaggedCardCount?: number;
   unhealthyCardCount?: number;
+  suggestedKnownCardCount?: number;
   stateCounts?: Record<string, number>;
   readinessCounts?: Record<string, number>;
   languageLevel?: LanguageLevel;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/CardController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/CardController.java
@@ -67,12 +67,13 @@ public class CardController {
       @RequestParam(required = false) Integer maxReviewScore,
       @RequestParam(required = false) String cardFilter,
       @RequestParam(required = false) Boolean flagged,
-      @RequestParam(required = false) Boolean unhealthy) {
+      @RequestParam(required = false) Boolean unhealthy,
+      @RequestParam(required = false) Boolean suggestedKnown) {
 
     final CardTableResponse response = cardService.getCardTable(
         sourceId, startRow, endRow, sortField, sortDirection,
         readiness, state, minReps, maxReps, lastReviewDaysAgo,
-        minReviewScore, maxReviewScore, cardFilter, flagged, unhealthy,
+        minReviewScore, maxReviewScore, cardFilter, flagged, unhealthy, suggestedKnown,
         startOfDayUtc(parseTimezone(timezone)));
 
     return ResponseEntity.ok(response);
@@ -92,12 +93,13 @@ public class CardController {
       @RequestParam(required = false) Integer maxReviewScore,
       @RequestParam(required = false) String cardFilter,
       @RequestParam(required = false) Boolean flagged,
-      @RequestParam(required = false) Boolean unhealthy) {
+      @RequestParam(required = false) Boolean unhealthy,
+      @RequestParam(required = false) Boolean suggestedKnown) {
 
     final List<String> ids = cardService.getFilteredCardIds(
         sourceId, readiness, state, minReps, maxReps,
         lastReviewDaysAgo,
-        minReviewScore, maxReviewScore, cardFilter, flagged, unhealthy,
+        minReviewScore, maxReviewScore, cardFilter, flagged, unhealthy, suggestedKnown,
         startOfDayUtc(parseTimezone(timezone)));
 
     return ResponseEntity.ok(ids);

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
@@ -72,7 +72,7 @@ public class SourceController {
     final var sources = sourceService.getAllSources();
     final var statsMap = cardService.getSourceStats();
     final var emptyStats = SourceStats.builder()
-        .cardCount(0).draftCardCount(0).flaggedCardCount(0).unhealthyCardCount(0)
+        .cardCount(0).draftCardCount(0).flaggedCardCount(0).unhealthyCardCount(0).suggestedKnownCardCount(0)
         .stateCounts(Map.of()).readinessCounts(Map.of())
         .build();
 
@@ -96,6 +96,7 @@ public class SourceController {
           .draftCardCount(stats.getDraftCardCount())
           .flaggedCardCount(stats.getFlaggedCardCount())
           .unhealthyCardCount(stats.getUnhealthyCardCount())
+          .suggestedKnownCardCount(stats.getSuggestedKnownCardCount())
           .stateCounts(stats.getStateCounts())
           .readinessCounts(stats.getReadinessCounts())
           .languageLevel(source.getLanguageLevel())

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/entity/CardView.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/entity/CardView.java
@@ -71,4 +71,7 @@ public class CardView {
 
     @Column(name = "is_unhealthy", nullable = false)
     private Boolean isUnhealthy;
+
+    @Column(name = "is_suggested_known", nullable = false)
+    private Boolean isSuggestedKnown;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceResponse.java
@@ -18,6 +18,7 @@ public class SourceResponse {
     private Integer draftCardCount;
     private Integer flaggedCardCount;
     private Integer unhealthyCardCount;
+    private Integer suggestedKnownCardCount;
     private Map<String, Integer> stateCounts;
     private Map<String, Integer> readinessCounts;
     private LanguageLevel languageLevel;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
@@ -42,10 +42,11 @@ public interface CardRepository
 
     @Query(value = """
         SELECT c.source_id AS sourceId, c.readiness AS readiness, c.state AS state,
-               c.flagged AS flagged, COALESCE(cv.is_unhealthy, false) AS unhealthy, COUNT(*) AS count
+               c.flagged AS flagged, COALESCE(cv.is_unhealthy, false) AS unhealthy,
+               COALESCE(cv.is_suggested_known, false) AS suggestedKnown, COUNT(*) AS count
         FROM learn_language.cards c
         LEFT JOIN learn_language.card_view cv ON c.id = cv.id
-        GROUP BY c.source_id, c.readiness, c.state, c.flagged, cv.is_unhealthy
+        GROUP BY c.source_id, c.readiness, c.state, c.flagged, cv.is_unhealthy, cv.is_suggested_known
         """, nativeQuery = true)
     List<SourceCardStatsProjection> getSourceCardStats();
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
@@ -43,10 +43,11 @@ public interface CardRepository
     @Query(value = """
         SELECT c.source_id AS sourceId, c.readiness AS readiness, c.state AS state,
                c.flagged AS flagged, COALESCE(cv.is_unhealthy, false) AS unhealthy,
-               COALESCE(cv.is_suggested_known, false) AS suggestedKnown, COUNT(*) AS count
+               COUNT(*) AS count,
+               SUM(CASE WHEN COALESCE(cv.is_suggested_known, false) THEN 1 ELSE 0 END) AS suggestedKnownCount
         FROM learn_language.cards c
         LEFT JOIN learn_language.card_view cv ON c.id = cv.id
-        GROUP BY c.source_id, c.readiness, c.state, c.flagged, cv.is_unhealthy, cv.is_suggested_known
+        GROUP BY c.source_id, c.readiness, c.state, c.flagged, cv.is_unhealthy
         """, nativeQuery = true)
     List<SourceCardStatsProjection> getSourceCardStats();
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/SourceCardStatsProjection.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/SourceCardStatsProjection.java
@@ -6,6 +6,6 @@ public interface SourceCardStatsProjection {
     String getState();
     Boolean getFlagged();
     Boolean getUnhealthy();
-    Boolean getSuggestedKnown();
     Long getCount();
+    Long getSuggestedKnownCount();
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/SourceCardStatsProjection.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/SourceCardStatsProjection.java
@@ -6,5 +6,6 @@ public interface SourceCardStatsProjection {
     String getState();
     Boolean getFlagged();
     Boolean getUnhealthy();
+    Boolean getSuggestedKnown();
     Long getCount();
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/specification/CardViewSpecifications.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/specification/CardViewSpecifications.java
@@ -68,6 +68,10 @@ public class CardViewSpecifications {
         return (root, cb) -> cb.isTrue(root.get(CardView_.isUnhealthy));
     }
 
+    public static PredicateSpecification<CardView> isSuggestedKnown() {
+        return (root, cb) -> cb.isTrue(root.get(CardView_.isSuggestedKnown));
+    }
+
     public static PredicateSpecification<CardView> isDue() {
         final LocalDateTime cutoff = LocalDateTime.now(ZoneOffset.UTC).plusHours(1);
         return hasReadinessIn(List.of(CardReadiness.READY)).and(isDueBefore(cutoff));

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -54,6 +54,7 @@ public class CardService {
     private final int draftCardCount;
     private final int flaggedCardCount;
     private final int unhealthyCardCount;
+    private final int suggestedKnownCardCount;
     private final Map<String, Integer> stateCounts;
     private final Map<String, Integer> readinessCounts;
   }
@@ -154,6 +155,11 @@ public class CardService {
                   .mapToInt(row -> row.getCount().intValue())
                   .sum();
 
+              final int suggestedKnownCardCount = rows.stream()
+                  .filter(row -> row.getSuggestedKnown())
+                  .mapToInt(row -> row.getCount().intValue())
+                  .sum();
+
               final Predicate<SourceCardStatsProjection> isReady =
                   row -> CardReadiness.READY.name().equals(row.getReadiness());
 
@@ -174,6 +180,7 @@ public class CardService {
                   .draftCardCount(draftCardCount)
                   .flaggedCardCount(flaggedCardCount)
                   .unhealthyCardCount(unhealthyCardCount)
+                  .suggestedKnownCardCount(suggestedKnownCardCount)
                   .stateCounts(stateCounts)
                   .readinessCounts(readinessCounts)
                   .build();
@@ -195,13 +202,13 @@ public class CardService {
       Integer minReps, Integer maxReps,
       Integer lastReviewDaysAgo,
       Integer minReviewScore, Integer maxReviewScore,
-      String cardFilter, Boolean flagged, Boolean unhealthy,
+      String cardFilter, Boolean flagged, Boolean unhealthy, Boolean suggestedKnown,
       LocalDateTime startOfDayUtc) {
 
     final PredicateSpecification<CardView> spec = buildCardTableSpec(
         sourceId, readiness, state, minReps, maxReps,
         lastReviewDaysAgo,
-        minReviewScore, maxReviewScore, cardFilter, flagged, unhealthy, startOfDayUtc);
+        minReviewScore, maxReviewScore, cardFilter, flagged, unhealthy, suggestedKnown, startOfDayUtc);
 
     return cardViewRepository.findAll(spec).stream()
         .map(CardView::getId)
@@ -215,13 +222,13 @@ public class CardService {
       Integer minReps, Integer maxReps,
       Integer lastReviewDaysAgo,
       Integer minReviewScore, Integer maxReviewScore,
-      String cardFilter, Boolean flagged, Boolean unhealthy,
+      String cardFilter, Boolean flagged, Boolean unhealthy, Boolean suggestedKnown,
       LocalDateTime startOfDayUtc) {
 
     final PredicateSpecification<CardView> spec = buildCardTableSpec(
         sourceId, readiness, state, minReps, maxReps,
         lastReviewDaysAgo,
-        minReviewScore, maxReviewScore, cardFilter, flagged, unhealthy, startOfDayUtc);
+        minReviewScore, maxReviewScore, cardFilter, flagged, unhealthy, suggestedKnown, startOfDayUtc);
 
     final int pageSize = Math.max(1, endRow - startRow);
     final int page = startRow / pageSize;
@@ -275,7 +282,7 @@ public class CardService {
       Integer minReps, Integer maxReps,
       Integer lastReviewDaysAgo,
       Integer minReviewScore, Integer maxReviewScore,
-      String cardFilter, Boolean flagged, Boolean unhealthy,
+      String cardFilter, Boolean flagged, Boolean unhealthy, Boolean suggestedKnown,
       LocalDateTime startOfDayUtc) {
 
     PredicateSpecification<CardView> spec = hasSourceId(sourceId);
@@ -312,6 +319,9 @@ public class CardService {
     }
     if (Boolean.TRUE.equals(unhealthy)) {
       spec = spec.and(isUnhealthy());
+    }
+    if (Boolean.TRUE.equals(suggestedKnown)) {
+      spec = spec.and(isSuggestedKnown());
     }
 
     return spec;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -156,7 +156,7 @@ public class CardService {
                   .sum();
 
               final int suggestedKnownCardCount = rows.stream()
-                  .filter(row -> row.getSuggestedKnown())
+                  .filter(row -> Boolean.TRUE.equals(row.getSuggestedKnown()))
                   .mapToInt(row -> row.getCount().intValue())
                   .sum();
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -156,8 +156,7 @@ public class CardService {
                   .sum();
 
               final int suggestedKnownCardCount = rows.stream()
-                  .filter(row -> Boolean.TRUE.equals(row.getSuggestedKnown()))
-                  .mapToInt(row -> row.getCount().intValue())
+                  .mapToInt(row -> row.getSuggestedKnownCount().intValue())
                   .sum();
 
               final Predicate<SourceCardStatsProjection> isReady =

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -239,7 +239,13 @@ SELECT
         (c.data->'translation'->>'ch' IS NULL OR TRIM(c.data->'translation'->>'ch') = '') OR
         (s.card_type = 'VOCABULARY' AND c.data->>'type' = 'NOUN' AND (c.data->>'gender' IS NULL OR TRIM(c.data->>'gender') = '')) OR
         (s.card_type = 'VOCABULARY' AND (c.data->>'type' IS NULL OR TRIM(c.data->>'type') = ''))
-    ) THEN true ELSE false END AS is_unhealthy
+    ) THEN true ELSE false END AS is_unhealthy,
+    CASE WHEN c.readiness = 'READY'
+        AND c.state = 'REVIEW'
+        AND c.stability >= 30
+        AND c.reps >= 5
+        AND c.lapses <= 1
+    THEN true ELSE false END AS is_suggested_known
 FROM learn_language.cards c
 JOIN learn_language.sources s ON c.source_id = s.id
 LEFT JOIN LATERAL (

--- a/test/tests/cards-table-page.spec.ts
+++ b/test/tests/cards-table-page.spec.ts
@@ -1590,6 +1590,7 @@ test('quick filter suggested known shows only cards meeting criteria', async ({ 
     cardId: 'suggested-known-card',
     sourceId: 'goethe-a1',
     sourcePageNumber: 9,
+    readiness: 'READY',
     data: {
       word: 'Hund',
       type: 'NOUN',
@@ -1606,6 +1607,7 @@ test('quick filter suggested known shows only cards meeting criteria', async ({ 
     cardId: 'not-suggested-card',
     sourceId: 'goethe-a1',
     sourcePageNumber: 9,
+    readiness: 'READY',
     data: {
       word: 'Katze',
       type: 'NOUN',
@@ -1633,6 +1635,7 @@ test('quick filter suggested known button displays count', async ({ page }) => {
     cardId: 'sk-count-1',
     sourceId: 'goethe-a1',
     sourcePageNumber: 9,
+    readiness: 'READY',
     data: {
       word: 'Hund',
       type: 'NOUN',
@@ -1649,6 +1652,7 @@ test('quick filter suggested known button displays count', async ({ page }) => {
     cardId: 'sk-count-2',
     sourceId: 'goethe-a1',
     sourcePageNumber: 9,
+    readiness: 'READY',
     data: {
       word: 'Katze',
       type: 'NOUN',

--- a/test/tests/cards-table-page.spec.ts
+++ b/test/tests/cards-table-page.spec.ts
@@ -1548,6 +1548,7 @@ test('quick filter buttons show count and hide when no matching cards', async ({
   await expect(page.getByRole('button', { name: 'Filter flagged cards' })).not.toBeVisible();
   await expect(page.getByRole('button', { name: 'Filter unhealthy cards' })).not.toBeVisible();
   await expect(page.getByRole('button', { name: 'Filter draft cards' })).not.toBeVisible();
+  await expect(page.getByRole('button', { name: 'Filter suggested known cards' })).not.toBeVisible();
 });
 
 test('quick filter buttons display card counts', async ({ page }) => {
@@ -1582,4 +1583,87 @@ test('quick filter buttons display card counts', async ({ page }) => {
   const flaggedButton = page.getByRole('button', { name: 'Filter flagged cards' });
   await expect(flaggedButton).toBeVisible();
   await expect(flaggedButton).toContainText('Flagged (2)');
+});
+
+test('quick filter suggested known shows only cards meeting criteria', async ({ page }) => {
+  await createCard({
+    cardId: 'suggested-known-card',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'Hund',
+      type: 'NOUN',
+      gender: 'M',
+      translation: { en: 'dog', hu: 'kutya', ch: 'Hund' },
+    },
+    state: 'REVIEW',
+    stability: 50,
+    reps: 8,
+    lapses: 0,
+  });
+
+  await createCard({
+    cardId: 'not-suggested-card',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'Katze',
+      type: 'NOUN',
+      gender: 'F',
+      translation: { en: 'cat', hu: 'macska', ch: 'Chatz' },
+    },
+    state: 'LEARNING',
+    stability: 2,
+    reps: 1,
+    lapses: 0,
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/cards?filter=suggestedKnown');
+
+  const grid = page.getByRole('grid');
+  await expect(async () => {
+    const rows = await getGridData(grid);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]['ID']).toBe('suggested-known-card');
+  }).toPass();
+});
+
+test('quick filter suggested known button displays count', async ({ page }) => {
+  await createCard({
+    cardId: 'sk-count-1',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'Hund',
+      type: 'NOUN',
+      gender: 'M',
+      translation: { en: 'dog', hu: 'kutya', ch: 'Hund' },
+    },
+    state: 'REVIEW',
+    stability: 40,
+    reps: 6,
+    lapses: 0,
+  });
+
+  await createCard({
+    cardId: 'sk-count-2',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'Katze',
+      type: 'NOUN',
+      gender: 'F',
+      translation: { en: 'cat', hu: 'macska', ch: 'Chatz' },
+    },
+    state: 'REVIEW',
+    stability: 35,
+    reps: 5,
+    lapses: 1,
+  });
+
+  await page.goto('http://localhost:8180/sources/goethe-a1/cards');
+
+  const suggestedKnownButton = page.getByRole('button', { name: 'Filter suggested known cards' });
+  await expect(suggestedKnownButton).toBeVisible();
+  await expect(suggestedKnownButton).toContainText('Suggested known (2)');
 });

--- a/test/tests/cards-table-page.spec.ts
+++ b/test/tests/cards-table-page.spec.ts
@@ -1664,6 +1664,8 @@ test('quick filter suggested known button displays count', async ({ page }) => {
   await page.goto('http://localhost:8180/sources/goethe-a1/cards');
 
   const suggestedKnownButton = page.getByRole('button', { name: 'Filter suggested known cards' });
-  await expect(suggestedKnownButton).toBeVisible();
-  await expect(suggestedKnownButton).toContainText('Suggested known (2)');
+  await expect(async () => {
+    await expect(suggestedKnownButton).toBeVisible();
+    await expect(suggestedKnownButton).toContainText('Suggested known (2)');
+  }).toPass();
 });


### PR DESCRIPTION
## Summary
This PR adds a new "suggested known" quick filter to the cards table, allowing users to quickly view cards that meet criteria indicating they are likely well-known by the learner.

## Key Changes

**Backend:**
- Added `isSuggestedKnown` column to the `card_view` database view with criteria: readiness = READY, state = REVIEW, stability >= 30, reps >= 5, and lapses <= 1
- Added `suggestedKnownCardCount` to `SourceStats` to track the count of suggested known cards per source
- Extended `CardService.getSourceStats()` to calculate the suggested known card count
- Added `suggestedKnown` parameter to card filtering methods in `CardService` and `CardController`
- Created `isSuggestedKnown()` specification in `CardViewSpecifications` for filtering
- Updated `CardView` entity with the new `isSuggestedKnown` boolean field
- Updated database queries to include the suggested known flag in stats projections

**Frontend:**
- Added `suggestedKnownCount` computed signal to track the count in the cards table component
- Extended `QuickFilter` type to include `'suggestedKnown'`
- Added new quick filter button with check_circle icon that displays when suggested known cards exist
- Integrated `suggestedKnown` parameter into card table and filtered card ID requests
- Updated type definitions in `CardTableParams` and `Source` types

**Tests:**
- Added assertion to verify the suggested known filter button is hidden when no matching cards exist
- Added test to verify the filter correctly shows only cards meeting the suggested known criteria
- Added test to verify the filter button displays the correct count of suggested known cards

## Implementation Details
The "suggested known" criteria identifies cards that are in REVIEW state with sufficient repetitions (5+), good stability (30+), and minimal lapses (0-1), indicating the learner likely knows the card well. This helps users identify cards that may be ready for retirement or less frequent review.

https://claude.ai/code/session_01A9AcuJCCPJm3CthfkFUwUU