### PR TITLE
Add image format detection and improve ffmpeg logging

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/AudioTrimService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/AudioTrimService.java
@@ -18,8 +18,8 @@ public class AudioTrimService {
         "ffmpeg", "-y", "-loglevel", "error",
         "-f", "s16le", "-ar", "44100", "-ac", "1",
         "-i", "pipe:0",
-        "-af", "silenceremove=start_periods=1:start_threshold=-50dB:stop_periods=-1:stop_threshold=-50dB",
-        "-c:a", "libmp3lame", "-b:a", "128k",
+        "-filter:a", "silenceremove=start_periods=1:start_threshold=-50dB:stop_periods=-1:stop_threshold=-50dB",
+        "-codec:a", "libmp3lame", "-b:a", "128k",
         "-f", "mp3",
         "pipe:1"
     ), audioData);

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/FfmpegService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/FfmpegService.java
@@ -52,15 +52,19 @@ public class FfmpegService {
             final int exitCode = process.exitValue();
             final String stderrOutput = new String(stderr[0], StandardCharsets.UTF_8);
 
+            if (exitCode != 0) {
+                log.error("ffmpeg exit code: {}, output size: {} bytes", exitCode, result.length);
+                if (!stderrOutput.isBlank()) {
+                    log.error("ffmpeg stderr: {}", stderrOutput);
+                }
+                throw new IOException("ffmpeg exited with code %d: %s".formatted(exitCode, stderrOutput));
+            }
+
             if (!stderrOutput.isBlank()) {
                 log.info("ffmpeg stderr: {}", stderrOutput);
             }
 
             log.info("ffmpeg exit code: {}, output size: {} bytes", exitCode, result.length);
-
-            if (exitCode != 0) {
-                throw new IOException("ffmpeg exited with code %d: %s".formatted(exitCode, stderrOutput));
-            }
 
             success = true;
             return result;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/FfmpegService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/FfmpegService.java
@@ -7,11 +7,17 @@ import java.util.concurrent.TimeUnit;
 
 import org.springframework.stereotype.Service;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Service
 public class FfmpegService {
     private static final int TIMEOUT_SECONDS = 30;
 
     public byte[] process(List<String> args, byte[] input) throws IOException {
+        log.info("Running ffmpeg command: {}", String.join(" ", args));
+        log.info("Input size: {} bytes", input.length);
+
         final ProcessBuilder pb = new ProcessBuilder(args);
         final Process process = pb.start();
         boolean success = false;
@@ -44,9 +50,16 @@ public class FfmpegService {
             }
 
             final int exitCode = process.exitValue();
+            final String stderrOutput = new String(stderr[0], StandardCharsets.UTF_8);
+
+            if (!stderrOutput.isBlank()) {
+                log.info("ffmpeg stderr: {}", stderrOutput);
+            }
+
+            log.info("ffmpeg exit code: {}, output size: {} bytes", exitCode, result.length);
+
             if (exitCode != 0) {
-                throw new IOException("ffmpeg exited with code %d: %s".formatted(
-                    exitCode, new String(stderr[0], StandardCharsets.UTF_8)));
+                throw new IOException("ffmpeg exited with code %d: %s".formatted(exitCode, stderrOutput));
             }
 
             success = true;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageResizeService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageResizeService.java
@@ -14,14 +14,45 @@ public class ImageResizeService {
     private final FfmpegService ffmpegService;
 
     public byte[] resizeImage(byte[] imageData, int width, int height) throws IOException {
+        final String inputFormat = detectImageFormat(imageData);
         return ffmpegService.process(List.of(
             "ffmpeg", "-y", "-loglevel", "error",
-            "-i", "pipe:0",
+            "-f", inputFormat, "-i", "pipe:0",
             "-vf", "scale=%d:%d:force_original_aspect_ratio=decrease".formatted(width, height),
             "-c:v", "libwebp", "-quality", "75",
             "-frames:v", "1",
             "-f", "webp",
             "pipe:1"
         ), imageData);
+    }
+
+    private static String detectImageFormat(byte[] data) {
+        if (data.length >= 4
+                && data[0] == (byte) 0x89
+                && data[1] == (byte) 'P'
+                && data[2] == (byte) 'N'
+                && data[3] == (byte) 'G') {
+            return "png_pipe";
+        }
+        if (data.length >= 3
+                && data[0] == (byte) 0xFF
+                && data[1] == (byte) 0xD8
+                && data[2] == (byte) 0xFF) {
+            return "jpeg_pipe";
+        }
+        if (data.length >= 12
+                && data[0] == (byte) 'R'
+                && data[1] == (byte) 'I'
+                && data[2] == (byte) 'F'
+                && data[3] == (byte) 'F'
+                && data[8] == (byte) 'W'
+                && data[9] == (byte) 'E'
+                && data[10] == (byte) 'B'
+                && data[11] == (byte) 'P') {
+            return "webp_pipe";
+        }
+        throw new IllegalArgumentException(
+                "Unsupported image format: unable to detect from magic bytes (first byte: 0x%02X, size: %d)"
+                        .formatted(data.length > 0 ? data[0] & 0xFF : 0, data.length));
     }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageResizeService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageResizeService.java
@@ -18,8 +18,8 @@ public class ImageResizeService {
         return ffmpegService.process(List.of(
             "ffmpeg", "-y", "-loglevel", "error",
             "-f", inputFormat, "-i", "pipe:0",
-            "-vf", "scale=%d:%d:force_original_aspect_ratio=decrease".formatted(width, height),
-            "-c:v", "libwebp", "-quality", "75",
+            "-filter:v", "scale=%d:%d:force_original_aspect_ratio=decrease".formatted(width, height),
+            "-codec:v", "libwebp", "-quality", "75",
             "-frames:v", "1",
             "-f", "webp",
             "pipe:1"


### PR DESCRIPTION
## Summary
Enhanced the image resize service to explicitly detect input image formats before processing, and added comprehensive logging to the ffmpeg service for better debugging and monitoring.

## Key Changes
- **Image Format Detection**: Added `detectImageFormat()` method to identify PNG, JPEG, and WebP formats by their magic bytes before passing to ffmpeg
  - Detects PNG (0x89504E47), JPEG (0xFFD8FF), and WebP (RIFF...WEBP) signatures
  - Throws `IllegalArgumentException` with diagnostic information for unsupported formats
  - Passes detected format to ffmpeg via `-f` flag for more reliable processing

- **Enhanced Logging**: Added structured logging to `FfmpegService` using Slf4j
  - Logs the complete ffmpeg command being executed
  - Logs input data size for debugging
  - Logs ffmpeg stderr output when present
  - Logs exit code and output size for each operation
  - Improves troubleshooting by capturing ffmpeg diagnostic information

## Implementation Details
- Magic byte detection uses byte-by-byte comparison for reliability
- Format detection happens before ffmpeg invocation to fail fast on unsupported formats
- Error messages include the first byte and total size for easier format identification
- Logging is informational level to avoid noise while providing useful diagnostics

https://claude.ai/code/session_01PFqemcwCfH1rbyGUjWKDRZ