### PR TITLE
Replace version signal with .reload() for resource refresh after card mutations

### DIFF
--- a/client/src/app/bulk-card-creation-fab/bulk-card-creation-fab.component.ts
+++ b/client/src/app/bulk-card-creation-fab/bulk-card-creation-fab.component.ts
@@ -12,6 +12,8 @@ import { BulkCardCreationService } from '../bulk-card-creation.service';
 import { BulkCreationProgressDialogComponent } from '../bulk-creation-progress-dialog/bulk-creation-progress-dialog.component';
 import { PageService } from '../page.service';
 import { DailyUsageService } from '../daily-usage.service';
+import { SourcesService } from '../sources.service';
+import { InReviewCardsService } from '../in-review-cards.service';
 import { ENVIRONMENT_CONFIG } from '../environment/environment.config';
 import { fetchJson } from '../utils/fetchJson';
 
@@ -30,6 +32,8 @@ export class BulkCardCreationFabComponent {
   readonly dialog = inject(MatDialog);
   readonly snackBar = inject(MatSnackBar);
   readonly dailyUsageService = inject(DailyUsageService);
+  private readonly sourcesService = inject(SourcesService);
+  private readonly inReviewCardsService = inject(InReviewCardsService);
   private readonly environmentConfig = inject(ENVIRONMENT_CONFIG);
 
   readonly totalImagesNeeded = computed(() => {
@@ -89,6 +93,8 @@ export class BulkCardCreationFabComponent {
     );
 
     this.dailyUsageService.reload();
+    this.sourcesService.refetchSources();
+    this.inReviewCardsService.refetchCards();
 
     if (result.succeeded > 0) {
       const regions = selections.map(sel => ({

--- a/client/src/app/cards-table/cards-table.component.ts
+++ b/client/src/app/cards-table/cards-table.component.ts
@@ -37,6 +37,8 @@ import {
 } from 'ag-grid-community';
 import { injectParams } from '../utils/inject-params';
 import { CardReadiness, CARD_READINESS_VALUES } from '../shared/state/card-readiness';
+import { DueCardsService } from '../due-cards.service';
+import { InReviewCardsService } from '../in-review-cards.service';
 import { CardsTableService, CardTableRow } from './cards-table.service';
 import { SelectAllHeaderComponent } from './select-all-header.component';
 import { SelectionCheckboxComponent } from './selection-checkbox.component';
@@ -111,6 +113,8 @@ export class CardsTableComponent {
   private readonly dialog = inject(MatDialog);
   private readonly bulkCreationService = inject(BulkCardCreationService);
   private readonly sourcesService = inject(SourcesService);
+  private readonly dueCardsService = inject(DueCardsService);
+  private readonly inReviewCardsService = inject(InReviewCardsService);
   private readonly routeSourceId = injectParams<string>('sourceId');
   private readonly filterParam = injectQueryParams<string>('filter');
 
@@ -421,6 +425,8 @@ export class CardsTableComponent {
     this.selectedIds.set([]);
     await this.cardsTableService.refreshCardView();
     this.refreshGrid();
+    this.sourcesService.refetchSources();
+    this.dueCardsService.refetchDueCounts();
   }
 
   async deleteSelected(): Promise<void> {
@@ -445,6 +451,9 @@ export class CardsTableComponent {
     });
     await this.cardsTableService.refreshCardView();
     this.refreshGrid();
+    this.sourcesService.refetchSources();
+    this.dueCardsService.refetchDueCounts();
+    this.inReviewCardsService.refetchCards();
   }
 
   async deleteSelectedAudio(): Promise<void> {
@@ -500,6 +509,8 @@ export class CardsTableComponent {
 
     await this.cardsTableService.refreshCardView();
     this.refreshGrid();
+    this.sourcesService.refetchSources();
+    this.inReviewCardsService.refetchCards();
   }
 
   private toggleSelection(id: string): void {

--- a/client/src/app/in-review-cards/in-review-cards.component.ts
+++ b/client/src/app/in-review-cards/in-review-cards.component.ts
@@ -3,6 +3,8 @@ import { ScrollingModule } from '@angular/cdk/scrolling';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { InReviewCardsService } from '../in-review-cards.service';
+import { DueCardsService } from '../due-cards.service';
+import { SourcesService } from '../sources.service';
 import { BatchAudioCreationFabComponent } from '../batch-audio-creation-fab/batch-audio-creation-fab.component';
 import { ReviewCardItemComponent } from './review-card-item/review-card-item.component';
 
@@ -21,6 +23,8 @@ import { ReviewCardItemComponent } from './review-card-item/review-card-item.com
 })
 export class InReviewCardsComponent {
   private readonly inReviewCardsService = inject(InReviewCardsService);
+  private readonly dueCardsService = inject(DueCardsService);
+  private readonly sourcesService = inject(SourcesService);
 
   readonly cards = this.inReviewCardsService.cards.value;
   readonly loading = computed(
@@ -45,9 +49,13 @@ export class InReviewCardsComponent {
 
   onCardReviewed(cardId: string) {
     this.reviewedCardIds.update((ids) => [...ids, cardId]);
+    this.dueCardsService.refetchDueCounts();
+    this.sourcesService.refetchSources();
   }
 
   onCardDeleted(cardId: string) {
     this.inReviewCardsService.refetchCards();
+    this.dueCardsService.refetchDueCounts();
+    this.sourcesService.refetchSources();
   }
 }

--- a/client/src/app/parser/edit-card/edit-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-card.component.ts
@@ -13,6 +13,8 @@ import { injectParams } from '../../utils/inject-params';
 import { Card } from '../types';
 import { ConfirmDialogComponent } from './confirm-dialog/confirm-dialog.component';
 import { InReviewCardsService } from '../../in-review-cards.service';
+import { DueCardsService } from '../../due-cards.service';
+import { SourcesService } from '../../sources.service';
 import { fetchJson } from '../../utils/fetchJson';
 import { mapCardDatesFromISOStrings } from '../../utils/date-mapping.util';
 import { EditVocabularyCardComponent } from './edit-vocabulary-card/edit-vocabulary-card.component';
@@ -43,6 +45,8 @@ export class EditCardComponent {
   private readonly routePageNumber = injectParams('pageNumber');
   private readonly routeCardId = injectParams('cardId');
   readonly inReviewCardsService = inject(InReviewCardsService);
+  private readonly dueCardsService = inject(DueCardsService);
+  private readonly sourcesService = inject(SourcesService);
   readonly dialog = inject(MatDialog);
   readonly snackBar = inject(MatSnackBar);
 
@@ -126,6 +130,7 @@ export class EditCardComponent {
       });
       this.pendingCardEdits.set(undefined);
       this.card.reload();
+      this.sourcesService.refetchSources();
       this.showSnackBar('Flag removed successfully');
     } catch {
       this.showSnackBar('Failed to remove flag', 'error');
@@ -176,6 +181,8 @@ export class EditCardComponent {
     this.pendingCardEdits.set(undefined);
     this.card.reload();
     this.inReviewCardsService.refetchCards();
+    this.dueCardsService.refetchDueCounts();
+    this.sourcesService.refetchSources();
     this.showSnackBar('Card marked as reviewed successfully');
   }
 
@@ -203,8 +210,8 @@ export class EditCardComponent {
       method: 'DELETE',
     });
 
-    if (this.isInReview()) {
-      this.inReviewCardsService.refetchCards();
-    }
+    this.inReviewCardsService.refetchCards();
+    this.dueCardsService.refetchDueCounts();
+    this.sourcesService.refetchSources();
   }
 }

--- a/client/src/app/study-session.service.ts
+++ b/client/src/app/study-session.service.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable, Injector, computed, inject, resource, signal } from '@angular/core';
+import { SourcesService } from './sources.service';
 import { firstValueFrom } from 'rxjs';
 import { fetchJson } from './utils/fetchJson';
 import { SessionStats, StudySession, StudySessionCard } from './parser/types';
@@ -13,17 +14,16 @@ export class StudySessionService {
   private readonly http = inject(HttpClient);
   private readonly injector = inject(Injector);
   private readonly dueCardsService = inject(DueCardsService);
+  private readonly sourcesService = inject(SourcesService);
 
   readonly sourceId = signal<string | undefined>(undefined);
   readonly hasSession = signal(false);
   readonly hasExistingSession = signal(false);
-  private sessionVersion = signal(0);
 
   readonly currentCard = resource({
     params: () => ({
       sourceId: this.sourceId(),
       hasSession: this.hasSession(),
-      version: this.sessionVersion(),
     }),
     loader: async ({ params: { sourceId, hasSession } }) => {
       if (!sourceId || !hasSession) {
@@ -91,8 +91,9 @@ export class StudySessionService {
   }
 
   refreshSession() {
-    this.sessionVersion.update((v) => v + 1);
+    this.currentCard.reload();
     this.dueCardsService.refetchDueCounts();
+    this.sourcesService.refetchSources();
   }
 
   async fetchSessionStats(sourceId: string): Promise<SessionStats | null> {


### PR DESCRIPTION
Use Angular's recommended .reload() pattern on all affected service resources
(sources, due counts, in-review cards) after card mutations instead of version
signals. This avoids the value-clearing issue and ensures consistent state.

https://claude.ai/code/session_01CetHbWhECH9BbvUo9YG9ka