### PR TITLE
Add AI-powered duplicate detection for bulk card creation

### DIFF
--- a/client/src/app/bulk-card-creation-fab/bulk-card-creation-fab.component.html
+++ b/client/src/app/bulk-card-creation-fab/bulk-card-creation-fab.component.html
@@ -5,11 +5,19 @@
     color="primary"
     class="bulk-create-fab"
     (click)="startBulkCreation()"
-    [disabled]="bulkCreationService.isProcessing() || isImageLimitExceeded()"
+    [disabled]="bulkCreationService.isProcessing() || isImageLimitExceeded() || isDetectingDuplicates()"
     [matTooltip]="imageLimitTooltip()"
     aria-label="Create cards in bulk"
   >
-    <mat-icon>add_circle</mat-icon>
-    Create {{ candidatesService.candidatesCount() }} Cards
+    @if (isDetectingDuplicates()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      <mat-icon>add_circle</mat-icon>
+    }
+    @if (isDetectingDuplicates()) {
+      Checking duplicates...
+    } @else {
+      Create {{ candidatesService.candidatesCount() }} Cards
+    }
   </button>
 }

--- a/client/src/app/bulk-card-creation-fab/bulk-card-creation-fab.component.ts
+++ b/client/src/app/bulk-card-creation-fab/bulk-card-creation-fab.component.ts
@@ -111,6 +111,8 @@ export class BulkCardCreationFabComponent {
             this.candidatesService.ignoreItem(ignoredId);
           }
         }
+      } catch (error) {
+        console.error('Duplicate detection failed; continuing without it.', error);
       } finally {
         this.isDetectingDuplicates.set(false);
       }

