### PR TITLE
Exclude active session sources from fallback due card query

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -39,6 +40,20 @@ public interface CardRepository
         GROUP BY source_id, state
         """, nativeQuery = true)
     List<SourceStateCountProjection> findTop50MostDueGroupedByStateAndSourceId();
+
+    @Query(value = """
+        SELECT source_id AS sourceId, state AS state, COUNT(*) AS count
+        FROM (
+            SELECT source_id, state,
+                   ROW_NUMBER() OVER (PARTITION BY source_id ORDER BY due ASC) AS row_num
+            FROM learn_language.cards
+            WHERE readiness = 'READY' AND due at time zone 'UTC' <= NOW() + INTERVAL '1 hour'
+                  AND source_id NOT IN (:excludedSourceIds)
+        ) AS ranked
+        WHERE row_num <= 50
+        GROUP BY source_id, state
+        """, nativeQuery = true)
+    List<SourceStateCountProjection> findTop50MostDueGroupedByStateAndSourceIdExcludingSources(@Param("excludedSourceIds") List<String> excludedSourceIds);
 
     @Query(value = """
         SELECT c.source_id AS sourceId, c.readiness AS readiness, c.state AS state,

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import lombok.Builder;
 import lombok.Value;
@@ -82,33 +83,45 @@ public class CardService {
   public List<SourceDueCardCountResponse> getDueCardCountsBySource(LocalDateTime startOfDay) {
     final List<StudySession> activeSessions = studySessionRepository.findAll(createdOnOrAfter(startOfDay));
 
-    if (!activeSessions.isEmpty()) {
-      final LocalDateTime cutoff = LocalDateTime.now(ZoneOffset.UTC).plusHours(1);
+    final LocalDateTime cutoff = LocalDateTime.now(ZoneOffset.UTC).plusHours(1);
 
-      return activeSessions.stream()
-          .flatMap(session -> studySessionRepository.findWithCardsById(session.getId())
-              .stream()
-              .flatMap(loaded -> loaded.getCards().stream()
-                  .map(StudySessionCard::getCard)
-                  .filter(Card::isReady)
-                  .filter(card -> !card.getDue().isAfter(cutoff))
-                  .collect(Collectors.groupingBy(Card::getState, Collectors.counting()))
-                  .entrySet().stream()
-                  .map(entry -> SourceDueCardCountResponse.builder()
-                      .sourceId(loaded.getSource().getId())
-                      .state(entry.getKey())
-                      .count(entry.getValue())
-                      .build())))
-          .toList();
-    }
-
-    return cardRepository.findTop50MostDueGroupedByStateAndSourceId().stream()
-        .map(row -> SourceDueCardCountResponse.builder()
-            .sourceId(row.getSourceId())
-            .state(row.getState())
-            .count(row.getCount())
-            .build())
+    final List<SourceDueCardCountResponse> sessionCounts = activeSessions.stream()
+        .flatMap(session -> studySessionRepository.findWithCardsById(session.getId())
+            .stream()
+            .flatMap(loaded -> loaded.getCards().stream()
+                .map(StudySessionCard::getCard)
+                .filter(Card::isReady)
+                .filter(card -> !card.getDue().isAfter(cutoff))
+                .collect(Collectors.groupingBy(Card::getState, Collectors.counting()))
+                .entrySet().stream()
+                .map(entry -> SourceDueCardCountResponse.builder()
+                    .sourceId(loaded.getSource().getId())
+                    .state(entry.getKey())
+                    .count(entry.getValue())
+                    .build())))
         .toList();
+
+    final List<String> sessionSourceIds = activeSessions.stream()
+        .map(session -> session.getSource().getId())
+        .toList();
+
+    final List<SourceDueCardCountResponse> nonSessionCounts = sessionSourceIds.isEmpty()
+        ? cardRepository.findTop50MostDueGroupedByStateAndSourceId().stream()
+            .map(row -> SourceDueCardCountResponse.builder()
+                .sourceId(row.getSourceId())
+                .state(row.getState())
+                .count(row.getCount())
+                .build())
+            .toList()
+        : cardRepository.findTop50MostDueGroupedByStateAndSourceIdExcludingSources(sessionSourceIds).stream()
+            .map(row -> SourceDueCardCountResponse.builder()
+                .sourceId(row.getSourceId())
+                .state(row.getState())
+                .count(row.getCount())
+                .build())
+            .toList();
+
+    return Stream.concat(sessionCounts.stream(), nonSessionCounts.stream()).toList();
   }
 
   public List<Card> getCardsByReadiness(CardReadiness readiness) {

--- a/test/tests/home-page.spec.ts
+++ b/test/tests/home-page.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../fixtures';
-import { createCard, createCardsWithStates } from '../utils';
+import { createCard, createCardsWithStates, createStudySession } from '../utils';
 import { v4 as uuidv4 } from 'uuid';
 
 test('displays welcome message', async ({ page }) => {
@@ -71,6 +71,32 @@ test('due cards limited to max 50 mixed states', async ({ page }) => {
   await expect(goetheA1Card.getByTitle('Learning', { exact: true })).toContainText('15');
   await expect(goetheA1Card.getByTitle('Review', { exact: true })).toContainText('10');
   await expect(goetheA1Card.getByTitle('Relearning', { exact: true })).toContainText('5');
+});
+
+test('due card counts are independent per source when study session exists', async ({ page }) => {
+  const now = new Date();
+  const yesterday = new Date(now.getTime() - 86400000);
+
+  await createCardsWithStates('goethe-a1', [
+    { state: 'NEW', count: 3, due_date: yesterday },
+  ]);
+
+  await createCardsWithStates('goethe-a2', [
+    { state: 'NEW', count: 2, due_date: yesterday },
+    { state: 'REVIEW', count: 1, due_date: yesterday },
+  ]);
+
+  const a1CardIds = Array.from({ length: 3 }, (_, i) => `goethe-a1_new_${i}`);
+  await createStudySession({ sourceId: 'goethe-a1', cardIds: a1CardIds });
+
+  await page.goto('http://localhost:8180');
+
+  const goetheA1Card = page.getByRole('heading', { name: 'Goethe A1' });
+  await expect(goetheA1Card.getByTitle('New', { exact: true })).toContainText('3');
+
+  const goetheA2Card = page.getByRole('heading', { name: 'Goethe A2' });
+  await expect(goetheA2Card.getByTitle('New', { exact: true })).toContainText('2');
+  await expect(goetheA2Card.getByTitle('Review', { exact: true })).toContainText('1');
 });
 
 test('in review cards not on home page', async ({ page }) => {


### PR DESCRIPTION
## Summary
Modified the due card count retrieval logic to prevent duplicate counting of cards from sources that have active study sessions. Cards from active sessions are now queried separately and excluded from the fallback query that retrieves the most due cards.

## Key Changes
- Refactored `getDueCardCountsBySource()` to separate session-based and non-session-based card counts
- Extracted active session source IDs and pass them to a new repository method to exclude these sources from the fallback query
- Added new repository method `findTop50MostDueGroupedByStateAndSourceIdExcludingSources()` that filters out specified source IDs
- Combined results from both queries using `Stream.concat()` to return a unified list
- Removed the conditional check that previously skipped the fallback query entirely when active sessions existed

## Implementation Details
- The cutoff time calculation is now performed unconditionally, simplifying the logic flow
- Session counts are computed first, then non-session counts are retrieved with exclusion of session source IDs
- The new repository query uses a `WHERE` clause with `source_id NOT IN (:excludedSourceIds)` to filter sources
- Added `@Param` annotation import to support parameterized query
- Added `Stream` import to support stream concatenation

https://claude.ai/code/session_011SRaybPbKQ7EUxfYW7AkUB