### PR TITLE
Switch ElevenLabs TTS output format from PCM to MP3

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/FfmpegService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/FfmpegService.java
@@ -34,7 +34,6 @@ public class FfmpegService {
         Files.createDirectories(outputFile.getParent());
         run(audioData,
                 "ffmpeg", "-y", "-loglevel", "error",
-                "-f", "s16le", "-ar", "44100", "-ac", "1",
                 "-i", INPUT,
                 "-filter:a",
                 "silenceremove=start_periods=1:start_threshold=-50dB:stop_periods=-1:stop_threshold=-50dB",

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -45,7 +45,7 @@ spring:
       api-key: ${eleven-labs-api-key}
       tts:
         options:
-          output-format: pcm_44100
+          output-format: mp3_44100_128
 server:
   servlet:
     context-path: /api


### PR DESCRIPTION
## Summary
Updated the ElevenLabs text-to-speech configuration to use MP3 format instead of PCM, and removed the corresponding PCM input format specification from FFmpeg processing.

## Key Changes
- Changed ElevenLabs TTS output format from `pcm_44100` to `mp3_44100_128` in application configuration
- Removed FFmpeg input format flags (`-f s16le -ar 44100 -ac 1`) from the silence trimming operation, as they are no longer needed for MP3 input

## Implementation Details
Since ElevenLabs now outputs MP3 format directly, FFmpeg can automatically detect the audio format without explicit input format specification. This simplifies the audio processing pipeline while maintaining the same 44.1kHz sample rate and 128kbps bitrate for the MP3 output.

https://claude.ai/code/session_01L998D3nvuoiMYoAxvTwybZ