### PR TITLE
Refactor ffmpeg process handling into reusable service

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/AudioController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/AudioController.java
@@ -53,12 +53,12 @@ public class AudioController {
             "Daily audio generation limit of " + dailyLimit + " reached");
       }
     }
-    String uuid = UUID.randomUUID().toString();
-    String filePath = "audio/%s.mp3".formatted(uuid);
+    final String uuid = UUID.randomUUID().toString();
+    final String filePath = "audio/%s.mp3".formatted(uuid);
 
-    byte[] data = audioService.generateAudio(audioSource.getInput(), audioSource.getVoice(), audioSource.getModel(), audioSource.getLanguage(), audioSource.getContext(), Boolean.TRUE.equals(audioSource.getSingleWord()));
-    fileStorageService.saveFile(BinaryData.fromBytes(data), filePath);
-    audioTrimService.trimSilence(filePath);
+    final byte[] data = audioService.generateAudio(audioSource.getInput(), audioSource.getVoice(), audioSource.getModel(), audioSource.getLanguage(), audioSource.getContext(), Boolean.TRUE.equals(audioSource.getSingleWord()));
+    final byte[] trimmed = audioTrimService.trimSilence(data);
+    fileStorageService.saveFile(BinaryData.fromBytes(trimmed), filePath);
 
     return AudioData.builder()
         .id(uuid)

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/AudioTrimService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/AudioTrimService.java
@@ -16,8 +16,10 @@ public class AudioTrimService {
   public byte[] trimSilence(byte[] audioData) throws IOException {
     return ffmpegService.process(List.of(
         "ffmpeg", "-y", "-loglevel", "error",
+        "-f", "s16le", "-ar", "44100", "-ac", "1",
         "-i", "pipe:0",
         "-af", "silenceremove=start_periods=1:start_threshold=-50dB:stop_periods=-1:stop_threshold=-50dB",
+        "-c:a", "libmp3lame", "-b:a", "128k",
         "-f", "mp3",
         "pipe:1"
     ), audioData);

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/AudioTrimService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/AudioTrimService.java
@@ -1,52 +1,25 @@
 package io.github.mucsi96.learnlanguage.service;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
+import java.io.IOException;
+import java.util.List;
 
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class AudioTrimService {
 
-  private final FileStorageService fileStorageService;
+  private final FfmpegService ffmpegService;
 
-  public void trimSilence(String fileKey) {
-    try {
-      final Path filePath = fileStorageService.resolveFilePath(fileKey);
-      final long originalSize = Files.size(filePath);
-      final Path tempOutput = filePath.resolveSibling(filePath.getFileName() + ".trimmed.mp3");
-
-      try {
-        final Process process = new ProcessBuilder(
-            "ffmpeg", "-y",
-            "-i", filePath.toString(),
-            "-af", "silenceremove=start_periods=1:start_threshold=-50dB:stop_periods=-1:stop_threshold=-50dB",
-            tempOutput.toString()
-        ).redirectErrorStream(true).redirectOutput(ProcessBuilder.Redirect.DISCARD).start();
-
-        final int exitCode = process.waitFor();
-
-        if (exitCode != 0) {
-          return;
-        }
-
-        Files.move(tempOutput, filePath, StandardCopyOption.REPLACE_EXISTING);
-        final long trimmedSize = Files.size(filePath);
-        log.info("Trimmed audio silence: {} -> {} bytes ({})", originalSize, trimmedSize, fileKey);
-      } finally {
-        Files.deleteIfExists(tempOutput);
-      }
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      log.warn("Interrupted while trimming silence from {}", fileKey, e);
-    } catch (Exception e) {
-      log.warn("Failed to trim silence from {}", fileKey, e);
-    }
+  public byte[] trimSilence(byte[] audioData) throws IOException {
+    return ffmpegService.process(List.of(
+        "ffmpeg", "-y", "-loglevel", "error",
+        "-i", "pipe:0",
+        "-af", "silenceremove=start_periods=1:start_threshold=-50dB:stop_periods=-1:stop_threshold=-50dB",
+        "-f", "mp3",
+        "pipe:1"
+    ), audioData);
   }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/FfmpegService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/FfmpegService.java
@@ -1,0 +1,63 @@
+package io.github.mucsi96.learnlanguage.service;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class FfmpegService {
+    private static final int TIMEOUT_SECONDS = 30;
+
+    public byte[] process(List<String> args, byte[] input) throws IOException {
+        final ProcessBuilder pb = new ProcessBuilder(args);
+        final Process process = pb.start();
+        boolean success = false;
+
+        try {
+            final byte[][] stderr = {null};
+            final Thread stderrReader = Thread.ofVirtual().start(() -> {
+                try {
+                    stderr[0] = process.getErrorStream().readAllBytes();
+                } catch (IOException e) {
+                    throw new RuntimeException("Failed to read ffmpeg stderr", e);
+                }
+            });
+
+            final Thread writer = Thread.ofVirtual().start(() -> {
+                try (final var os = process.getOutputStream()) {
+                    os.write(input);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            final byte[] result = process.getInputStream().readAllBytes();
+            writer.join();
+            stderrReader.join();
+
+            final boolean finished = process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (!finished) {
+                throw new IOException("ffmpeg timed out after %d seconds".formatted(TIMEOUT_SECONDS));
+            }
+
+            final int exitCode = process.exitValue();
+            if (exitCode != 0) {
+                throw new IOException("ffmpeg exited with code %d: %s".formatted(
+                    exitCode, new String(stderr[0], StandardCharsets.UTF_8)));
+            }
+
+            success = true;
+            return result;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("ffmpeg process interrupted", e);
+        } finally {
+            if (!success) {
+                process.destroyForcibly();
+            }
+        }
+    }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageResizeService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageResizeService.java
@@ -1,17 +1,20 @@
 package io.github.mucsi96.learnlanguage.service;
 
+import java.io.IOException;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
 
 @Service
+@RequiredArgsConstructor
 public class ImageResizeService {
-    private static final int TIMEOUT_SECONDS = 30;
+
+    private final FfmpegService ffmpegService;
 
     public byte[] resizeImage(byte[] imageData, int width, int height) throws IOException {
-        final ProcessBuilder pb = new ProcessBuilder(
+        return ffmpegService.process(List.of(
             "ffmpeg", "-y", "-loglevel", "error",
             "-i", "pipe:0",
             "-vf", "scale=%d:%d:force_original_aspect_ratio=decrease".formatted(width, height),
@@ -19,52 +22,6 @@ public class ImageResizeService {
             "-frames:v", "1",
             "-f", "webp",
             "pipe:1"
-        );
-        final Process process = pb.start();
-        boolean success = false;
-
-        try {
-            final byte[][] stderr = {null};
-            final Thread stderrReader = Thread.ofVirtual().start(() -> {
-                try {
-                    stderr[0] = process.getErrorStream().readAllBytes();
-                } catch (IOException e) {
-                    throw new RuntimeException("Failed to read ffmpeg stderr", e);
-                }
-            });
-
-            final Thread writer = Thread.ofVirtual().start(() -> {
-                try (final var os = process.getOutputStream()) {
-                    os.write(imageData);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            });
-
-            final byte[] result = process.getInputStream().readAllBytes();
-            writer.join();
-            stderrReader.join();
-
-            final boolean finished = process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            if (!finished) {
-                throw new IOException("ffmpeg timed out after %d seconds".formatted(TIMEOUT_SECONDS));
-            }
-
-            final int exitCode = process.exitValue();
-            if (exitCode != 0) {
-                throw new IOException("ffmpeg exited with code %d: %s".formatted(
-                    exitCode, new String(stderr[0], StandardCharsets.UTF_8)));
-            }
-
-            success = true;
-            return result;
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IOException("ffmpeg process interrupted", e);
-        } finally {
-            if (!success) {
-                process.destroyForcibly();
-            }
-        }
+        ), imageData);
     }
 }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -45,7 +45,7 @@ spring:
       api-key: ${eleven-labs-api-key}
       tts:
         options:
-          output-format: mp3_44100_128
+          output-format: pcm_44100
 server:
   servlet:
     context-path: /api


### PR DESCRIPTION
## Summary
Extracted common ffmpeg process handling logic into a dedicated `FfmpegService` to eliminate code duplication and improve maintainability. Updated `ImageResizeService` and `AudioTrimService` to use this new service, and refactored audio trimming to work with in-memory byte arrays instead of file operations.

## Key Changes
- **New `FfmpegService`**: Created a reusable service that handles ffmpeg process execution with proper error handling, timeout management, and virtual thread usage for I/O operations
- **`ImageResizeService` refactoring**: Removed 43 lines of duplicated ffmpeg process code and now delegates to `FfmpegService`
- **`AudioTrimService` refactoring**: 
  - Removed file-based operations and file storage dependency
  - Changed `trimSilence()` to accept and return byte arrays instead of file keys
  - Now uses `FfmpegService` for process execution
  - Simplified error handling by delegating to the service
- **`AudioController` update**: Updated to work with the new in-memory audio trimming API
- **Audio format change**: Updated ElevenLabs output format from `mp3_44100_128` to `pcm_44100` to support the new trimming pipeline

## Implementation Details
- `FfmpegService` uses virtual threads for concurrent I/O operations (reading stderr, writing input, reading output)
- Implements 30-second timeout for ffmpeg processes with proper cleanup on failure
- Provides detailed error messages including ffmpeg exit codes and stderr output
- All services now follow a consistent pattern for ffmpeg invocation

https://claude.ai/code/session_01Q2G1ckdoXbUoee7shRsnBD