### PR TITLE
Drop circular foreign key constraint from sources table

### DIFF
--- a/server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -874,3 +874,10 @@ databaseChangeLog:
                   ) stats
               ) rs ON true;
               CREATE UNIQUE INDEX IF NOT EXISTS card_view_id_idx ON card_view (id)
+  - changeSet:
+      id: 23-drop-circular-fk-sources-bookmarked-document
+      author: mucsi96
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: sources
+            constraintName: sources_bookmarked_document_fkey


### PR DESCRIPTION
## Summary
This change removes a circular foreign key constraint from the `sources` table that references the `bookmarked_document` table.

## Changes
- Dropped the `sources_bookmarked_document_fkey` foreign key constraint from the `sources` table via a new database migration

## Details
This migration addresses a circular dependency in the database schema by removing the foreign key constraint between `sources` and `bookmarked_document` tables. This change improves the database design and may resolve issues related to cascading deletes or constraint violations when managing these related entities.

https://claude.ai/code/session_0159gLMu9PBwez3FvX7JPGtk