### PR TITLE
Add OID environment variable to test pod configuration

### DIFF
--- a/test/test-pod.yaml
+++ b/test/test-pod.yaml
@@ -124,6 +124,8 @@ spec:
           value: Test User
         - name: PREFERRED_USERNAME
           value: test-user@example.com
+        - name: OID
+          value: 00000000-0000-0000-0000-000000000001
         - name: ROLES
           value: DeckReader,DeckCreator
         - name: SCP


### PR DESCRIPTION
## Summary
Added the OID (Object Identifier) environment variable to the test pod specification to support testing scenarios that require a unique identifier.

## Changes
- Added `OID` environment variable with value `00000000-0000-0000-0000-000000000001` to the pod's container environment configuration
- The variable is positioned between `PREFERRED_USERNAME` and `ROLES` environment variables

## Details
This change enables the test pod to include an OID value that can be used for testing identity or object identification functionality. The UUID format (`00000000-0000-0000-0000-000000000001`) follows standard conventions for test/placeholder identifiers.

https://claude.ai/code/session_01KG3sRLF7mLqWBSPGVp2Uoy