### PR TITLE
Add automatic data refresh on navigation and visibility change

### DIFF
--- a/client/src/app/api-tokens/api-tokens.service.ts
+++ b/client/src/app/api-tokens/api-tokens.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject, resource, Injector } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { fetchJson } from '../utils/fetchJson';
+import { DataRefreshService } from '../data-refresh.service';
 
 export interface ApiToken {
   id: number;
@@ -21,12 +22,12 @@ export interface ApiTokenCreateResponse {
 export class ApiTokensService {
   private readonly http = inject(HttpClient);
   private readonly injector = inject(Injector);
+  private readonly dataRefreshService = inject(DataRefreshService);
 
-  readonly tokens = resource<ApiToken[], never>({
+  readonly tokens = resource({
     injector: this.injector,
-    loader: async () => {
-      return await fetchJson<ApiToken[]>(this.http, '/api/api-tokens');
-    },
+    params: () => ({ _refresh: this.dataRefreshService.refreshTrigger() }),
+    loader: async () => fetchJson<ApiToken[]>(this.http, '/api/api-tokens'),
   });
 
   async createToken(name: string): Promise<ApiTokenCreateResponse> {

--- a/client/src/app/cards-table/cards-table.component.ts
+++ b/client/src/app/cards-table/cards-table.component.ts
@@ -41,6 +41,7 @@ import { CardsTableService, CardTableRow } from './cards-table.service';
 import { SelectAllHeaderComponent } from './select-all-header.component';
 import { SelectionCheckboxComponent } from './selection-checkbox.component';
 import { injectQueryParams } from '../utils/inject-query-params';
+import { DataRefreshService } from '../data-refresh.service';
 
 type QuickFilter = 'unhealthy' | 'flagged' | 'draft' | 'suggestedKnown';
 
@@ -111,6 +112,7 @@ export class CardsTableComponent {
   private readonly dialog = inject(MatDialog);
   private readonly bulkCreationService = inject(BulkCardCreationService);
   private readonly sourcesService = inject(SourcesService);
+  private readonly dataRefreshService = inject(DataRefreshService);
   private readonly routeSourceId = injectParams<string>('sourceId');
   private readonly filterParam = injectQueryParams<string>('filter');
 
@@ -156,6 +158,12 @@ export class CardsTableComponent {
       this.activeQuickFilter();
       if (this.gridApi) {
         this.refreshGrid();
+      }
+    });
+    effect(() => {
+      this.dataRefreshService.refreshTrigger();
+      if (this.gridApi) {
+        this.cardsTableService.refreshCardView().then(() => this.refreshGrid());
       }
     });
   }
@@ -205,6 +213,7 @@ export class CardsTableComponent {
       if (!sourceId) return undefined;
       const reviewScoreRange = this.parseReviewScoreRange(this.reviewScoreFilter());
       return {
+        _refresh: this.dataRefreshService.refreshTrigger(),
         sourceId,
         readiness: this.readinessParam(),
         state: this.stateFilter() || undefined,

--- a/client/src/app/data-refresh.service.ts
+++ b/client/src/app/data-refresh.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, signal, inject } from '@angular/core';
+import { Router, NavigationEnd } from '@angular/router';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DataRefreshService {
+  private readonly router = inject(Router);
+  private readonly version = signal(0);
+  private isFirstNavigation = true;
+
+  readonly refreshTrigger = this.version.asReadonly();
+
+  constructor() {
+    this.router.events.subscribe((event) => {
+      if (event instanceof NavigationEnd) {
+        if (this.isFirstNavigation) {
+          this.isFirstNavigation = false;
+          return;
+        }
+        this.version.update((v) => v + 1);
+      }
+    });
+
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') {
+        this.version.update((v) => v + 1);
+      }
+    });
+  }
+}

--- a/client/src/app/due-cards.service.ts
+++ b/client/src/app/due-cards.service.ts
@@ -2,6 +2,7 @@ import { inject, Injectable, resource } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { fetchJson } from './utils/fetchJson';
 import { CardState } from './shared/state/card-state';
+import { DataRefreshService } from './data-refresh.service';
 
 export interface SourceDueCardCount {
   sourceId: string;
@@ -14,11 +15,11 @@ export interface SourceDueCardCount {
 })
 export class DueCardsService {
   private readonly http = inject(HttpClient);
+  private readonly dataRefreshService = inject(DataRefreshService);
 
-  readonly dueCounts = resource<SourceDueCardCount[], unknown>({
-    loader: async () => {
-      return fetchJson(this.http, '/api/sources/due-cards-count');
-    },
+  readonly dueCounts = resource({
+    params: () => ({ _refresh: this.dataRefreshService.refreshTrigger() }),
+    loader: async () => fetchJson<SourceDueCardCount[]>(this.http, '/api/sources/due-cards-count'),
   });
 
   refetchDueCounts() {

--- a/client/src/app/in-review-cards.service.ts
+++ b/client/src/app/in-review-cards.service.ts
@@ -3,14 +3,17 @@ import { HttpClient } from '@angular/common/http';
 import { fetchJson } from './utils/fetchJson';
 import { Card } from './parser/types';
 import { mapCardDatesFromISOStrings } from './utils/date-mapping.util';
+import { DataRefreshService } from './data-refresh.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class InReviewCardsService {
   private readonly http = inject(HttpClient);
+  private readonly dataRefreshService = inject(DataRefreshService);
 
-  readonly cards = resource<Card[], unknown>({
+  readonly cards = resource({
+    params: () => ({ _refresh: this.dataRefreshService.refreshTrigger() }),
     loader: async () => {
       const cards = await fetchJson<Card[]>(this.http, '/api/cards/readiness/IN_REVIEW');
       return cards.map(card => mapCardDatesFromISOStrings(card));

--- a/client/src/app/in-review-cards/in-review-cards.component.ts
+++ b/client/src/app/in-review-cards/in-review-cards.component.ts
@@ -39,10 +39,6 @@ export class InReviewCardsComponent {
     () => (this.totalCount() > 0 && this.remainingCount() <= 0 ? 1 : 0)
   );
 
-  constructor() {
-    this.inReviewCardsService.refetchCards();
-  }
-
   onCardReviewed(cardId: string) {
     this.reviewedCardIds.update((ids) => [...ids, cardId]);
   }

--- a/client/src/app/known-words/known-words.service.ts
+++ b/client/src/app/known-words/known-words.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject, resource, Injector } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { fetchJson } from '../utils/fetchJson';
+import { DataRefreshService } from '../data-refresh.service';
 
 export interface KnownWordDTO {
   word: string;
@@ -22,15 +23,12 @@ export interface KnownWordsImportResponse {
 export class KnownWordsService {
   private readonly http = inject(HttpClient);
   private readonly injector = inject(Injector);
+  private readonly dataRefreshService = inject(DataRefreshService);
 
-  readonly knownWords = resource<KnownWordsResponse, never>({
+  readonly knownWords = resource({
     injector: this.injector,
-    loader: async () => {
-      return await fetchJson<KnownWordsResponse>(
-        this.http,
-        '/api/known-words'
-      );
-    },
+    params: () => ({ _refresh: this.dataRefreshService.refreshTrigger() }),
+    loader: async () => fetchJson<KnownWordsResponse>(this.http, '/api/known-words'),
   });
 
   async importWords(text: string): Promise<KnownWordsImportResponse> {

--- a/client/src/app/learning-partners/learning-partners.service.ts
+++ b/client/src/app/learning-partners/learning-partners.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject, resource, Injector } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { fetchJson } from '../utils/fetchJson';
+import { DataRefreshService } from '../data-refresh.service';
 
 export interface LearningPartner {
   id: number;
@@ -19,15 +20,12 @@ export interface LearningPartnerRequest {
 export class LearningPartnersService {
   private readonly http = inject(HttpClient);
   private readonly injector = inject(Injector);
+  private readonly dataRefreshService = inject(DataRefreshService);
 
-  readonly partners = resource<LearningPartner[], never>({
+  readonly partners = resource({
     injector: this.injector,
-    loader: async () => {
-      return await fetchJson<LearningPartner[]>(
-        this.http,
-        '/api/learning-partners'
-      );
-    },
+    params: () => ({ _refresh: this.dataRefreshService.refreshTrigger() }),
+    loader: async () => fetchJson<LearningPartner[]>(this.http, '/api/learning-partners'),
   });
 
   async createPartner(request: LearningPartnerRequest): Promise<LearningPartner> {

--- a/client/src/app/model-usage-logs/model-usage-logs.service.ts
+++ b/client/src/app/model-usage-logs/model-usage-logs.service.ts
@@ -3,6 +3,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { fetchJson } from '../utils/fetchJson';
 import { ENVIRONMENT_CONFIG } from '../environment/environment.config';
+import { DataRefreshService } from '../data-refresh.service';
 
 export interface ModelUsageLog {
   id: number;
@@ -80,16 +81,16 @@ export interface ModelUsageLogFetchParams {
 export class ModelUsageLogsService {
   private readonly http = inject(HttpClient);
   private readonly environmentConfig = inject(ENVIRONMENT_CONFIG);
+  private readonly dataRefreshService = inject(DataRefreshService);
 
   readonly dateFilter = signal<string>(this.getTodayDateString());
   readonly modelTypeFilter = signal<ModelType | 'ALL'>('ALL');
   readonly operationTypeFilter = signal<string>('ALL');
   readonly modelNameFilter = signal<string>('ALL');
 
-  readonly summary = resource<ModelSummary[], unknown>({
-    loader: async () => {
-      return await fetchJson<ModelSummary[]>(this.http, '/api/model-usage-logs/summary');
-    },
+  readonly summary = resource({
+    params: () => ({ _refresh: this.dataRefreshService.refreshTrigger() }),
+    loader: async () => fetchJson<ModelSummary[]>(this.http, '/api/model-usage-logs/summary'),
   });
 
   readonly groupedSummary = computed<OperationTypeSummaryGroup[]>(() => {

--- a/client/src/app/page.service.ts
+++ b/client/src/app/page.service.ts
@@ -14,6 +14,7 @@ import { HttpClient } from '@angular/common/http';
 import { CardTypeRegistry } from './cardTypes/card-type.registry';
 import { ExtractionRegion, ExtractionRegionSelection, Page } from './parser/types';
 import { PagedSelection, SelectionStateService } from './selection-state.service';
+import { DataRefreshService } from './data-refresh.service';
 
 type SelectedSource = { sourceId: string; pageNumber: number; documentId?: number } | undefined;
 type SelectedRectangle = {
@@ -32,12 +33,14 @@ export class PageService {
   private readonly injector = inject(Injector);
   private readonly strategyRegistry = inject(CardTypeRegistry);
   private readonly selectionStateService = inject(SelectionStateService);
+  private readonly dataRefreshService = inject(DataRefreshService);
   private readonly selectedSource = signal<SelectedSource>(undefined);
   private readonly extractionGroups = signal<ExtractionGroup[]>([]);
 
   readonly page = resource({
     params: () => ({
       selectedSource: this.selectedSource(),
+      _refresh: this.dataRefreshService.refreshTrigger(),
     }),
     loader: async ({ params: { selectedSource } }) => {
       if (!selectedSource) {

--- a/client/src/app/sources.service.ts
+++ b/client/src/app/sources.service.ts
@@ -2,16 +2,17 @@ import { inject, Injectable, resource } from '@angular/core';
 import { Source } from './parser/types';
 import { fetchJson } from './utils/fetchJson';
 import { HttpClient } from '@angular/common/http';
+import { DataRefreshService } from './data-refresh.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class SourcesService {
   private readonly http = inject(HttpClient);
-  readonly sources = resource<Source[], unknown>({
-    loader: async () => {
-      return fetchJson(this.http, '/api/sources');
-    },
+  private readonly dataRefreshService = inject(DataRefreshService);
+  readonly sources = resource({
+    params: () => ({ _refresh: this.dataRefreshService.refreshTrigger() }),
+    loader: async () => fetchJson<Source[]>(this.http, '/api/sources'),
   });
 
   refetchSources() {

--- a/client/src/app/study-session.service.ts
+++ b/client/src/app/study-session.service.ts
@@ -5,6 +5,7 @@ import { fetchJson } from './utils/fetchJson';
 import { SessionStats, StudySession, StudySessionCard } from './parser/types';
 import { mapCardDatesFromISOStrings } from './utils/date-mapping.util';
 import { DueCardsService } from './due-cards.service';
+import { DataRefreshService } from './data-refresh.service';
 
 @Injectable({
   providedIn: 'root',
@@ -13,6 +14,7 @@ export class StudySessionService {
   private readonly http = inject(HttpClient);
   private readonly injector = inject(Injector);
   private readonly dueCardsService = inject(DueCardsService);
+  private readonly dataRefreshService = inject(DataRefreshService);
 
   readonly sourceId = signal<string | undefined>(undefined);
   readonly hasSession = signal(false);
@@ -24,6 +26,7 @@ export class StudySessionService {
       sourceId: this.sourceId(),
       hasSession: this.hasSession(),
       version: this.sessionVersion(),
+      _refresh: this.dataRefreshService.refreshTrigger(),
     }),
     loader: async ({ params: { sourceId, hasSession } }) => {
       if (!sourceId || !hasSession) {

--- a/client/src/app/voice-config/voice-config.service.ts
+++ b/client/src/app/voice-config/voice-config.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { fetchJson } from '../utils/fetchJson';
 import { Card } from '../parser/types';
 import { ENVIRONMENT_CONFIG } from '../environment/environment.config';
+import { DataRefreshService } from '../data-refresh.service';
 
 export interface VoiceConfiguration {
   id: number;
@@ -28,6 +29,7 @@ export class VoiceConfigService {
   private readonly http = inject(HttpClient);
   private readonly injector = inject(Injector);
   private readonly config = inject(ENVIRONMENT_CONFIG);
+  private readonly dataRefreshService = inject(DataRefreshService);
 
   readonly audioModels = this.config.audioModels;
   readonly availableVoices = this.config.voices;
@@ -37,21 +39,16 @@ export class VoiceConfigService {
   readonly audioDailyLimit = signal(this.config.audioDailyLimit);
   readonly frontAudioEnabled = signal(this.config.frontAudioEnabled);
 
-  readonly configurations = resource<VoiceConfiguration[], never>({
+  readonly configurations = resource({
     injector: this.injector,
-    loader: async () => {
-      return await fetchJson<VoiceConfiguration[]>(
-        this.http,
-        '/api/voice-configurations'
-      );
-    },
+    params: () => ({ _refresh: this.dataRefreshService.refreshTrigger() }),
+    loader: async () => fetchJson<VoiceConfiguration[]>(this.http, '/api/voice-configurations'),
   });
 
-  readonly sampleCards = resource<Card[], never>({
+  readonly sampleCards = resource({
     injector: this.injector,
-    loader: async () => {
-      return await fetchJson<Card[]>(this.http, '/api/cards/sample');
-    },
+    params: () => ({ _refresh: this.dataRefreshService.refreshTrigger() }),
+    loader: async () => fetchJson<Card[]>(this.http, '/api/cards/sample'),
   });
 
   async createConfiguration(


### PR DESCRIPTION
## Summary
Implement automatic data refresh across the application when users navigate between routes or return to the application after it has been backgrounded. This ensures data is always fresh without requiring manual refresh actions.

## Key Changes
- **New DataRefreshService**: Created a centralized service that:
  - Monitors router navigation events and increments a refresh signal (skipping the first navigation)
  - Listens for document visibility changes and triggers refresh when the app becomes visible
  - Exposes a readonly `refreshTrigger` signal for components to subscribe to refresh events

- **Updated Resource Definitions**: Modified all resource-based data fetching across multiple services to:
  - Include `params: () => ({ _refresh: this.dataRefreshService.refreshTrigger() })` to reactively depend on the refresh trigger
  - Simplify loader functions and remove explicit type parameters where they can be inferred
  - Services updated: VoiceConfigService, KnownWordsService, LearningPartnersService, ApiTokensService, DueCardsService, ModelUsageLogsService, SourcesService, InReviewCardsService, PageService, and StudySessionService

- **Component Updates**:
  - CardsTableComponent: Added effect to refresh grid data when refresh trigger fires
  - InReviewCardsComponent: Removed manual refetch from constructor (now handled automatically)

## Implementation Details
- The refresh signal uses Angular's new signal-based reactivity system to automatically invalidate and reload resources
- Navigation-based refresh skips the initial navigation to avoid unnecessary data fetches on app startup
- Visibility change detection ensures data is refreshed when users switch back to the application tab
- All resource loaders now reactively depend on the refresh trigger through the params function

https://claude.ai/code/session_01VVzfscbWBr2MoqNjpnfe8Z