### PR TITLE
Wrap flaky database assertions in expect().toPass()

### DIFF
--- a/test/tests/study-page.spec.ts
+++ b/test/tests/study-page.spec.ts
@@ -489,8 +489,10 @@ test('unflag card via context menu', async ({ page }) => {
   await expect(page.getByRole('menuitem', { name: 'Remove Flag' })).toBeVisible();
   await page.getByRole('menuitem', { name: 'Remove Flag' }).click();
 
-  const card = await getCardFromDb('erste-elso');
-  expect(card.flagged).toBe(false);
+  await expect(async () => {
+    const card = await getCardFromDb('erste-elso');
+    expect(card.flagged).toBe(false);
+  }).toPass();
 });
 
 test('edit card button navigation', async ({ page }) => {

--- a/test/tests/study-page.spec.ts
+++ b/test/tests/study-page.spec.ts
@@ -1419,11 +1419,11 @@ test('all color keys map to correct grades', async ({ page }) => {
   await expect(page.getByRole('button', { name: 'Incorrect' })).toBeVisible();
   await pressRemoteKey(page, 'Green');
 
-  await expect(flashcard).toBeVisible();
-
-  const reviewLogs = await getReviewLogs();
-  const ratings = reviewLogs.map((log) => log.rating).sort();
-  expect(ratings).toEqual([1, 3]);
+  await expect(async () => {
+    const reviewLogs = await getReviewLogs();
+    const ratings = reviewLogs.map((log) => log.rating).sort();
+    expect(ratings).toEqual([1, 3]);
+  }).toPass();
 });
 
 test('color keys do not grade when card is not revealed', async ({ page }) => {


### PR DESCRIPTION
## Summary
This PR wraps two flaky test assertions that depend on database state in Playwright's `expect().toPass()` utility to handle timing issues and race conditions.

## Key Changes
- **unflag card via context menu test**: Wrapped the card flagged state assertion in `expect().toPass()` to retry until the database reflects the unflagged state
- **all color keys map to correct grades test**: Wrapped the review logs rating assertion in `expect().toPass()` to retry until the database contains the expected review records
- Removed unnecessary `await expect(flashcard).toBeVisible()` assertion that was unrelated to the test's purpose

## Implementation Details
These changes use Playwright's built-in retry mechanism for async operations, which automatically retries the wrapped function until the assertion passes or the timeout is exceeded. This is a more robust approach than adding arbitrary delays and handles the inherent timing issues when assertions depend on asynchronous database operations.

https://claude.ai/code/session_019J7tXrGqH14ePi4wAcAGAU