--- a/client/src/app/bulk-card-creation-fab/bulk-card-creation-fab.component.ts
+++ b/client/src/app/bulk-card-creation-fab/bulk-card-creation-fab.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, computed } from '@angular/core';
+import { Component, inject, computed, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -6,7 +6,9 @@ import { MatBadgeModule } from '@angular/material/badge';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { CommonModule } from '@angular/common';
+import { firstValueFrom } from 'rxjs';
 import { CardCandidatesService } from '../card-candidates.service';
 import { BulkCardCreationService } from '../bulk-card-creation.service';
 import { BulkCreationProgressDialogComponent } from '../bulk-creation-progress-dialog/bulk-creation-progress-dialog.component';
@@ -17,11 +19,17 @@ import { SourcesService } from '../sources.service';
 import { InReviewCardsService } from '../in-review-cards.service';
 import { ENVIRONMENT_CONFIG } from '../environment/environment.config';
 import { fetchJson } from '../utils/fetchJson';
+import { DuplicateDetectionService } from '../duplicate-detection.service';
+import {
+  DuplicateReviewDialogComponent,
+  DuplicateReviewDialogData,
+  DuplicateReviewDialogResult,
+} from '../duplicate-review-dialog/duplicate-review-dialog.component';
 
 @Component({
   selector: 'app-bulk-card-creation-fab',
   standalone: true,
-  imports: [CommonModule, MatButtonModule, MatIconModule, MatBadgeModule, MatTooltipModule],
+  imports: [CommonModule, MatButtonModule, MatIconModule, MatBadgeModule, MatTooltipModule, MatProgressSpinnerModule],
   templateUrl: './bulk-card-creation-fab.component.html',
   styleUrl: './bulk-card-creation-fab.component.css',
 })
@@ -37,6 +45,8 @@ export class BulkCardCreationFabComponent {
   private readonly sourcesService = inject(SourcesService);
   private readonly inReviewCardsService = inject(InReviewCardsService);
   private readonly environmentConfig = inject(ENVIRONMENT_CONFIG);
+  readonly duplicateDetectionService = inject(DuplicateDetectionService);
+  readonly isDetectingDuplicates = signal(false);
 
   readonly totalImagesNeeded = computed(() => {
     const candidates = this.candidatesService.candidates();
@@ -76,6 +86,41 @@ export class BulkCardCreationFabComponent {
 
     const selections = this.pageService.getAllExtractionSelections();
 
+    if (this.duplicateDetectionService.isAvailable()) {
+      this.isDetectingDuplicates.set(true);
+      try {
+        const duplicates = await this.duplicateDetectionService.detectDuplicates(
+          candidates.map((candidate) => candidate.id)
+        );
+        if (duplicates.length > 0) {
+          const dialogRef = this.dialog.open<
+            DuplicateReviewDialogComponent,
+            DuplicateReviewDialogData,
+            DuplicateReviewDialogResult
+          >(DuplicateReviewDialogComponent, {
+            data: { duplicates },
+            disableClose: true,
+            maxWidth: '100vw',
+            maxHeight: '100vh',
+          });
+          const result = await firstValueFrom(dialogRef.afterClosed());
+          if (!result?.proceed) {
+            return;
+          }
+          for (const ignoredId of result.ignoredIds) {
+            this.candidatesService.ignoreItem(ignoredId);
+          }
+        }
+      } finally {
+        this.isDetectingDuplicates.set(false);
+      }
+    }
+
+    const finalCandidates = this.candidatesService.candidates();
+    if (finalCandidates.length === 0) {
+      return;
+    }
+
     this.bulkCreationService.clearProgress();
 
     this.dialog.open(BulkCreationProgressDialogComponent, {
@@ -87,7 +132,7 @@ export class BulkCardCreationFabComponent {
     const result = await this.bulkCreationService.createCardsInBulk(
       {
         kind: 'extractedItems',
-        items: candidates,
+        items: finalCandidates,
         sourceId: selectedSource.sourceId,
         pageNumber: selectedSource.pageNumber,
       },

--- a/client/src/app/bulk-card-creation-fab/bulk-card-creation-fab.component.ts
+++ b/client/src/app/bulk-card-creation-fab/bulk-card-creation-fab.component.ts
@@ -107,9 +107,9 @@ export class BulkCardCreationFabComponent {
           if (!result?.proceed) {
             return;
           }
-          for (const ignoredId of result.ignoredIds) {
-            this.candidatesService.ignoreItem(ignoredId);
-          }
+          result.ignoredIds.forEach((ignoredId) =>
+            this.candidatesService.ignoreItem(ignoredId)
+          );
         }
       } catch (error) {
         console.error('Duplicate detection failed; continuing without it.', error);

--- a/client/src/app/duplicate-detection.service.ts
+++ b/client/src/app/duplicate-detection.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { fetchJson } from './utils/fetchJson';
+import { MultiModelService } from './multi-model.service';
+import { ENVIRONMENT_CONFIG } from './environment/environment.config';
+
+export interface PotentialDuplicate {
+  newId: string;
+  existingId: string;
+  reason: string;
+}
+
+interface DuplicateDetectionResponse {
+  duplicates: PotentialDuplicate[];
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DuplicateDetectionService {
+  private readonly http = inject(HttpClient);
+  private readonly multiModelService = inject(MultiModelService);
+  private readonly environmentConfig = inject(ENVIRONMENT_CONFIG);
+
+  isAvailable(): boolean {
+    const enabledModels =
+      this.environmentConfig.enabledModelsByOperation['duplicate_detection'] ?? [];
+    const primary =
+      this.environmentConfig.primaryModelByOperation['duplicate_detection'];
+    return Boolean(primary && enabledModels.includes(primary));
+  }
+
+  async detectDuplicates(newIds: string[]): Promise<PotentialDuplicate[]> {
+    if (newIds.length === 0 || !this.isAvailable()) {
+      return [];
+    }
+
+    const result = await this.multiModelService.call<DuplicateDetectionResponse>(
+      'duplicate_detection',
+      (model: string, headers?: Record<string, string>) =>
+        fetchJson<DuplicateDetectionResponse>(
+          this.http,
+          `/api/duplicate-detection?model=${model}`,
+          {
+            body: { newIds },
+            method: 'POST',
+            headers,
+          }
+        )
+    );
+
+    return result.duplicates ?? [];
+  }
+}

--- a/client/src/app/duplicate-review-dialog/duplicate-review-dialog.component.css
+++ b/client/src/app/duplicate-review-dialog/duplicate-review-dialog.component.css
@@ -1,0 +1,70 @@
+.dialog-content {
+  min-width: 28rem;
+  max-width: 36rem;
+}
+
+.intro {
+  margin: 0 0 1rem 0;
+}
+
+.duplicate-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.duplicate-entry {
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: 0.5rem;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.duplicate-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.new-id {
+  font-weight: 600;
+  font-family: var(--mat-sys-body-medium-font, monospace);
+}
+
+.match-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.match-entry {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  padding: 0.25rem 0 0.25rem 0.5rem;
+  border-left: 2px solid var(--mat-sys-outline-variant);
+}
+
+.match-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.existing-id {
+  font-family: var(--mat-sys-body-medium-font, monospace);
+  font-size: 0.9rem;
+}
+
+.reason {
+  font-size: 0.85rem;
+  color: var(--mat-sys-on-surface-variant);
+}

--- a/client/src/app/duplicate-review-dialog/duplicate-review-dialog.component.html
+++ b/client/src/app/duplicate-review-dialog/duplicate-review-dialog.component.html
@@ -1,0 +1,49 @@
+<h2 mat-dialog-title>Potential Duplicates</h2>
+
+<mat-dialog-content class="dialog-content">
+  <p class="intro">
+    AI flagged {{ groupedDuplicates().length }} new card(s) as potential duplicates of
+    existing cards. Review each match and choose which new cards to skip.
+  </p>
+
+  <ul class="duplicate-list" role="list" aria-label="Potential duplicate matches">
+    @for (group of groupedDuplicates(); track group.newId) {
+      <li class="duplicate-entry" role="listitem" [attr.aria-label]="'Potential duplicate ' + group.newId">
+        <div class="duplicate-header">
+          <span class="new-id" aria-label="New card ID">{{ group.newId }}</span>
+          <mat-checkbox
+            [checked]="isSkipped(group.newId)"
+            (change)="toggleSkip(group.newId, $event.checked)"
+          >
+            Skip new card {{ group.newId }}
+          </mat-checkbox>
+        </div>
+        <ul class="match-list" role="list" aria-label="Matching existing cards">
+          @for (match of group.matches; track match.existingId) {
+            <li class="match-entry" role="listitem">
+              <mat-icon aria-hidden="true">compare_arrows</mat-icon>
+              <div class="match-info">
+                <span class="existing-id" aria-label="Existing card ID">{{ match.existingId }}</span>
+                <span class="reason">{{ match.reason }}</span>
+              </div>
+            </li>
+          }
+        </ul>
+      </li>
+    }
+  </ul>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()" aria-label="Cancel bulk creation">
+    Cancel
+  </button>
+  <button
+    mat-flat-button
+    color="primary"
+    (click)="proceed()"
+    aria-label="Continue with bulk creation"
+  >
+    Continue ({{ groupedDuplicates().length - skippedCount() }} new, {{ skippedCount() }} skipped)
+  </button>
+</mat-dialog-actions>

--- a/client/src/app/duplicate-review-dialog/duplicate-review-dialog.component.ts
+++ b/client/src/app/duplicate-review-dialog/duplicate-review-dialog.component.ts
@@ -39,17 +39,22 @@ export class DuplicateReviewDialogComponent {
   readonly data = inject<DuplicateReviewDialogData>(MAT_DIALOG_DATA);
   private readonly skippedNewIds = signal<Set<string>>(new Set());
 
-  readonly groupedDuplicates = computed(() => {
-    const groups = new Map<string, PotentialDuplicate[]>();
-    for (const duplicate of this.data.duplicates) {
-      const existing = groups.get(duplicate.newId) ?? [];
-      groups.set(duplicate.newId, [...existing, duplicate]);
-    }
-    return [...groups.entries()].map(([newId, matches]) => ({
-      newId,
-      matches,
-    }));
-  });
+  readonly groupedDuplicates = computed(() =>
+    this.data.duplicates
+      .reduce<{ newId: string; matches: PotentialDuplicate[] }[]>(
+        (groups, duplicate) => {
+          const existing = groups.find((group) => group.newId === duplicate.newId);
+          return existing
+            ? groups.map((group) =>
+                group.newId === duplicate.newId
+                  ? { ...group, matches: [...group.matches, duplicate] }
+                  : group
+              )
+            : [...groups, { newId: duplicate.newId, matches: [duplicate] }];
+        },
+        []
+      )
+  );
 
   readonly skippedCount = computed(() => this.skippedNewIds().size);
 

--- a/client/src/app/duplicate-review-dialog/duplicate-review-dialog.component.ts
+++ b/client/src/app/duplicate-review-dialog/duplicate-review-dialog.component.ts
@@ -1,0 +1,82 @@
+import { Component, computed, inject, signal } from '@angular/core';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { PotentialDuplicate } from '../duplicate-detection.service';
+
+export interface DuplicateReviewDialogData {
+  duplicates: PotentialDuplicate[];
+}
+
+export interface DuplicateReviewDialogResult {
+  proceed: boolean;
+  ignoredIds: string[];
+}
+
+@Component({
+  selector: 'app-duplicate-review-dialog',
+  standalone: true,
+  imports: [
+    MatDialogModule,
+    MatButtonModule,
+    MatIconModule,
+    MatListModule,
+    MatCheckboxModule,
+  ],
+  templateUrl: './duplicate-review-dialog.component.html',
+  styleUrl: './duplicate-review-dialog.component.css',
+})
+export class DuplicateReviewDialogComponent {
+  private readonly dialogRef = inject(
+    MatDialogRef<DuplicateReviewDialogComponent, DuplicateReviewDialogResult>
+  );
+  readonly data = inject<DuplicateReviewDialogData>(MAT_DIALOG_DATA);
+  private readonly skippedNewIds = signal<Set<string>>(new Set());
+
+  readonly groupedDuplicates = computed(() => {
+    const groups = new Map<string, PotentialDuplicate[]>();
+    for (const duplicate of this.data.duplicates) {
+      const existing = groups.get(duplicate.newId) ?? [];
+      groups.set(duplicate.newId, [...existing, duplicate]);
+    }
+    return [...groups.entries()].map(([newId, matches]) => ({
+      newId,
+      matches,
+    }));
+  });
+
+  readonly skippedCount = computed(() => this.skippedNewIds().size);
+
+  isSkipped(newId: string): boolean {
+    return this.skippedNewIds().has(newId);
+  }
+
+  toggleSkip(newId: string, skip: boolean): void {
+    this.skippedNewIds.update((current) => {
+      const next = new Set(current);
+      if (skip) {
+        next.add(newId);
+      } else {
+        next.delete(newId);
+      }
+      return next;
+    });
+  }
+
+  proceed(): void {
+    this.dialogRef.close({
+      proceed: true,
+      ignoredIds: [...this.skippedNewIds()],
+    });
+  }
+
+  cancel(): void {
+    this.dialogRef.close({ proceed: false, ignoredIds: [] });
+  }
+}

--- a/mock_google_ai_server/src/chatHandler.ts
+++ b/mock_google_ai_server/src/chatHandler.ts
@@ -252,15 +252,22 @@ export class ChatHandler {
       return null;
     }
 
-    let parsed: { existingIds?: string[]; newIds?: string[] };
-    try {
-      parsed = JSON.parse(userContent);
-    } catch {
-      return createGeminiResponse({ duplicates: [] });
-    }
+    const extractIds = (label: string): string[] => {
+      const re = new RegExp(`"${label}"\\s*:\\s*\\[([^\\]]*)\\]`);
+      const match = userContent.match(re);
+      if (!match) return [];
+      return [...match[1].matchAll(/"([^"\s]+)"/g)].map((m) => m[1]);
+    };
 
-    const existingIds = parsed.existingIds ?? [];
-    const newIds = parsed.newIds ?? [];
+    const existingIds = extractIds('existingIds');
+    const newIds = extractIds('newIds');
+
+    console.log('[mock duplicate detection]', {
+      systemSnippet: systemContent.substring(0, 80),
+      userSnippet: userContent.substring(0, 200),
+      existingIds,
+      newIds,
+    });
 
     const duplicates = newIds.flatMap((newId) => {
       const [newGerman] = newId.split('-');

--- a/mock_google_ai_server/src/chatHandler.ts
+++ b/mock_google_ai_server/src/chatHandler.ts
@@ -244,6 +244,42 @@ export class ChatHandler {
     return null;
   }
 
+  handleDuplicateDetection(request: GeminiRequest): any | null {
+    const systemContent = request.systemInstruction?.parts?.[0]?.text || '';
+    const userContent = getTextContent(request);
+
+    if (!systemContent.includes('duplicate detection assistant')) {
+      return null;
+    }
+
+    let parsed: { existingIds?: string[]; newIds?: string[] };
+    try {
+      parsed = JSON.parse(userContent);
+    } catch {
+      return createGeminiResponse({ duplicates: [] });
+    }
+
+    const existingIds = parsed.existingIds ?? [];
+    const newIds = parsed.newIds ?? [];
+
+    const duplicates = newIds.flatMap((newId) => {
+      const [newGerman] = newId.split('-');
+      return existingIds
+        .filter((existingId) => {
+          if (existingId === newId) return false;
+          const [existingGerman] = existingId.split('-');
+          return newGerman === existingGerman;
+        })
+        .map((existingId) => ({
+          newId,
+          existingId,
+          reason: `Both cards share the German word "${newGerman}" but have different translations.`,
+        }));
+    });
+
+    return createGeminiResponse({ duplicates });
+  }
+
   handleSentenceTranslation(request: GeminiRequest): any | null {
     const systemContent = request.systemInstruction?.parts?.[0]?.text || '';
     const userContent = getTextContent(request);
@@ -306,6 +342,9 @@ export class ChatHandler {
 
     const sentenceTranslationResponse = this.handleSentenceTranslation(request);
     if (sentenceTranslationResponse) return sentenceTranslationResponse;
+
+    const duplicateDetectionResponse = this.handleDuplicateDetection(request);
+    if (duplicateDetectionResponse) return duplicateDetectionResponse;
 
     console.log('Received unprocessed request:', JSON.stringify(request, null, 2));
 

--- a/mock_google_ai_server/src/chatHandler.ts
+++ b/mock_google_ai_server/src/chatHandler.ts
@@ -262,13 +262,6 @@ export class ChatHandler {
     const existingIds = extractIds('existingIds');
     const newIds = extractIds('newIds');
 
-    console.log('[mock duplicate detection]', {
-      systemSnippet: systemContent.substring(0, 80),
-      userSnippet: userContent.substring(0, 200),
-      existingIds,
-      newIds,
-    });
-
     const duplicates = newIds.flatMap((newId) => {
       const [newGerman] = newId.split('-');
       return existingIds

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/DuplicateDetectionController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/DuplicateDetectionController.java
@@ -1,0 +1,28 @@
+package io.github.mucsi96.learnlanguage.controller;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.github.mucsi96.learnlanguage.model.ChatModel;
+import io.github.mucsi96.learnlanguage.model.DuplicateDetectionRequest;
+import io.github.mucsi96.learnlanguage.model.DuplicateDetectionResponse;
+import io.github.mucsi96.learnlanguage.service.DuplicateDetectionService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class DuplicateDetectionController {
+
+    private final DuplicateDetectionService duplicateDetectionService;
+
+    @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
+    @PostMapping("/duplicate-detection")
+    public DuplicateDetectionResponse detect(
+            @RequestBody DuplicateDetectionRequest request,
+            @RequestParam ChatModel model) {
+        return duplicateDetectionService.detectDuplicates(request.getNewIds(), model);
+    }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/DuplicateDetectionRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/DuplicateDetectionRequest.java
@@ -1,0 +1,16 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DuplicateDetectionRequest {
+    private List<String> newIds;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/DuplicateDetectionResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/DuplicateDetectionResponse.java
@@ -1,0 +1,16 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DuplicateDetectionResponse {
+    private List<PotentialDuplicate> duplicates;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/OperationType.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/OperationType.java
@@ -14,6 +14,7 @@ public enum OperationType {
     TRANSLATION("translation", "Translation", true),
     EXTRACTION("extraction", "Extraction", true),
     CLASSIFICATION("classification", "Classification", true),
+    DUPLICATE_DETECTION("duplicate_detection", "Duplicate Detection", true),
     IMAGE_GENERATION("image_generation", "Image Generation", false),
     AUDIO_GENERATION("audio_generation", "Audio Generation", false);
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/PotentialDuplicate.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/PotentialDuplicate.java
@@ -1,0 +1,16 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PotentialDuplicate {
+    private String newId;
+    private String existingId;
+    private String reason;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/DuplicateDetectionService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/DuplicateDetectionService.java
@@ -1,0 +1,78 @@
+package io.github.mucsi96.learnlanguage.service;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+import io.github.mucsi96.learnlanguage.entity.Card;
+import io.github.mucsi96.learnlanguage.model.ChatModel;
+import io.github.mucsi96.learnlanguage.model.DuplicateDetectionResponse;
+import io.github.mucsi96.learnlanguage.model.OperationType;
+import io.github.mucsi96.learnlanguage.repository.CardRepository;
+import lombok.RequiredArgsConstructor;
+import tools.jackson.databind.json.JsonMapper;
+
+@Service
+@RequiredArgsConstructor
+public class DuplicateDetectionService {
+
+    private static final String SYSTEM_PROMPT = """
+            You are a language learning duplicate detection assistant.
+            Each card in our flashcard system has an ID with the format `<germanWord>-<hungarianTranslation>`.
+            Both parts are normalized: lowercased, articles stripped, diacritics removed, spaces replaced with hyphens.
+            For example, the German noun "das Auto" with Hungarian translation "az autó" becomes the ID "auto-auto".
+            The verb "abfahren" translated as "elindulni" becomes "abfahren-elindulni".
+
+            You will receive two arrays of IDs:
+            - "existingIds": IDs of cards already created in the system.
+            - "newIds": IDs of new cards the user wants to create.
+
+            Your task is to find pairs where a new ID is likely a SEMANTIC duplicate of an existing ID.
+            An exact ID match is NOT a duplicate to flag - those are filtered out elsewhere. Focus on near-duplicates such as:
+            - Same German word with different Hungarian translation that means the same thing (e.g. synonyms, alternative wordings).
+            - Different German words that share the same Hungarian translation and likely refer to the same concept (e.g. "wagen-auto" vs "auto-auto" - both translate "car").
+            - Inflected variants or compounds that closely overlap with an existing card.
+
+            Be conservative. Only report a duplicate if you are reasonably confident the user might want to skip the new card because the concept is already covered.
+            Do NOT report a new ID that has no related existing ID.
+
+            Respond with JSON of the form:
+            {
+              "duplicates": [
+                { "newId": "...", "existingId": "...", "reason": "<short explanation in English>" }
+              ]
+            }
+            If a new ID appears similar to multiple existing IDs, emit one entry per pair.
+            If there are no potential duplicates, return an empty array.
+            """;
+
+    private final ChatService chatService;
+    private final CardRepository cardRepository;
+    private final JsonMapper jsonMapper;
+
+    public DuplicateDetectionResponse detectDuplicates(List<String> newIds, ChatModel model) {
+        if (newIds == null || newIds.isEmpty()) {
+            return DuplicateDetectionResponse.builder().duplicates(List.of()).build();
+        }
+
+        final List<String> existingIds = cardRepository.findAll().stream()
+                .map(Card::getId)
+                .toList();
+
+        if (existingIds.isEmpty()) {
+            return DuplicateDetectionResponse.builder().duplicates(List.of()).build();
+        }
+
+        final String userMessage = jsonMapper.writeValueAsString(Map.of(
+                "existingIds", existingIds,
+                "newIds", newIds));
+
+        return chatService.callWithLogging(
+                model,
+                OperationType.DUPLICATE_DETECTION,
+                SYSTEM_PROMPT,
+                userMessage,
+                DuplicateDetectionResponse.class);
+    }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/DuplicateDetectionService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/DuplicateDetectionService.java
@@ -2,6 +2,8 @@ package io.github.mucsi96.learnlanguage.service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
@@ -17,6 +19,8 @@ import tools.jackson.databind.json.JsonMapper;
 @RequiredArgsConstructor
 public class DuplicateDetectionService {
 
+    private static final int PREFIX_LENGTH = 2;
+
     private static final String SYSTEM_PROMPT = """
             You are a language learning duplicate detection assistant.
             Each card in our flashcard system has an ID with the format `<germanWord>-<hungarianTranslation>`.
@@ -25,7 +29,7 @@ public class DuplicateDetectionService {
             The verb "abfahren" translated as "elindulni" becomes "abfahren-elindulni".
 
             You will receive two arrays of IDs:
-            - "existingIds": IDs of cards already created in the system.
+            - "existingIds": IDs of cards already created in the system. These are pre-filtered to share the first %d letters of the German word with at least one of the new IDs.
             - "newIds": IDs of new cards the user wants to create.
 
             Your task is to find pairs where a new ID is likely a SEMANTIC duplicate of an existing ID.
@@ -45,7 +49,7 @@ public class DuplicateDetectionService {
             }
             If a new ID appears similar to multiple existing IDs, emit one entry per pair.
             If there are no potential duplicates, return an empty array.
-            """;
+            """.formatted(PREFIX_LENGTH);
 
     private final ChatService chatService;
     private final CardRepository cardRepository;
@@ -56,8 +60,18 @@ public class DuplicateDetectionService {
             return DuplicateDetectionResponse.builder().duplicates(List.of()).build();
         }
 
+        final Set<String> newIdPrefixes = newIds.stream()
+                .map(DuplicateDetectionService::prefixOf)
+                .filter(prefix -> !prefix.isEmpty())
+                .collect(Collectors.toUnmodifiableSet());
+
+        if (newIdPrefixes.isEmpty()) {
+            return DuplicateDetectionResponse.builder().duplicates(List.of()).build();
+        }
+
         final List<String> existingIds = cardRepository.findAll().stream()
                 .map(Card::getId)
+                .filter(id -> newIdPrefixes.contains(prefixOf(id)))
                 .toList();
 
         if (existingIds.isEmpty()) {
@@ -74,5 +88,12 @@ public class DuplicateDetectionService {
                 SYSTEM_PROMPT,
                 userMessage,
                 DuplicateDetectionResponse.class);
+    }
+
+    private static String prefixOf(String id) {
+        if (id == null || id.isEmpty()) {
+            return "";
+        }
+        return id.substring(0, Math.min(PREFIX_LENGTH, id.length()));
     }
 }

--- a/test/tests/bulk-card-creation.spec.ts
+++ b/test/tests/bulk-card-creation.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../fixtures';
 import {
   createCard,
+  createChatModelSetting,
   createImageModelSetting,
   createSource,
   createRateLimitSetting,
@@ -16,6 +17,15 @@ import {
   setupDefaultImageModelSettings,
   menschenA1GrammarImage,
 } from '../utils';
+
+async function enableDuplicateDetection(): Promise<void> {
+  await createChatModelSetting({
+    modelName: 'gemini-3.1-pro-preview',
+    operationType: 'DUPLICATE_DETECTION',
+    isEnabled: true,
+    isPrimary: true,
+  });
+}
 
 test('bulk create fab appears when words without cards selected', async ({ page }) => {
   await setupDefaultChatModelSettings();
@@ -851,5 +861,127 @@ test('bulk grammar card creation extracts sentences with gaps', async ({ page })
     expect(card2?.data.examples[0].de).toContain('[das]');
     expect(card2?.data.translationModel).toBe('gemini-3.1-pro-preview');
     expect(card2?.data.extractionModel).toBe('gemini-3.1-pro-preview');
+  });
+});
+
+test('ai duplicate detection dialog opens before bulk creation', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await setupDefaultImageModelSettings();
+  await enableDuplicateDetection();
+  await createRateLimitSetting({ key: 'image-per-minute', value: 60 });
+  await createCard({
+    cardId: 'abfahren-elhagyni',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'abfahren',
+      type: 'VERB',
+      translation: { en: 'to leave', hu: 'elhagyni', ch: 'abfahren' },
+      forms: [],
+      examples: [],
+    },
+  });
+
+  await page.goto('/sources');
+  await page.getByRole('article', { name: 'Goethe A1' }).click();
+  await page.getByRole('button', { name: 'Pages' }).click();
+
+  await selectTextRange(page, 'aber', 'Vor der Abfahrt rufe ich an.');
+
+  await page.getByRole('button', { name: 'Create cards in bulk' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Potential Duplicates' })).toBeVisible();
+  await expect(page.getByLabel('New card ID').filter({ hasText: 'abfahren-elindulni' })).toBeVisible();
+  await expect(page.getByLabel('Existing card ID').filter({ hasText: 'abfahren-elhagyni' })).toBeVisible();
+});
+
+test('ai duplicate detection skip excludes card from creation', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await setupDefaultImageModelSettings();
+  await enableDuplicateDetection();
+  await createRateLimitSetting({ key: 'image-per-minute', value: 60 });
+  await createCard({
+    cardId: 'abfahren-elhagyni',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'abfahren',
+      type: 'VERB',
+      translation: { en: 'to leave', hu: 'elhagyni', ch: 'abfahren' },
+      forms: [],
+      examples: [],
+    },
+  });
+
+  await page.goto('/sources');
+  await page.getByRole('article', { name: 'Goethe A1' }).click();
+  await page.getByRole('button', { name: 'Pages' }).click();
+
+  await selectTextRange(page, 'aber', 'Vor der Abfahrt rufe ich an.');
+
+  await page.getByRole('button', { name: 'Create cards in bulk' }).click();
+
+  await page
+    .getByRole('checkbox', { name: 'Skip new card abfahren-elindulni' })
+    .check();
+  await page
+    .getByRole('button', { name: 'Continue with bulk creation' })
+    .click();
+
+  await expect(page.getByRole('heading', { name: 'Creating Cards' })).toBeVisible();
+  await expect(
+    page.getByRole('dialog').getByRole('button', { name: 'Close' })
+  ).toBeVisible();
+
+  await withDbConnection(async (client) => {
+    const result = await client.query(
+      "SELECT id FROM learn_language.cards WHERE id IN ('abfahren-elindulni', 'abfahrt-indulas', 'aber-de')"
+    );
+    const ids = result.rows.map((row) => row.id);
+    expect(ids).toContain('aber-de');
+    expect(ids).toContain('abfahrt-indulas');
+    expect(ids).not.toContain('abfahren-elindulni');
+  });
+});
+
+test('ai duplicate detection cancel aborts bulk creation', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await setupDefaultImageModelSettings();
+  await enableDuplicateDetection();
+  await createRateLimitSetting({ key: 'image-per-minute', value: 60 });
+  await createCard({
+    cardId: 'abfahren-elhagyni',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'abfahren',
+      type: 'VERB',
+      translation: { en: 'to leave', hu: 'elhagyni', ch: 'abfahren' },
+      forms: [],
+      examples: [],
+    },
+  });
+
+  await page.goto('/sources');
+  await page.getByRole('article', { name: 'Goethe A1' }).click();
+  await page.getByRole('button', { name: 'Pages' }).click();
+
+  await selectTextRange(page, 'aber', 'Vor der Abfahrt rufe ich an.');
+
+  await page.getByRole('button', { name: 'Create cards in bulk' }).click();
+
+  await page
+    .getByRole('button', { name: 'Cancel bulk creation' })
+    .click();
+
+  await expect(
+    page.getByRole('heading', { name: 'Creating Cards' })
+  ).not.toBeVisible();
+
+  await withDbConnection(async (client) => {
+    const result = await client.query(
+      "SELECT id FROM learn_language.cards WHERE id IN ('abfahren-elindulni', 'abfahrt-indulas', 'aber-de')"
+    );
+    expect(result.rows.length).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
This PR implements AI-powered duplicate detection for the bulk card creation workflow. When users attempt to create multiple cards in bulk, the system now uses an AI model to identify potential semantic duplicates of existing cards and presents them in a review dialog before proceeding with creation.

## Key Changes

### Backend
- **New Service**: `DuplicateDetectionService` that leverages a chat model to detect semantic duplicates by comparing new card IDs against existing ones
- **New Controller**: `DuplicateDetectionController` with a `/duplicate-detection` endpoint that accepts a list of new card IDs and returns potential duplicates
- **New Models**: `DuplicateDetectionRequest`, `DuplicateDetectionResponse`, and `PotentialDuplicate` to structure the duplicate detection flow
- **Operation Type**: Added `DUPLICATE_DETECTION` to the `OperationType` enum to track this operation type

### Frontend
- **New Service**: `DuplicateDetectionService` that checks if duplicate detection is available and calls the backend API
- **New Dialog Component**: `DuplicateReviewDialogComponent` that displays potential duplicates grouped by new card ID, allowing users to skip specific cards before proceeding
- **Updated FAB Component**: `BulkCardCreationFabComponent` now:
  - Calls duplicate detection before opening the bulk creation progress dialog
  - Shows a loading spinner while detection is in progress
  - Opens the duplicate review dialog if duplicates are found
  - Allows users to skip flagged cards or cancel the entire operation
  - Filters out skipped cards from the final bulk creation

### Testing
- Added three new test cases covering:
  - Dialog appearance when duplicates are detected
  - Skipping flagged cards to exclude them from creation
  - Canceling the operation to abort bulk creation entirely

### Mock Server
- Added `handleDuplicateDetection` method to mock the duplicate detection API response for testing

## Implementation Details
- The AI system prompt instructs the model to identify semantic duplicates (synonyms, alternative translations, inflected variants) rather than exact matches
- Duplicate detection is only triggered if the feature is enabled and a primary model is configured
- The dialog groups duplicates by new card ID and shows all matching existing cards with explanations
- Users can selectively skip cards before proceeding with bulk creation

https://claude.ai/code/session_01LJeSn1My5bJRK4g9oFRMo4