### PR TITLE
Add ability to move ready cards back to draft status

### DIFF
--- a/client/src/app/cards-table/cards-table.component.html
+++ b/client/src/app/cards-table/cards-table.component.html
@@ -169,7 +169,7 @@
           class="action-fab"
           (click)="markSelectedAsDraft()"
         >
-          <mat-icon>drafts</mat-icon>
+          <mat-icon>restore</mat-icon>
           Move {{ selectedCount() }} to draft
         </button>
       }

--- a/client/src/app/cards-table/cards-table.component.html
+++ b/client/src/app/cards-table/cards-table.component.html
@@ -163,6 +163,15 @@
           <mat-icon>check_circle</mat-icon>
           Mark {{ selectedCount() }} as known
         </button>
+        <button
+          mat-fab
+          extended
+          class="action-fab"
+          (click)="markSelectedAsDraft()"
+        >
+          <mat-icon>drafts</mat-icon>
+          Move {{ selectedCount() }} to draft
+        </button>
       }
       @if (selectionContainsDrafts() && sourceCardType()) {
         <button

--- a/client/src/app/cards-table/cards-table.component.ts
+++ b/client/src/app/cards-table/cards-table.component.ts
@@ -445,6 +445,32 @@ export class CardsTableComponent {
     this.dueCardsService.refetchDueCounts();
   }
 
+  async markSelectedAsDraft(): Promise<void> {
+    const ids = this.selectedIds();
+    if (ids.length === 0) return;
+
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+      width: '300px',
+      data: {
+        message: `Are you sure you want to move ${ids.length} card(s) back to draft?`,
+      },
+    });
+
+    const result = await firstValueFrom(dialogRef.afterClosed());
+    if (!result) return;
+
+    await this.cardsTableService.markCardsAsDraft(ids);
+    this.snackBar.open(`${ids.length} card(s) moved to draft`, 'Close', {
+      duration: 3000,
+      verticalPosition: 'top',
+    });
+    this.selectedIds.set([]);
+    this.refreshGrid();
+    this.sourcesService.refetchSources();
+    this.dueCardsService.refetchDueCounts();
+    this.inReviewCardsService.refetchCards();
+  }
+
   async deleteSelected(): Promise<void> {
     const ids = this.selectedIds();
     if (ids.length === 0) return;

--- a/client/src/app/cards-table/cards-table.service.ts
+++ b/client/src/app/cards-table/cards-table.service.ts
@@ -127,6 +127,12 @@ export class CardsTableService {
     );
   }
 
+  async markCardsAsDraft(cardIds: readonly string[]): Promise<void> {
+    await firstValueFrom(
+      this.http.put('/api/cards/mark-draft', cardIds)
+    );
+  }
+
   async deleteCards(cardIds: readonly string[]): Promise<void> {
     await firstValueFrom(
       this.http.delete('/api/cards', { body: cardIds })

--- a/test/tests/cards-table-page.spec.ts
+++ b/test/tests/cards-table-page.spec.ts
@@ -157,6 +157,40 @@ test('marks selected cards as known', async ({ page }) => {
   await expect(page.getByText('1 card(s) marked as known')).toBeVisible();
 });
 
+test('moves selected ready cards back to draft', async ({ page }) => {
+  await createCard({
+    cardId: 'move-draft-card',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: { word: 'zurück', type: 'ADVERB', translation: { en: 'back' } },
+    readiness: 'READY',
+  });
+
+  await page.goto('/sources/goethe-a1/cards');
+
+  await expect(async () => {
+    const rows = await getGridData(page.getByRole('grid'));
+    expect(rows[0]).toEqual(expect.objectContaining({ ID: 'move-draft-card' }));
+  }).toPass();
+
+  await page
+    .getByRole('row', { name: /move-draft-card/ })
+    .getByRole('checkbox')
+    .click();
+
+  await page.getByRole('button', { name: /Move 1 to draft/ }).click();
+  await page.getByRole('button', { name: 'Yes' }).click();
+
+  await expect(page.getByText('1 card(s) moved to draft')).toBeVisible();
+
+  await withDbConnection(async (client) => {
+    const result = await client.query(
+      `SELECT readiness FROM learn_language.cards WHERE id = 'move-draft-card'`
+    );
+    expect(result.rows[0].readiness).toBe('DRAFT');
+  });
+});
+
 test('displays review information in table', async ({ page }) => {
   await createCard({
     cardId: 'reviewed-card',
@@ -1327,6 +1361,7 @@ test('draft cards hide delete audio and mark as known actions', async ({ page })
   await expect(page.getByRole('button', { name: /Delete 1/ })).toBeVisible();
   await expect(page.getByRole('button', { name: /Delete audio/ })).not.toBeVisible();
   await expect(page.getByRole('button', { name: /Mark .* as known/ })).not.toBeVisible();
+  await expect(page.getByRole('button', { name: /Move .* to draft/ })).not.toBeVisible();
 });
 
 test('draft cards do not navigate on row click', async ({ page }) => {


### PR DESCRIPTION
## Summary
This PR adds functionality to move selected ready cards back to draft status in the cards table. Users can now revert cards from READY state to DRAFT state through a new "Move to draft" action button.

## Key Changes
- **Backend API**: Added `markCardsAsDraft()` method in `CardsTableService` to call the `/api/cards/mark-draft` endpoint
- **Component Logic**: Implemented `markSelectedAsDraft()` method in `CardsTableComponent` that:
  - Displays a confirmation dialog before moving cards
  - Updates card readiness status to DRAFT
  - Shows success notification with card count
  - Refreshes grid and related data (sources, due cards, in-review cards)
- **UI**: Added "Move to draft" action button with drafts icon in the cards table toolbar
- **Visibility Rules**: The "Move to draft" button is hidden when only draft cards are selected (consistent with other action visibility rules)
- **Tests**: Added comprehensive test coverage including:
  - Test for moving ready cards back to draft with database verification
  - Test ensuring the button is hidden for draft-only selections

## Implementation Details
- The action follows the same pattern as existing bulk actions (mark as known, delete)
- Uses Angular Material dialog for confirmation
- Displays snackbar notification with action count
- Properly clears selection after operation completes
- Refreshes all relevant data sources to keep UI in sync

https://claude.ai/code/session_01Ga4aheHtBRA7iKEcViubCM