### PR TITLE
Move skip card functionality from grading buttons to card actions menu

### DIFF
--- a/client/src/app/shared/card-actions/card-actions.component.html
+++ b/client/src/app/shared/card-actions/card-actions.component.html
@@ -9,6 +9,12 @@
   </button>
 
   <mat-menu #actionsMenu="matMenu">
+    @if (sourceId()) {
+      <button mat-menu-item (click)="skipCard()">
+        <mat-icon>skip_next</mat-icon>
+        <span>Skip Card</span>
+      </button>
+    }
     <button mat-menu-item (click)="openVoiceSelection()">
       <mat-icon>record_voice_over</mat-icon>
       <span>Voice Selection</span>

--- a/client/src/app/shared/card-actions/card-actions.component.ts
+++ b/client/src/app/shared/card-actions/card-actions.component.ts
@@ -11,6 +11,7 @@ import { AudioData } from '../types/audio-generation.types';
 import { VoiceSelectionDialogComponent } from '../voice-selection-dialog/voice-selection-dialog.component';
 import { LanguageTexts } from '../../parser/types';
 import { CardResourceLike } from '../types/card-resource.types';
+import { StudySessionService } from '../../study-session.service';
 
 @Component({
   selector: 'app-card-actions',
@@ -26,11 +27,13 @@ import { CardResourceLike } from '../types/card-resource.types';
 })
 export class CardActionsComponent {
   card = input<CardResourceLike>();
+  sourceId = input<string | null>(null);
   languageTexts = input<LanguageTexts[]>([]);
   cardProcessed = output<void>();
 
   private readonly http = inject(HttpClient);
   private readonly dialog = inject(MatDialog);
+  private readonly studySessionService = inject(StudySessionService);
 
   isFlagged(): boolean {
     return this.card()?.value()?.flagged ?? false;
@@ -51,6 +54,19 @@ export class CardActionsComponent {
       this.card()?.reload?.();
     } catch (error) {
       console.error('Error toggling card flag:', error);
+    }
+  }
+
+  async skipCard() {
+    const cardData = this.card()?.value();
+    const sourceId = this.sourceId();
+    if (!cardData || !sourceId) return;
+
+    try {
+      await this.studySessionService.skipCard(sourceId, cardData.id);
+      this.cardProcessed.emit();
+    } catch (error) {
+      console.error('Error skipping card:', error);
     }
   }
 

--- a/client/src/app/shared/card-grading-buttons/card-grading-buttons.component.css
+++ b/client/src/app/shared/card-grading-buttons/card-grading-buttons.component.css
@@ -30,20 +30,12 @@
   background-color: #dc3545 !important;
 }
 
-.grade-skip {
-  background-color: #6c757d !important;
-}
-
 .grade-correct {
   background-color: #28a745 !important;
 }
 
 .grade-incorrect:hover {
   background-color: #bb2d3b !important;
-}
-
-.grade-skip:hover {
-  background-color: #565e64 !important;
 }
 
 .grade-correct:hover {

--- a/client/src/app/shared/card-grading-buttons/card-grading-buttons.component.html
+++ b/client/src/app/shared/card-grading-buttons/card-grading-buttons.component.html
@@ -1,8 +1,4 @@
 <div class="grading-buttons">
-  <button mat-raised-button class="grade-skip" (click)="skipCard()">
-    <mat-icon>skip_next</mat-icon>
-    Skip
-  </button>
   <button mat-raised-button class="grade-incorrect" (click)="gradeCard('Again')">
     <mat-icon>close</mat-icon>
     Incorrect

--- a/client/src/app/shared/card-grading-buttons/card-grading-buttons.component.ts
+++ b/client/src/app/shared/card-grading-buttons/card-grading-buttons.component.ts
@@ -2,7 +2,6 @@ import { Component, inject, input, output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { FsrsGradingService } from '../../fsrs-grading.service';
-import { StudySessionService } from '../../study-session.service';
 import { CardResourceLike } from '../types/card-resource.types';
 
 type Grade = 'Again' | 'Good';
@@ -16,13 +15,11 @@ type Grade = 'Again' | 'Good';
 })
 export class CardGradingButtonsComponent {
   card = input<CardResourceLike | null>(null);
-  sourceId = input<string | null>(null);
   learningPartnerId = input<number | null>(null);
   reviewDuration = input<number | null>(null);
   cardProcessed = output<void>();
 
   private readonly fsrsGradingService = inject(FsrsGradingService);
-  private readonly studySessionService = inject(StudySessionService);
 
   async gradeCard(grade: Grade) {
     const cardData = this.card()?.value();
@@ -34,19 +31,6 @@ export class CardGradingButtonsComponent {
       this.cardProcessed.emit();
     } catch (error) {
       console.error('Error grading card:', error);
-    }
-  }
-
-  async skipCard() {
-    const cardData = this.card()?.value();
-    const sourceId = this.sourceId();
-    if (!cardData || !sourceId) return;
-
-    try {
-      await this.studySessionService.skipCard(sourceId, cardData.id);
-      this.cardProcessed.emit();
-    } catch (error) {
-      console.error('Error skipping card:', error);
     }
   }
 }

