### PR TITLE
Add safety checks and refactor file cleanup logic

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/FileStorageCleanupService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/FileStorageCleanupService.java
@@ -83,6 +83,11 @@ public class FileStorageCleanupService {
     final var allFiles = fileStorageService.listFiles("audio");
     final var cards = cardRepository.findAll();
 
+    if (!allFiles.isEmpty() && cards.isEmpty()) {
+      log.warn("Skipping audio cleanup: {} audio files exist but no cards found in database", allFiles.size());
+      return;
+    }
+
     final Set<String> referencedPaths = cards.stream()
         .map(Card::getData)
         .flatMap(data -> Optional.ofNullable(data.getAudio())
@@ -92,17 +97,24 @@ public class FileStorageCleanupService {
         .map(id -> "audio/%s.mp3".formatted(id))
         .collect(Collectors.toSet());
 
-    allFiles.stream()
+    final var unreferencedFiles = allFiles.stream()
         .filter(file -> !referencedPaths.contains(file))
-        .forEach(file -> {
-          log.info("Deleting unreferenced audio file: {}", file);
-          fileStorageService.deleteFile(file);
-        });
+        .toList();
+
+    unreferencedFiles.forEach(file -> {
+      log.info("Deleting unreferenced audio file: {}", file);
+      fileStorageService.deleteFile(file);
+    });
   }
 
   private void cleanupImageFiles() {
     final var allFiles = fileStorageService.listFiles("images");
     final var cards = cardRepository.findAll();
+
+    if (!allFiles.isEmpty() && cards.isEmpty()) {
+      log.warn("Skipping image cleanup: {} image files exist but no cards found in database", allFiles.size());
+      return;
+    }
 
     final Set<String> referencedPaths = cards.stream()
         .map(Card::getData)
@@ -116,17 +128,25 @@ public class FileStorageCleanupService {
         .map(id -> "images/%s.webp".formatted(id))
         .collect(Collectors.toSet());
 
-    allFiles.stream()
+    final var unreferencedFiles = allFiles.stream()
         .filter(file -> !referencedPaths.contains(file))
-        .forEach(file -> {
-          log.info("Deleting unreferenced image file: {}", file);
-          fileStorageService.deleteFile(file);
-        });
+        .toList();
+
+    unreferencedFiles.forEach(file -> {
+      log.info("Deleting unreferenced image file: {}", file);
+      fileStorageService.deleteFile(file);
+    });
   }
 
   private void cleanupSourceDocuments() {
     final var allFiles = fileStorageService.listFiles("sources");
     final var documents = documentRepository.findAllWithSource();
+
+    if (!allFiles.isEmpty() && documents.isEmpty()) {
+      log.warn("Skipping source document cleanup: {} source files exist but no documents found in database",
+          allFiles.size());
+      return;
+    }
 
     final Set<String> referencedPaths = documents.stream()
         .map(doc -> doc.getPageNumber() == null
@@ -134,11 +154,13 @@ public class FileStorageCleanupService {
             : "sources/%s/%s".formatted(doc.getSource().getId(), doc.getFileName()))
         .collect(Collectors.toSet());
 
-    allFiles.stream()
+    final var unreferencedFiles = allFiles.stream()
         .filter(file -> !referencedPaths.contains(file))
-        .forEach(file -> {
-          log.info("Deleting unreferenced source document: {}", file);
-          fileStorageService.deleteFile(file);
-        });
+        .toList();
+
+    unreferencedFiles.forEach(file -> {
+      log.info("Deleting unreferenced source document: {}", file);
+      fileStorageService.deleteFile(file);
+    });
   }
 }


### PR DESCRIPTION
## Summary
Enhanced the file storage cleanup service with safety checks to prevent accidental deletion of files when the database is empty, and refactored the cleanup logic for better readability.

## Key Changes
- **Added safety guards**: Each cleanup method (`cleanupAudioFiles`, `cleanupImageFiles`, `cleanupSourceDocuments`) now checks if files exist but no corresponding database records are found, and skips cleanup with a warning log if this condition is detected
- **Refactored stream operations**: Changed from directly chaining `forEach` on filtered streams to first collecting unreferenced files into a list, then iterating over them. This improves code readability and allows for easier debugging
- **Improved logging**: Added warning-level logs when cleanup is skipped due to missing database records, helping operators understand why cleanup didn't run

## Implementation Details
- The safety check pattern is consistent across all three cleanup methods: `if (!allFiles.isEmpty() && records.isEmpty()) { log.warn(...); return; }`
- Unreferenced files are now collected into a `final var` before deletion, making the intent clearer and the code more maintainable
- No functional changes to the actual deletion logic, only structural improvements to prevent data loss scenarios

https://claude.ai/code/session_018qCT9ehqSCdKW96AXLJ6JX