### PR TITLE
claude/apply-skeleton-patterns-6JiJM

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -29,7 +29,67 @@ jobs:
       - name: Install Playwright browsers
         working-directory: test
         run: npx playwright install chromium --with-deps
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build server image
+        uses: docker/build-push-action@v6
+        with:
+          context: server
+          load: true
+          tags: localhost/learn-language-server:test
+          cache-from: type=gha,scope=server
+          cache-to: type=gha,mode=max,scope=server
+      - name: Build client image
+        uses: docker/build-push-action@v6
+        with:
+          context: client
+          load: true
+          tags: localhost/learn-language-client:test
+          cache-from: type=gha,scope=client
+          cache-to: type=gha,mode=max,scope=client
+      - name: Build mock OpenAI image
+        uses: docker/build-push-action@v6
+        with:
+          context: mock_openai_server
+          load: true
+          tags: localhost/learn-language-mock-openai:test
+          cache-from: type=gha,scope=mock-openai
+          cache-to: type=gha,mode=max,scope=mock-openai
+      - name: Build mock Google AI image
+        uses: docker/build-push-action@v6
+        with:
+          context: mock_google_ai_server
+          load: true
+          tags: localhost/learn-language-mock-google-ai:test
+          cache-from: type=gha,scope=mock-google-ai
+          cache-to: type=gha,mode=max,scope=mock-google-ai
+      - name: Build mock ElevenLabs image
+        uses: docker/build-push-action@v6
+        with:
+          context: mock_elevenlabs_server
+          load: true
+          tags: localhost/learn-language-mock-elevenlabs:test
+          cache-from: type=gha,scope=mock-elevenlabs
+          cache-to: type=gha,mode=max,scope=mock-elevenlabs
+      - name: Build mock Anthropic image
+        uses: docker/build-push-action@v6
+        with:
+          context: mock_anthropic_server
+          load: true
+          tags: localhost/learn-language-mock-anthropic:test
+          cache-from: type=gha,scope=mock-anthropic
+          cache-to: type=gha,mode=max,scope=mock-anthropic
+      - name: Load images into Podman
+        run: |
+          docker save localhost/learn-language-server:test | podman load
+          docker save localhost/learn-language-client:test | podman load
+          docker save localhost/learn-language-mock-openai:test | podman load
+          docker save localhost/learn-language-mock-google-ai:test | podman load
+          docker save localhost/learn-language-mock-elevenlabs:test | podman load
+          docker save localhost/learn-language-mock-anthropic:test | podman load
       - name: Setup test environment and start pod
+        env:
+          SKIP_BUILD: "1"
         run: scripts/pod_up.sh
       - name: Run Playwright tests
         working-directory: test
@@ -68,14 +128,24 @@ jobs:
         with:
           prefix: 'server'
           src: server
+      - name: Set up Docker Buildx
+        if: steps.get_next_version.outputs.hasNextVersion == 'true'
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         if: steps.get_next_version.outputs.hasNextVersion == 'true'
-        run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | podman login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin docker.io
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push server image
         if: steps.get_next_version.outputs.hasNextVersion == 'true'
-        run: |
-          podman build -t docker.io/${{ secrets.DOCKERHUB_USERNAME }}/learn-language-server:${{ steps.get_next_version.outputs.version }} server
-          podman push docker.io/${{ secrets.DOCKERHUB_USERNAME }}/learn-language-server:${{ steps.get_next_version.outputs.version }}
+        uses: docker/build-push-action@v6
+        with:
+          context: server
+          push: true
+          tags: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/learn-language-server:${{ steps.get_next_version.outputs.version }}
+          cache-from: type=gha,scope=server
+          cache-to: type=gha,mode=max,scope=server
       - name: Create release
         if: steps.get_next_version.outputs.hasNextVersion == 'true'
         uses: softprops/action-gh-release@v2
@@ -102,14 +172,24 @@ jobs:
         with:
           prefix: 'client'
           src: client