--- a/client/src/app/study/learn-card/learn-card.component.html
+++ b/client/src/app/study/learn-card/learn-card.component.html
@@ -97,7 +97,6 @@
   <div class="grading-buttons-container" [class.hidden]="!isRevealed()">
     <app-card-grading-buttons
       [card]="cardResource"
-      [sourceId]="sourceId()"
       [learningPartnerId]="currentTurn().partnerId"
       [reviewDuration]="reviewDuration()"
       (cardProcessed)="onCardProcessed()">
@@ -105,6 +104,7 @@
     <div class="grading-row-actions">
       <app-card-actions
         [card]="cardResource"
+        [sourceId]="sourceId()"
         [languageTexts]="languageTexts()"
         (cardProcessed)="onCardProcessed()">
       </app-card-actions>

--- a/test/tests/study-page.spec.ts
+++ b/test/tests/study-page.spec.ts
@@ -182,7 +182,6 @@ test('study page revealed state', async ({ page }) => {
   const imageContent = await getImageContent(flashcard.getByRole('img', { name: 'Wann fährt der Zug ab?' }));
   expect(await getImageColor(page, imageContent)).toBe('green');
   await expect(page.getByRole('button', { name: 'Incorrect' })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Skip' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Correct', exact: true })).toBeVisible();
 });
 
@@ -559,7 +558,6 @@ test('grading buttons visibility after reveal', async ({ page }) => {
 
   // Initially grading buttons should not be visible
   await expect(page.getByRole('button', { name: 'Incorrect' })).not.toBeVisible();
-  await expect(page.getByRole('button', { name: 'Skip' })).not.toBeVisible();
   await expect(page.getByRole('button', { name: 'Correct', exact: true })).not.toBeVisible();
 
   // Click to reveal the card
@@ -567,7 +565,6 @@ test('grading buttons visibility after reveal', async ({ page }) => {
 
   // Now grading buttons should be visible
   await expect(page.getByRole('button', { name: 'Incorrect' })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Skip' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Correct', exact: true })).toBeVisible();
 });
 
@@ -754,7 +751,8 @@ test('skip button moves card to back without grading', async ({ page }) => {
 
   await flashcard.getByRole('heading', { name: 'átugrani' }).click();
 
-  await page.getByRole('button', { name: 'Skip' }).click();
+  await page.getByRole('button', { name: 'Card actions' }).click();
+  await page.getByRole('menuitem', { name: 'Skip Card' }).click();
 
   await expect(flashcard.getByRole('heading', { name: 'várni' })).toBeVisible();
   await expect(flashcard.getByRole('heading', { name: 'átugrani' })).not.toBeVisible();


### PR DESCRIPTION
## Summary
Refactored the skip card functionality by moving it from the card grading buttons component to the card actions menu. This improves the UI/UX by separating the skip action (which doesn't grade the card) from the grading actions (Correct/Incorrect).

## Key Changes
- **Moved skip card logic**: Transferred `skipCard()` method from `CardGradingButtonsComponent` to `CardActionsComponent`
- **Updated component inputs**: Moved `sourceId` input from `CardGradingButtonsComponent` to `CardActionsComponent` where it's now needed
- **Updated template**: 
  - Removed skip button from grading buttons template
  - Added skip card menu item to card actions menu (conditionally shown when `sourceId` is available)
- **Removed unused imports**: Removed `StudySessionService` import from `CardGradingButtonsComponent` since it's no longer needed there
- **Cleaned up styles**: Removed `.grade-skip` and `.grade-skip:hover` CSS classes that are no longer used
- **Updated parent component**: Modified `LearnCardComponent` to pass `sourceId` to `CardActionsComponent` instead of `CardGradingButtonsComponent`
- **Updated tests**: Modified test expectations to reflect the new skip button location in the card actions menu

## Implementation Details
- The skip card functionality remains unchanged; it still calls `StudySessionService.skipCard()` and emits `cardProcessed` event
- The skip button is now only visible when `sourceId` is provided (conditional rendering in template)
- This change logically separates card grading actions from other card management actions

https://claude.ai/code/session_01KvhFwk6paj5JMf9X8mHNRt