### PR TITLE
Migrate deployment to Azure Key Vault for secrets management

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -203,19 +203,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: [publish-server, publish-client]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
-      # - name: Connect to Twingate
-      #   uses: twingate/github-action@v1
-      #   with:
-      #     service-key: ${{ secrets.TWINGATE_SERVICE_KEY }}
+      - uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy to Kubernetes
         env:
-          K8S_CONFIG: ${{ secrets.K8S_CONFIG }}
-          HOSTNAME: ${{ secrets.HOSTNAME }}
-          API_CLIENT_ID: ${{ secrets.API_CLIENT_ID }}
+          AZURE_KEYVAULT_NAME: ${{ secrets.AZURE_KEYVAULT_NAME }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          AZURE_KEYVAULT_ENDPOINT: ${{ secrets.AZURE_KEYVAULT_ENDPOINT }}
         run: scripts/deploy.sh

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,11 +2,13 @@
 
 set -e  # Exit immediately if a command exits with a non-zero status
 
-: "${K8S_CONFIG:?Environment variable K8S_CONFIG is required}"
-: "${HOSTNAME:?Environment variable HOSTNAME is required}"
-: "${API_CLIENT_ID:?Environment variable API_CLIENT_ID is required}"
+: "${AZURE_KEYVAULT_NAME:?Environment variable AZURE_KEYVAULT_NAME is required}"
 : "${DOCKERHUB_USERNAME:?Environment variable DOCKERHUB_USERNAME is required}"
-: "${AZURE_KEYVAULT_ENDPOINT:?Environment variable AZURE_KEYVAULT_ENDPOINT is required}"
+
+AZURE_KEYVAULT_ENDPOINT="https://${AZURE_KEYVAULT_NAME}.vault.azure.net/"
+K8S_CONFIG=$(az keyvault secret show --vault-name "$AZURE_KEYVAULT_NAME" --name k8s-config --query value -o tsv)
+HOSTNAME=$(az keyvault secret show --vault-name "$AZURE_KEYVAULT_NAME" --name hostname --query value -o tsv)
+API_CLIENT_ID=$(az keyvault secret show --vault-name "$AZURE_KEYVAULT_NAME" --name api-client-id --query value -o tsv)
 
 # Create a temporary file in /dev/shm (RAM) to avoid writing to disk
 KUBECONFIG_FILE=$(mktemp /dev/shm/kubeconfig.XXXXXX)


### PR DESCRIPTION
## Summary
This PR refactors the deployment pipeline to use Azure Key Vault as the centralized secrets management system, replacing direct secret injection via GitHub Actions secrets. This improves security by leveraging Azure's native secret management capabilities and enables OIDC-based authentication.

## Key Changes
- **GitHub Actions Workflow**: 
  - Replaced Twingate VPN connection with Azure login using OIDC (OpenID Connect) authentication
  - Added required permissions for `id-token: write` to support OIDC token generation
  - Updated environment variables to only require `AZURE_KEYVAULT_NAME` instead of individual secrets
  - Removed direct secret passing for `K8S_CONFIG`, `HOSTNAME`, `API_CLIENT_ID`, and `AZURE_KEYVAULT_ENDPOINT`

- **Deploy Script**:
  - Simplified required environment variables to only `AZURE_KEYVAULT_NAME` and `DOCKERHUB_USERNAME`
  - Dynamically construct the Key Vault endpoint URL from the vault name
  - Fetch sensitive configuration values (`k8s-config`, `hostname`, `api-client-id`) directly from Azure Key Vault at runtime using `az keyvault secret show` commands
  - Removed hardcoded secret dependencies from the workflow

## Implementation Details
- Uses Azure CLI (`az keyvault`) to retrieve secrets, which requires prior Azure login via the `azure/login@v3` action
- Secrets are fetched on-demand during deployment rather than being passed through GitHub Actions, reducing exposure in logs and workflow configuration
- The Key Vault endpoint is now derived programmatically from the vault name following Azure's standard naming convention

https://claude.ai/code/session_01Gw44pMnwAquDgn6ft91FrB