### PR TITLE
Add Prometheus metrics and filter kube-probe logs from nginx

### DIFF
--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,6 +1,13 @@
+map $http_user_agent $loggable {
+    ~kube-probe 0;
+    default     1;
+}
+
 server {
     listen 8000;
     listen [::]:8000;
+
+    access_log /var/log/nginx/access.log combined if=$loggable;
 
     root /usr/share/nginx/html;
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -36,6 +36,11 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>


### PR DESCRIPTION
## Summary
This PR adds observability improvements by enabling Prometheus metrics collection and reducing log noise from Kubernetes health probes in nginx.

## Key Changes
- **Nginx logging**: Added conditional logging to exclude kube-probe requests from access logs, reducing log volume from Kubernetes health checks
- **Prometheus metrics**: Added micrometer Prometheus registry dependency to enable metrics export for monitoring and observability

## Implementation Details
- The nginx `map` directive filters requests based on the User-Agent header, setting `$loggable` to 0 for kube-probe requests and 1 for all others
- The access log now uses the `if=$loggable` condition to only log requests that should be recorded
- The micrometer Prometheus registry is added as a runtime dependency, which works in conjunction with the existing Spring Boot Actuator to expose metrics on the `/actuator/prometheus` endpoint

https://claude.ai/code/session_01PCzHQmRkXSvoKphJ7T6H4Y