### PR TITLE
Add configurable card limits per source

### DIFF
--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -231,6 +231,8 @@ export type Source = {
   languageLevel?: LanguageLevel;
   cardType?: CardType;
   formatType?: SourceFormatType;
+  cardLimit?: number;
+  newCardLimit?: number;
 };
 
 export type WordList = {

--- a/client/src/app/shared/source-dialog/source-dialog.component.html
+++ b/client/src/app/shared/source-dialog/source-dialog.component.html
@@ -127,6 +127,24 @@
       />
     </mat-form-field>
     }
+
+    <mat-form-field appearance="fill" class="full-width">
+      <mat-label>Card Limit</mat-label>
+      <input
+        matInput
+        type="number"
+        [formField]="sourceForm.cardLimit"
+      />
+    </mat-form-field>
+
+    <mat-form-field appearance="fill" class="full-width">
+      <mat-label>New Card Limit</mat-label>
+      <input
+        matInput
+        type="number"
+        [formField]="sourceForm.newCardLimit"
+      />
+    </mat-form-field>
   </form>
 </mat-dialog-content>
 <mat-dialog-actions align="end">

--- a/client/src/app/shared/source-dialog/source-dialog.component.ts
+++ b/client/src/app/shared/source-dialog/source-dialog.component.ts
@@ -60,6 +60,8 @@ export class SourceDialogComponent {
     languageLevel: LanguageLevel | '';
     cardType: CardType | '';
     formatType: SourceFormatType | '';
+    cardLimit: number;
+    newCardLimit: number;
   }>({
     id: this.data.source?.id || '',
     name: this.data.source?.name || '',
@@ -69,6 +71,8 @@ export class SourceDialogComponent {
     languageLevel: this.data.source?.languageLevel ?? '',
     cardType: this.data.source?.cardType ?? '',
     formatType: this.data.source?.formatType ?? '',
+    cardLimit: this.data.source?.cardLimit ?? 50,
+    newCardLimit: this.data.source?.newCardLimit ?? 50,
   });
   readonly sourceForm = form(this.formModel, (path) => {
     required(path.id);
@@ -77,6 +81,8 @@ export class SourceDialogComponent {
     required(path.languageLevel);
     required(path.sourceType);
     min(path.startPage, 1);
+    min(path.cardLimit, 1);
+    min(path.newCardLimit, 1);
     validate(path.formatType, (ctx) => {
       const ct = ctx.valueOf(path.cardType);
       if (ct !== 'speech' && ct !== 'grammar' && !ctx.value()) {
@@ -125,6 +131,8 @@ export class SourceDialogComponent {
         formatType: result.cardType === 'speech' || result.cardType === 'grammar'
           ? 'flowingText'
           : result.formatType || undefined,
+        cardLimit: result.cardLimit,
+        newCardLimit: result.newCardLimit,
       };
       this.dialogRef.close(formData);
     }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
@@ -101,6 +101,8 @@ public class SourceController {
           .readinessCounts(stats.getReadinessCounts())
           .languageLevel(source.getLanguageLevel())
           .formatType(source.getFormatType())
+          .cardLimit(source.getCardLimit())
+          .newCardLimit(source.getNewCardLimit())
           .build();
     }).collect(Collectors.toList());
   }
@@ -285,6 +287,8 @@ public class SourceController {
         .languageLevel(request.getLanguageLevel())
         .cardType(request.getCardType())
         .formatType(request.getFormatType())
+        .cardLimit(request.getCardLimit() != null ? request.getCardLimit() : 50)
+        .newCardLimit(request.getNewCardLimit() != null ? request.getNewCardLimit() : 50)
         .build();
 
     sourceService.saveSource(source);
@@ -316,6 +320,8 @@ public class SourceController {
         .languageLevel(request.getLanguageLevel())
         .cardType(request.getCardType())
         .formatType(request.getFormatType())
+        .cardLimit(request.getCardLimit())
+        .newCardLimit(request.getNewCardLimit())
         .build();
 
     BeanUtils.copyNonNullProperties(updates, existingSource);

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
@@ -287,8 +287,8 @@ public class SourceController {
         .languageLevel(request.getLanguageLevel())
         .cardType(request.getCardType())
         .formatType(request.getFormatType())
-        .cardLimit(request.getCardLimit() != null ? request.getCardLimit() : 50)
-        .newCardLimit(request.getNewCardLimit() != null ? request.getNewCardLimit() : 50)
+        .cardLimit(request.getCardLimit())
+        .newCardLimit(request.getNewCardLimit())
         .build();
 
     sourceService.saveSource(source);

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/entity/Source.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/entity/Source.java
@@ -49,11 +49,9 @@ public class Source {
   @Column(name = "format_type")
   private SourceFormatType formatType;
 
-  @Builder.Default
-  @Column(name = "card_limit", nullable = false)
-  private Integer cardLimit = 50;
+  @Column(name = "card_limit")
+  private Integer cardLimit;
 
-  @Builder.Default
-  @Column(name = "new_card_limit", nullable = false)
-  private Integer newCardLimit = 50;
+  @Column(name = "new_card_limit")
+  private Integer newCardLimit;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/entity/Source.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/entity/Source.java
@@ -48,4 +48,12 @@ public class Source {
   @Enumerated(EnumType.STRING)
   @Column(name = "format_type")
   private SourceFormatType formatType;
+
+  @Builder.Default
+  @Column(name = "card_limit", nullable = false)
+  private Integer cardLimit = 50;
+
+  @Builder.Default
+  @Column(name = "new_card_limit", nullable = false)
+  private Integer newCardLimit = 50;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceRequest.java
@@ -18,4 +18,6 @@ public class SourceRequest {
     private LanguageLevel languageLevel;
     private CardType cardType;
     private SourceFormatType formatType;
+    private Integer cardLimit;
+    private Integer newCardLimit;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceResponse.java
@@ -23,4 +23,6 @@ public class SourceResponse {
     private Map<String, Integer> readinessCounts;
     private LanguageLevel languageLevel;
     private SourceFormatType formatType;
+    private Integer cardLimit;
+    private Integer newCardLimit;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/StudySessionService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/StudySessionService.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -81,10 +82,12 @@ public class StudySessionService {
                     .build();
         }
 
-        final int cardLimit = source.getCardLimit() != null ? source.getCardLimit() : Integer.MAX_VALUE;
-
-        final List<Card> allDueCards = cardRepository.findAll(
-                Specification.where(isDueForSource(sourceId)), PageRequest.of(0, cardLimit, Sort.by("due"))).getContent();
+        final List<Card> allDueCards = source.getCardLimit() != null
+                ? cardRepository.findAll(
+                        Specification.where(isDueForSource(sourceId)),
+                        PageRequest.of(0, source.getCardLimit(), Sort.by("due"))).getContent()
+                : cardRepository.findAll(
+                        Specification.where(isDueForSource(sourceId)), Sort.by("due"));
         final List<Card> dueCards = source.getNewCardLimit() != null
                 ? applyNewCardLimit(allDueCards, source.getNewCardLimit())
                 : allDueCards;
@@ -100,9 +103,10 @@ public class StudySessionService {
                 .cards(new ArrayList<>())
                 .build();
 
+        final int effectiveLimit = source.getCardLimit() != null ? source.getCardLimit() : dueCards.size();
         final List<StudySessionCard> sessionCards = activePartner
-                .map(partner -> assignCardsSmartly(dueCards, session, partner, cardLimit, 0))
-                .orElseGet(() -> assignCardsSolo(dueCards, session, cardLimit, 0));
+                .map(partner -> assignCardsSmartly(dueCards, session, partner, effectiveLimit, 0))
+                .orElseGet(() -> assignCardsSolo(dueCards, session, effectiveLimit, 0));
 
         final StudySession sessionWithCards = session.toBuilder()
                 .cards(new ArrayList<>(sessionCards))
@@ -187,13 +191,11 @@ public class StudySessionService {
         final List<Card> reviewCards = cards.stream()
                 .filter(c -> !"NEW".equals(c.getState()))
                 .toList();
-        final List<Card> newCards = cards.stream()
+        final List<Card> limitedNewCards = cards.stream()
                 .filter(c -> "NEW".equals(c.getState()))
                 .limit(newCardLimit)
                 .toList();
-        return cards.stream()
-                .filter(c -> reviewCards.contains(c) || newCards.contains(c))
-                .toList();
+        return Stream.concat(reviewCards.stream(), limitedNewCards.stream()).toList();
     }
 
     private Map<String, Double> toComplexityMap(List<Object[]> rows) {
@@ -243,23 +245,35 @@ public class StudySessionService {
         studySessionRepository.findBySource_IdAndCreatedAtGreaterThanEqual(sourceId, startOfDay)
                 .flatMap(session -> studySessionRepository.findWithCardsById(session.getId()))
                 .ifPresent(session -> {
-                    final Integer cardLimit = session.getSource().getCardLimit();
+                    final Source source = session.getSource();
                     final Set<String> existingCardIds = session.getCards().stream()
                             .map(sc -> sc.getCard().getId())
                             .collect(Collectors.toSet());
 
-                    final List<Card> newCards = cards.stream()
+                    final List<Card> candidateCards = cards.stream()
                             .filter(c -> !existingCardIds.contains(c.getId()))
                             .toList();
 
-                    if (newCards.isEmpty()) {
+                    if (candidateCards.isEmpty()) {
                         return;
                     }
 
-                    final int remainingSlots = cardLimit != null
-                            ? cardLimit - session.getCards().size()
-                            : Integer.MAX_VALUE;
+                    final int remainingSlots = source.getCardLimit() != null
+                            ? source.getCardLimit() - session.getCards().size()
+                            : candidateCards.size();
                     if (remainingSlots <= 0) {
+                        return;
+                    }
+
+                    final List<Card> slotLimitedCards = candidateCards.stream()
+                            .limit(remainingSlots)
+                            .toList();
+
+                    final List<Card> limitedCards = source.getNewCardLimit() != null
+                            ? applyNewCardLimitForSession(slotLimitedCards, session, source.getNewCardLimit())
+                            : slotLimitedCards;
+
+                    if (limitedCards.isEmpty()) {
                         return;
                     }
 
@@ -273,12 +287,20 @@ public class StudySessionService {
                             : Optional.empty();
 
                     final List<StudySessionCard> newSessionCards = activePartner
-                            .map(partner -> assignCardsSmartly(newCards, session, partner, remainingSlots,
+                            .map(partner -> assignCardsSmartly(limitedCards, session, partner, limitedCards.size(),
                                     positionOffset))
-                            .orElseGet(() -> assignCardsSolo(newCards, session, remainingSlots, positionOffset));
+                            .orElseGet(() -> assignCardsSolo(limitedCards, session, limitedCards.size(), positionOffset));
 
                     studySessionCardRepository.saveAll(newSessionCards);
                 });
+    }
+
+    private List<Card> applyNewCardLimitForSession(List<Card> candidates, StudySession session, int newCardLimit) {
+        final long existingNewCardCount = session.getCards().stream()
+                .filter(sc -> "NEW".equals(sc.getCard().getState()))
+                .count();
+        final int remainingNewSlots = (int) Math.max(0, newCardLimit - existingNewCardCount);
+        return applyNewCardLimit(candidates, remainingNewSlots);
     }
 
     @Transactional

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/StudySessionService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/StudySessionService.java
@@ -81,12 +81,13 @@ public class StudySessionService {
                     .build();
         }
 
-        final int cardLimit = source.getCardLimit();
-        final int newCardLimit = source.getNewCardLimit();
+        final int cardLimit = source.getCardLimit() != null ? source.getCardLimit() : Integer.MAX_VALUE;
 
         final List<Card> allDueCards = cardRepository.findAll(
                 Specification.where(isDueForSource(sourceId)), PageRequest.of(0, cardLimit, Sort.by("due"))).getContent();
-        final List<Card> dueCards = applyNewCardLimit(allDueCards, newCardLimit);
+        final List<Card> dueCards = source.getNewCardLimit() != null
+                ? applyNewCardLimit(allDueCards, source.getNewCardLimit())
+                : allDueCards;
         final Optional<LearningPartner> activePartner = learningPartnerService.getActivePartner();
 
         final String sessionId = UUID.randomUUID().toString();
@@ -242,7 +243,7 @@ public class StudySessionService {
         studySessionRepository.findBySource_IdAndCreatedAtGreaterThanEqual(sourceId, startOfDay)
                 .flatMap(session -> studySessionRepository.findWithCardsById(session.getId()))
                 .ifPresent(session -> {
-                    final int cardLimit = session.getSource().getCardLimit();
+                    final Integer cardLimit = session.getSource().getCardLimit();
                     final Set<String> existingCardIds = session.getCards().stream()
                             .map(sc -> sc.getCard().getId())
                             .collect(Collectors.toSet());
@@ -255,7 +256,9 @@ public class StudySessionService {
                         return;
                     }
 
-                    final int remainingSlots = cardLimit - session.getCards().size();
+                    final int remainingSlots = cardLimit != null
+                            ? cardLimit - session.getCards().size()
+                            : Integer.MAX_VALUE;
                     if (remainingSlots <= 0) {
                         return;
                     }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/StudySessionService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/StudySessionService.java
@@ -50,7 +50,6 @@ import static io.github.mucsi96.learnlanguage.repository.specification.StudySess
 public class StudySessionService {
 
     private static final Duration DUE_CARD_LOOKAHEAD = Duration.ofHours(1);
-    private static final int SESSION_CARD_LIMIT = 50;
 
     private final CardRepository cardRepository;
     private final SourceRepository sourceRepository;
@@ -82,8 +81,12 @@ public class StudySessionService {
                     .build();
         }
 
-        final List<Card> dueCards = cardRepository.findAll(
-                Specification.where(isDueForSource(sourceId)), PageRequest.of(0, SESSION_CARD_LIMIT, Sort.by("due"))).getContent();
+        final int cardLimit = source.getCardLimit();
+        final int newCardLimit = source.getNewCardLimit();
+
+        final List<Card> allDueCards = cardRepository.findAll(
+                Specification.where(isDueForSource(sourceId)), PageRequest.of(0, cardLimit, Sort.by("due"))).getContent();
+        final List<Card> dueCards = applyNewCardLimit(allDueCards, newCardLimit);
         final Optional<LearningPartner> activePartner = learningPartnerService.getActivePartner();
 
         final String sessionId = UUID.randomUUID().toString();
@@ -97,8 +100,8 @@ public class StudySessionService {
                 .build();
 
         final List<StudySessionCard> sessionCards = activePartner
-                .map(partner -> assignCardsSmartly(dueCards, session, partner, SESSION_CARD_LIMIT, 0))
-                .orElseGet(() -> assignCardsSolo(dueCards, session, SESSION_CARD_LIMIT, 0));
+                .map(partner -> assignCardsSmartly(dueCards, session, partner, cardLimit, 0))
+                .orElseGet(() -> assignCardsSolo(dueCards, session, cardLimit, 0));
 
         final StudySession sessionWithCards = session.toBuilder()
                 .cards(new ArrayList<>(sessionCards))
@@ -179,6 +182,19 @@ public class StudySessionService {
                 .toList();
     }
 
+    private List<Card> applyNewCardLimit(List<Card> cards, int newCardLimit) {
+        final List<Card> reviewCards = cards.stream()
+                .filter(c -> !"NEW".equals(c.getState()))
+                .toList();
+        final List<Card> newCards = cards.stream()
+                .filter(c -> "NEW".equals(c.getState()))
+                .limit(newCardLimit)
+                .toList();
+        return cards.stream()
+                .filter(c -> reviewCards.contains(c) || newCards.contains(c))
+                .toList();
+    }
+
     private Map<String, Double> toComplexityMap(List<Object[]> rows) {
         return rows.stream()
                 .collect(Collectors.toMap(
@@ -226,6 +242,7 @@ public class StudySessionService {
         studySessionRepository.findBySource_IdAndCreatedAtGreaterThanEqual(sourceId, startOfDay)
                 .flatMap(session -> studySessionRepository.findWithCardsById(session.getId()))
                 .ifPresent(session -> {
+                    final int cardLimit = session.getSource().getCardLimit();
                     final Set<String> existingCardIds = session.getCards().stream()
                             .map(sc -> sc.getCard().getId())
                             .collect(Collectors.toSet());
@@ -238,7 +255,7 @@ public class StudySessionService {
                         return;
                     }
 
-                    final int remainingSlots = SESSION_CARD_LIMIT - session.getCards().size();
+                    final int remainingSlots = cardLimit - session.getCards().size();
                     if (remainingSlots <= 0) {
                         return;
                     }

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -47,8 +47,8 @@ ALTER TABLE learn_language.cards ADD COLUMN IF NOT EXISTS flagged BOOLEAN NOT NU
 
 ALTER TABLE learn_language.sources ADD COLUMN IF NOT EXISTS bookmarked_document_id integer;
 
-ALTER TABLE learn_language.sources ADD COLUMN IF NOT EXISTS card_limit integer NOT NULL DEFAULT 50;
-ALTER TABLE learn_language.sources ADD COLUMN IF NOT EXISTS new_card_limit integer NOT NULL DEFAULT 50;
+ALTER TABLE learn_language.sources ADD COLUMN IF NOT EXISTS card_limit integer;
+ALTER TABLE learn_language.sources ADD COLUMN IF NOT EXISTS new_card_limit integer;
 
 ALTER TABLE learn_language.sources DROP CONSTRAINT IF EXISTS sources_bookmarked_document_fkey;
 ALTER TABLE learn_language.sources

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -10,6 +10,8 @@ CREATE TABLE IF NOT EXISTS learn_language.sources (
     format_type character varying(255),
     source_type character varying(255),
     bookmarked_document_id integer,
+    card_limit integer,
+    new_card_limit integer,
     CONSTRAINT sources_pkey PRIMARY KEY (id)
 );
 

--- a/server/src/main/resources/schema.sql
+++ b/server/src/main/resources/schema.sql
@@ -47,6 +47,9 @@ ALTER TABLE learn_language.cards ADD COLUMN IF NOT EXISTS flagged BOOLEAN NOT NU
 
 ALTER TABLE learn_language.sources ADD COLUMN IF NOT EXISTS bookmarked_document_id integer;
 
+ALTER TABLE learn_language.sources ADD COLUMN IF NOT EXISTS card_limit integer NOT NULL DEFAULT 50;
+ALTER TABLE learn_language.sources ADD COLUMN IF NOT EXISTS new_card_limit integer NOT NULL DEFAULT 50;
+
 ALTER TABLE learn_language.sources DROP CONSTRAINT IF EXISTS sources_bookmarked_document_fkey;
 ALTER TABLE learn_language.sources
     ADD CONSTRAINT sources_bookmarked_document_fkey

--- a/test/tests/smart-card-assignment.spec.ts
+++ b/test/tests/smart-card-assignment.spec.ts
@@ -5,6 +5,7 @@ import {
   createReviewLog,
   getStudySessionCards,
   getStudySessionCardsBySource,
+  withDbConnection,
 } from '../utils';
 
 test('smart assignment: equal distribution between user and partner', async ({ page }) => {
@@ -593,8 +594,11 @@ test('smart assignment: uses first grading of the day instead of last corrected 
   expect(correctedCard?.learningPartnerId).toBeNull();
 });
 
-test('smart assignment: session limited to 50 most complex cards', async ({ page }) => {
+test('smart assignment: session limited to configured card limit', async ({ page }) => {
   await page.reload();
+  await withDbConnection(async (client) => {
+    await client.query(`UPDATE learn_language.sources SET card_limit = 50 WHERE id = 'goethe-a1'`);
+  });
   const partnerId = await createLearningPartner({ name: 'Partner', isActive: true });
   const twoDaysAgo = new Date(Date.now() - 2 * 86400000);
   const tenDaysAgo = new Date(Date.now() - 10 * 86400000);

--- a/test/tests/sources.spec.ts
+++ b/test/tests/sources.spec.ts
@@ -512,8 +512,8 @@ test('edit dialog shows card limit and new card limit fields with defaults', asy
 
   await expect(page.getByRole('heading', { name: 'Edit Source' })).toBeVisible();
 
-  const cardLimitField = page.getByRole('spinbutton', { name: 'Card Limit' });
-  const newCardLimitField = page.getByRole('spinbutton', { name: 'New Card Limit' });
+  const cardLimitField = page.getByRole('spinbutton', { name: 'Card Limit', exact: true });
+  const newCardLimitField = page.getByRole('spinbutton', { name: 'New Card Limit', exact: true });
 
   await expect(cardLimitField).toBeVisible();
   await expect(newCardLimitField).toBeVisible();
@@ -529,14 +529,17 @@ test('can edit card limit and new card limit', async ({ page }) => {
 
   await expect(page.getByRole('heading', { name: 'Edit Source' })).toBeVisible();
 
-  await page.getByRole('spinbutton', { name: 'Card Limit' }).fill('30');
-  await page.getByRole('spinbutton', { name: 'New Card Limit' }).fill('10');
+  await page.getByRole('spinbutton', { name: 'Card Limit', exact: true }).fill('30');
+  await page.getByRole('spinbutton', { name: 'New Card Limit', exact: true }).fill('10');
 
   await page.getByRole('button', { name: 'Update' }).click();
   await expect(page.getByRole('heading', { name: 'Edit Source' })).not.toBeVisible();
 
-  const updatedSource = await getSource('goethe-a1');
-  expect(updatedSource?.cardLimit).toBe(30);
-  expect(updatedSource?.newCardLimit).toBe(10);
+  await expect(async () => {
+    const updatedSource = await getSource('goethe-a1');
+    expect(updatedSource?.cardLimit).toBe(30);
+    expect(updatedSource?.newCardLimit).toBe(10);
+  }).toPass();
+
 });
 

--- a/test/tests/sources.spec.ts
+++ b/test/tests/sources.spec.ts
@@ -504,3 +504,39 @@ test('can create a grammar source with image collection', async ({ page }) => {
   expect(createdSource?.sourceType).toBe('IMAGES');
 });
 
+test('edit dialog shows card limit and new card limit fields with defaults', async ({ page }) => {
+  await page.goto('http://localhost:8180/sources');
+
+  await page.getByRole('article', { name: 'Goethe A1' }).click();
+  await page.getByRole('button', { name: 'Edit' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Edit Source' })).toBeVisible();
+
+  const cardLimitField = page.getByRole('spinbutton', { name: 'Card Limit' });
+  const newCardLimitField = page.getByRole('spinbutton', { name: 'New Card Limit' });
+
+  await expect(cardLimitField).toBeVisible();
+  await expect(newCardLimitField).toBeVisible();
+  await expect(cardLimitField).toHaveValue('50');
+  await expect(newCardLimitField).toHaveValue('50');
+});
+
+test('can edit card limit and new card limit', async ({ page }) => {
+  await page.goto('http://localhost:8180/sources');
+
+  await page.getByRole('article', { name: 'Goethe A1' }).click();
+  await page.getByRole('button', { name: 'Edit' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Edit Source' })).toBeVisible();
+
+  await page.getByRole('spinbutton', { name: 'Card Limit' }).fill('30');
+  await page.getByRole('spinbutton', { name: 'New Card Limit' }).fill('10');
+
+  await page.getByRole('button', { name: 'Update' }).click();
+  await expect(page.getByRole('heading', { name: 'Edit Source' })).not.toBeVisible();
+
+  const updatedSource = await getSource('goethe-a1');
+  expect(updatedSource?.cardLimit).toBe(30);
+  expect(updatedSource?.newCardLimit).toBe(10);
+});
+

--- a/test/tests/study-page.spec.ts
+++ b/test/tests/study-page.spec.ts
@@ -13,6 +13,10 @@ import {
   getReviewLogs,
   setupDefaultChatModelSettings,
   setupDefaultImageModelSettings,
+  cleanupDbRecords,
+  createSource,
+  createDocument,
+  getStudySessionCardsBySource,
 } from '../utils';
 import { v4 as uuidv4 } from 'uuid';
 import { Page } from '@playwright/test';
@@ -1591,4 +1595,82 @@ test('session stats show per-person breakdown when studying with partner', async
   await expect(aliceStats.getByRole('group', { name: 'Good reviews' }).getByLabel('value')).toHaveText('0');
   await expect(aliceStats.getByRole('group', { name: 'Struggled reviews' }).getByLabel('value')).toHaveText('1');
   await expect(aliceStats.getByRole('group', { name: 'Accuracy' })).toContainText('0%');
+});
+
+test('study session respects source card limit', async ({ page }) => {
+  await cleanupDbRecords({ withSources: true });
+  await createSource({
+    id: 'limited-source',
+    name: 'Limited Source',
+    startPage: 1,
+    languageLevel: 'A1',
+    cardType: 'VOCABULARY',
+    formatType: 'WORD_LIST_WITH_FORMS_AND_EXAMPLES',
+    cardLimit: 3,
+  });
+  await createDocument({
+    sourceId: 'limited-source',
+    fileName: 'A1_SD1_Wortliste_02.pdf',
+  });
+
+  for (let i = 1; i <= 5; i++) {
+    await createCard({
+      cardId: `card-${i}`,
+      sourceId: 'limited-source',
+      data: { word: `wort${i}`, type: 'NOUN', translation: { hu: `szó${i}` } },
+      due: new Date(Date.now() - i * 86400000),
+    });
+  }
+
+  await page.goto('http://localhost:8180/sources/limited-source/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
+  await expect(page.getByRole('article', { name: 'Flashcard' })).toBeVisible();
+
+  const sessionCards = await getStudySessionCardsBySource('limited-source');
+  expect(sessionCards.length).toBe(3);
+});
+
+test('study session respects source new card limit', async ({ page }) => {
+  await cleanupDbRecords({ withSources: true });
+  await createSource({
+    id: 'new-limited-source',
+    name: 'New Limited Source',
+    startPage: 1,
+    languageLevel: 'A1',
+    cardType: 'VOCABULARY',
+    formatType: 'WORD_LIST_WITH_FORMS_AND_EXAMPLES',
+    newCardLimit: 2,
+  });
+  await createDocument({
+    sourceId: 'new-limited-source',
+    fileName: 'A1_SD1_Wortliste_02.pdf',
+  });
+
+  for (let i = 1; i <= 3; i++) {
+    await createCard({
+      cardId: `new-card-${i}`,
+      sourceId: 'new-limited-source',
+      data: { word: `neuwort${i}`, type: 'NOUN', translation: { hu: `újszó${i}` } },
+      state: 'NEW',
+      due: new Date(Date.now() - i * 86400000),
+    });
+  }
+
+  for (let i = 1; i <= 2; i++) {
+    await createCard({
+      cardId: `review-card-${i}`,
+      sourceId: 'new-limited-source',
+      data: { word: `altwort${i}`, type: 'NOUN', translation: { hu: `régiszó${i}` } },
+      state: 'REVIEW',
+      reps: 3,
+      due: new Date(Date.now() - i * 86400000),
+    });
+  }
+
+  await page.goto('http://localhost:8180/sources/new-limited-source/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
+  await expect(page.getByRole('article', { name: 'Flashcard' })).toBeVisible();
+
+  const sessionCards = await getStudySessionCardsBySource('new-limited-source');
+  expect(sessionCards.length).toBe(4);
 });

--- a/test/tests/study-page.spec.ts
+++ b/test/tests/study-page.spec.ts
@@ -17,6 +17,7 @@ import {
   createSource,
   createDocument,
   getStudySessionCardsBySource,
+  setupTestRateLimits,
 } from '../utils';
 import { v4 as uuidv4 } from 'uuid';
 import { Page } from '@playwright/test';
@@ -1599,6 +1600,7 @@ test('session stats show per-person breakdown when studying with partner', async
 
 test('study session respects source card limit', async ({ page }) => {
   await cleanupDbRecords({ withSources: true });
+  await setupTestRateLimits();
   await createSource({
     id: 'limited-source',
     name: 'Limited Source',
@@ -1632,6 +1634,7 @@ test('study session respects source card limit', async ({ page }) => {
 
 test('study session respects source new card limit', async ({ page }) => {
   await cleanupDbRecords({ withSources: true });
+  await setupTestRateLimits();
   await createSource({
     id: 'new-limited-source',
     name: 'New Limited Source',

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -43,6 +43,8 @@ export async function createSource(params: {
   sourceType?: string;
   bookmarkedPage?: number | null;
   bookmarkedDocumentId?: number | null;
+  cardLimit?: number | null;
+  newCardLimit?: number | null;
 }): Promise<void> {
   const {
     id,
@@ -54,13 +56,15 @@ export async function createSource(params: {
     sourceType = 'PDF',
     bookmarkedPage = null,
     bookmarkedDocumentId = null,
+    cardLimit = null,
+    newCardLimit = null,
   } = params;
 
   await withDbConnection(async (client) => {
     await client.query(
-      `INSERT INTO learn_language.sources (id, name, start_page, language_level, card_type, format_type, source_type, bookmarked_page, bookmarked_document_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
-      [id, name, startPage, languageLevel, cardType, formatType, sourceType, bookmarkedPage, bookmarkedDocumentId]
+      `INSERT INTO learn_language.sources (id, name, start_page, language_level, card_type, format_type, source_type, bookmarked_page, bookmarked_document_id, card_limit, new_card_limit)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+      [id, name, startPage, languageLevel, cardType, formatType, sourceType, bookmarkedPage, bookmarkedDocumentId, cardLimit, newCardLimit]
     );
   });
 }
@@ -112,6 +116,8 @@ export async function getSource(id: string): Promise<{
   sourceType: string | null;
   bookmarkedPage: number | null;
   bookmarkedDocumentId: number | null;
+  cardLimit: number | null;
+  newCardLimit: number | null;
 } | null> {
   return withDbConnection(async (client) => {
     const result = await client.query(
@@ -119,7 +125,9 @@ export async function getSource(id: string): Promise<{
               language_level as "languageLevel", card_type as "cardType",
               format_type as "formatType", source_type as "sourceType",
               bookmarked_page as "bookmarkedPage",
-              bookmarked_document_id as "bookmarkedDocumentId"
+              bookmarked_document_id as "bookmarkedDocumentId",
+              card_limit as "cardLimit",
+              new_card_limit as "newCardLimit"
        FROM learn_language.sources
        WHERE id = $1`,
       [id]

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -167,6 +167,7 @@ export async function cleanupDbRecords({ withSources }: { withSources?: boolean 
       cardType: 'VOCABULARY',
       formatType: 'WORD_LIST_WITH_FORMS_AND_EXAMPLES',
       bookmarkedPage: 9,
+      cardLimit: 50
     });
     await createDocument({
       sourceId: 'goethe-a1',


### PR DESCRIPTION
## Summary
This PR introduces per-source configuration for card limits, allowing users to control the maximum number of cards in a study session and limit the number of new cards studied per session.

## Key Changes
- **Backend Entity & Database**: Added `cardLimit` and `newCardLimit` fields to the `Source` entity with corresponding database columns
- **Study Session Logic**: 
  - Replaced hardcoded `SESSION_CARD_LIMIT` constant with dynamic per-source `cardLimit`
  - Implemented `applyNewCardLimit()` method to limit new cards while including all review cards
  - Updated card assignment logic to use source-specific limits
- **API Layer**: Updated `SourceRequest` and `SourceResponse` DTOs to include the new limit fields
- **Controller**: Modified source creation and update endpoints to persist the new limit values
- **Frontend**: 
  - Added form fields for "Card Limit" and "New Card Limit" in the source dialog
  - Updated TypeScript types to include the new properties
  - Set default values of 50 for both limits with validation requiring minimum value of 1

## Implementation Details
- The `applyNewCardLimit()` method separates cards into review and new categories, applies the limit only to new cards, and preserves all review cards regardless of the limit
- When `cardLimit` is null, the system defaults to `Integer.MAX_VALUE` to maintain backward compatibility
- The new card limit is only applied if explicitly set on the source; otherwise all due cards are used

https://claude.ai/code/session_018Yf8N3UB69CbFrWqqARS9h