+      - name: Set up Docker Buildx
+        if: steps.get_next_version.outputs.hasNextVersion == 'true'
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         if: steps.get_next_version.outputs.hasNextVersion == 'true'
-        run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | podman login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin docker.io
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push client image
         if: steps.get_next_version.outputs.hasNextVersion == 'true'
-        run: |
-          podman build -t docker.io/${{ secrets.DOCKERHUB_USERNAME }}/learn-language-client:${{ steps.get_next_version.outputs.version }} client
-          podman push docker.io/${{ secrets.DOCKERHUB_USERNAME }}/learn-language-client:${{ steps.get_next_version.outputs.version }}
+        uses: docker/build-push-action@v6
+        with:
+          context: client
+          push: true
+          tags: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/learn-language-client:${{ steps.get_next_version.outputs.version }}
+          cache-from: type=gha,scope=client
+          cache-to: type=gha,mode=max,scope=client
       - name: Create release
         if: steps.get_next_version.outputs.hasNextVersion == 'true'
         uses: softprops/action-gh-release@v2

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,7 @@
         "esbenp.prettier-vscode",
         "anweber.vscode-httpyac",
         "ms-kubernetes-tools.vscode-kubernetes-tools",
-        "ms-playwright.playwright"
+        "ms-playwright.playwright",
+        "dreamcatcher45.podmanager"
     ]
 }

--- a/scripts/pod_up.sh
+++ b/scripts/pod_up.sh
@@ -9,14 +9,18 @@ echo "Cleaning up test storage directories..."
 rm -rf "$PROJECT_DIR/test/storage"
 mkdir -p "$PROJECT_DIR/test/storage"
 
-echo "Building container images..."
-podman build -t localhost/learn-language-server:test "$PROJECT_DIR/server" &
-podman build -t localhost/learn-language-client:test "$PROJECT_DIR/client" &
-podman build -t localhost/learn-language-mock-openai:test "$PROJECT_DIR/mock_openai_server" &
-podman build -t localhost/learn-language-mock-google-ai:test "$PROJECT_DIR/mock_google_ai_server" &
-podman build -t localhost/learn-language-mock-elevenlabs:test "$PROJECT_DIR/mock_elevenlabs_server" &
-podman build -t localhost/learn-language-mock-anthropic:test "$PROJECT_DIR/mock_anthropic_server" &
-wait
+if [ "${SKIP_BUILD:-}" = "1" ]; then
+  echo "Skipping image build (SKIP_BUILD=1)..."
+else
+  echo "Building container images..."
+  podman build -t localhost/learn-language-server:test "$PROJECT_DIR/server" &
+  podman build -t localhost/learn-language-client:test "$PROJECT_DIR/client" &
+  podman build -t localhost/learn-language-mock-openai:test "$PROJECT_DIR/mock_openai_server" &
+  podman build -t localhost/learn-language-mock-google-ai:test "$PROJECT_DIR/mock_google_ai_server" &
+  podman build -t localhost/learn-language-mock-elevenlabs:test "$PROJECT_DIR/mock_elevenlabs_server" &
+  podman build -t localhost/learn-language-mock-anthropic:test "$PROJECT_DIR/mock_anthropic_server" &
+  wait
+fi
 
 echo "Cleaning up existing pod..."
 podman kube down "$PROJECT_DIR/test/test-pod.yaml" 2>/dev/null || true

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,11 +3,12 @@ FROM docker.io/library/maven:3-eclipse-temurin-21 AS build
 
 WORKDIR /workspace
 
-# Copy POM and source code
+# Copy POM and download dependencies (cached separately from source)
 COPY pom.xml ./
-COPY src ./src
+RUN mvn dependency:go-offline -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
-# Build the application
+# Copy source code and build
+COPY src ./src
 RUN mvn package -DskipTests -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
 # Extract dependencies for layer caching


### PR DESCRIPTION
Use Docker Buildx with GitHub Actions cache for all image builds in CI,
replacing direct podman build commands. Add SKIP_BUILD support to pod_up.sh
and separate Maven dependency download from source build in server Dockerfile
for better layer caching.

https://claude.ai/code/session_01Mcy3Zn6SmBYyhxk12YdQVU