### PR TITLE
Remove client-side image resizing and simplify image endpoint

### DIFF
--- a/client/src/app/shared/image-resource.service.ts
+++ b/client/src/app/shared/image-resource.service.ts
@@ -135,7 +135,7 @@ export class ImageResourceService {
   private async fetchImageUrl(imageId: string) {
     return await fetchAsset(
       this.http,
-      `/api/image/${imageId}?width=600&height=600`
+      `/api/image/${imageId}`
     );
   }
 }

--- a/client/src/app/study/learn-grammar-card/learn-grammar-card.component.ts
+++ b/client/src/app/study/learn-grammar-card/learn-grammar-card.component.ts
@@ -74,7 +74,7 @@ export class LearnGrammarCardComponent {
                 ...image,
                 url: await fetchAsset(
                   this.http,
-                  `/api/image/${image.id}?width=1200&height=1200`
+                  `/api/image/${image.id}`
                 ),
               };
             },

--- a/client/src/app/study/learn-speech-card/learn-speech-card.component.ts
+++ b/client/src/app/study/learn-speech-card/learn-speech-card.component.ts
@@ -61,7 +61,7 @@ export class LearnSpeechCardComponent {
                 ...image,
                 url: await fetchAsset(
                   this.http,
-                  `/api/image/${image.id}?width=1200&height=1200`
+                  `/api/image/${image.id}`
                 ),
               };
             },

--- a/client/src/app/study/learn-vocabulary-card/learn-vocabulary-card.component.ts
+++ b/client/src/app/study/learn-vocabulary-card/learn-vocabulary-card.component.ts
@@ -85,7 +85,7 @@ export class LearnVocabularyCardComponent {
                 ...image,
                 url: await fetchAsset(
                   this.http,
-                  `/api/image/${image.id}?width=1200&height=1200`
+                  `/api/image/${image.id}`
                 ),
               };
             },

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ImageController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ImageController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -74,16 +73,12 @@ public class ImageController {
 
   @GetMapping(value = "/image/{id}", produces = IMAGE_WEBP_VALUE)
   @PreAuthorize("hasAuthority('APPROLE_DeckReader') and hasAuthority('SCOPE_readDecks')")
-  public ResponseEntity<byte[]> getCachedResizedImage(
-      @PathVariable String id,
-      @RequestParam int width,
-      @RequestParam int height) throws Exception {
+  public ResponseEntity<byte[]> getImage(@PathVariable String id) {
     final String filePath = "images/%s.webp".formatted(id);
-    final byte[] original = fileStorageService.fetchFile(filePath).toBytes();
-    final byte[] resized = imageResizeService.resizeImage(original, width, height);
+    final byte[] data = fileStorageService.fetchFile(filePath).toBytes();
     return ResponseEntity.ok()
         .contentType(IMAGE_WEBP)
         .header("Cache-Control", "public, max-age=31536000, immutable")
-        .body(resized);
+        .body(data);
   }
 }


### PR DESCRIPTION
## Summary
This PR removes client-side image resizing logic by eliminating width and height query parameters from the image API endpoint. The server now returns images without resizing, and clients receive the original cached images.

## Key Changes
- **Backend**: Simplified `ImageController.getImage()` method to remove image resizing functionality
  - Removed `@RequestParam` annotations for width and height parameters
  - Removed call to `imageResizeService.resizeImage()`
  - Removed unused import for `RequestParam`
  - Renamed method from `getCachedResizedImage` to `getImage` for clarity

- **Frontend**: Updated all image fetch calls to remove query parameters
  - `ImageResourceService`: Removed `?width=600&height=600` from image endpoint
  - `LearnGrammarCardComponent`: Removed `?width=1200&height=1200` from image endpoint
  - `LearnSpeechCardComponent`: Removed `?width=1200&height=1200` from image endpoint
  - `LearnVocabularyCardComponent`: Removed `?width=1200&height=1200` from image endpoint

## Implementation Details
The image endpoint now serves pre-cached WebP images without any runtime resizing. The server response includes appropriate cache headers (`Cache-Control: public, max-age=31536000, immutable`) to leverage browser caching for these immutable assets.

https://claude.ai/code/session_019RZzjM5vcYNfoaBV7dvi6m