### PR TITLE
Defer service refetches until component destruction

### DIFF
--- a/client/src/app/batch-audio-creation-fab/batch-audio-creation-fab.component.ts
+++ b/client/src/app/batch-audio-creation-fab/batch-audio-creation-fab.component.ts
@@ -12,6 +12,8 @@ import { Card, CardType } from '../parser/types';
 import { CardTypeRegistry } from '../cardTypes/card-type.registry';
 import { VoiceConfigService } from '../voice-config/voice-config.service';
 import { DailyUsageService } from '../daily-usage.service';
+import { DueCardsService } from '../due-cards.service';
+import { SourcesService } from '../sources.service';
 import { fetchJson } from '../utils/fetchJson';
 import { HttpClient } from '@angular/common/http';
 import { mapCardDatesFromISOStrings } from '../utils/date-mapping.util';
@@ -31,6 +33,8 @@ export class BatchAudioCreationFabComponent {
   private readonly cardTypeRegistry = inject(CardTypeRegistry);
   private readonly voiceConfigService = inject(VoiceConfigService);
   readonly dailyUsageService = inject(DailyUsageService);
+  private readonly dueCardsService = inject(DueCardsService);
+  private readonly sourcesService = inject(SourcesService);
   readonly refreshTrigger = input(0);
   readonly cards = resource<Card[], unknown>({
     params: () => this.refreshTrigger(),
@@ -125,6 +129,8 @@ export class BatchAudioCreationFabComponent {
         }
 
         this.cards.reload();
+        this.dueCardsService.refetchDueCounts();
+        this.sourcesService.refetchSources();
         this.snackBar.open(
           `Audio generated successfully for ${results.successful} card${results.successful === 1 ? '' : 's'}!`,
           'Close',

--- a/client/src/app/bulk-card-creation-fab/bulk-card-creation-fab.component.ts
+++ b/client/src/app/bulk-card-creation-fab/bulk-card-creation-fab.component.ts
@@ -12,6 +12,7 @@ import { BulkCardCreationService } from '../bulk-card-creation.service';
 import { BulkCreationProgressDialogComponent } from '../bulk-creation-progress-dialog/bulk-creation-progress-dialog.component';
 import { PageService } from '../page.service';
 import { DailyUsageService } from '../daily-usage.service';
+import { DueCardsService } from '../due-cards.service';
 import { SourcesService } from '../sources.service';
 import { InReviewCardsService } from '../in-review-cards.service';
 import { ENVIRONMENT_CONFIG } from '../environment/environment.config';
@@ -32,6 +33,7 @@ export class BulkCardCreationFabComponent {
   readonly dialog = inject(MatDialog);
   readonly snackBar = inject(MatSnackBar);
   readonly dailyUsageService = inject(DailyUsageService);
+  private readonly dueCardsService = inject(DueCardsService);
   private readonly sourcesService = inject(SourcesService);
   private readonly inReviewCardsService = inject(InReviewCardsService);
   private readonly environmentConfig = inject(ENVIRONMENT_CONFIG);
@@ -93,6 +95,7 @@ export class BulkCardCreationFabComponent {
     );
 
     this.dailyUsageService.reload();
+    this.dueCardsService.refetchDueCounts();
     this.sourcesService.refetchSources();
     this.inReviewCardsService.refetchCards();
 

--- a/client/src/app/in-review-cards/in-review-cards.component.ts
+++ b/client/src/app/in-review-cards/in-review-cards.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, computed, signal } from '@angular/core';
+import { Component, inject, computed, signal, OnDestroy } from '@angular/core';
 import { ScrollingModule } from '@angular/cdk/scrolling';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
@@ -21,7 +21,7 @@ import { ReviewCardItemComponent } from './review-card-item/review-card-item.com
   templateUrl: './in-review-cards.component.html',
   styleUrl: './in-review-cards.component.css',
 })
-export class InReviewCardsComponent {
+export class InReviewCardsComponent implements OnDestroy {
   private readonly inReviewCardsService = inject(InReviewCardsService);
   private readonly dueCardsService = inject(DueCardsService);
   private readonly sourcesService = inject(SourcesService);
@@ -32,6 +32,7 @@ export class InReviewCardsComponent {
   );
 
   readonly reviewedCardIds = signal<ReadonlyArray<string>>([]);
+  private hasChanges = false;
 
   readonly totalCount = computed(() => this.cards()?.length ?? 0);
 
@@ -47,15 +48,20 @@ export class InReviewCardsComponent {
     this.inReviewCardsService.refetchCards();
   }
 
+  ngOnDestroy() {
+    if (this.hasChanges) {
+      this.dueCardsService.refetchDueCounts();
+      this.sourcesService.refetchSources();
+    }
+  }
+
   onCardReviewed(cardId: string) {
     this.reviewedCardIds.update((ids) => [...ids, cardId]);
-    this.dueCardsService.refetchDueCounts();
-    this.sourcesService.refetchSources();
+    this.hasChanges = true;
   }
 
   onCardDeleted(cardId: string) {
     this.inReviewCardsService.refetchCards();
-    this.dueCardsService.refetchDueCounts();
-    this.sourcesService.refetchSources();
+    this.hasChanges = true;
   }
 }


### PR DESCRIPTION
## Summary
Optimizes service refetch calls by deferring them until component destruction rather than executing them immediately on every state change. This reduces unnecessary API calls and improves performance when multiple card operations occur in quick succession.

## Key Changes
- **InReviewCardsComponent**: Implemented `OnDestroy` lifecycle hook to batch refetch calls for `DueCardsService` and `SourcesService`. Added a `hasChanges` flag that tracks whether any card operations occurred, and only refetches services if changes were made when the component is destroyed.

- **BatchAudioCreationFabComponent**: Added injections for `DueCardsService` and `SourcesService`, and added refetch calls after successful audio generation to ensure related data is updated.

- **BulkCardCreationFabComponent**: Added injection for `DueCardsService` and added refetch call after bulk card creation to keep due counts synchronized.

## Implementation Details
- The `hasChanges` flag is set to `true` in both `onCardReviewed()` and `onCardDeleted()` methods instead of immediately calling refetch services
- Refetch operations are consolidated in the `ngOnDestroy()` lifecycle hook, ensuring they execute once when the component is destroyed
- This pattern prevents redundant API calls when multiple card operations happen in sequence
- Other components that trigger data changes (batch audio creation, bulk card creation) still refetch immediately as they represent discrete completion events

https://claude.ai/code/session_017sVQctHJ5Nbq9HazsU9KFo