### PR TITLE
Optimize resource requests and limits for server and client

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -49,10 +49,10 @@ helm upgrade learn-language-server mucsi96/spring-app \
     --set persistentVolumeClaims[0].mountPath=/app/storage \
     --set persistentVolumeClaims[0].storageClassName="" \
     --set persistentVolumeClaims[0].storage=5Gi \
-    --set resources.requests.memory=1Gi \
-    --set resources.requests.cpu=1 \
-    --set resources.limits.memory=2Gi \
-    --set resources.limits.cpu=2 \
+    --set resources.requests.memory=640Mi \
+    --set resources.requests.cpu=50m \
+    --set resources.limits.memory=1Gi \
+    --set resources.limits.cpu=1 \
     --wait
 
 echo "Deploying client: $DOCKERHUB_USERNAME/learn-language-client:$clientLatestTag to $HOSTNAME using client-app chart $clientAppChartVersion"
@@ -64,4 +64,8 @@ helm upgrade learn-language-client mucsi96/client-app \
     --set image=$DOCKERHUB_USERNAME/learn-language-client:$clientLatestTag \
     --set host=$HOSTNAME \
     --set entryPoint=web \
+    --set resources.requests.memory=32Mi \
+    --set resources.requests.cpu=10m \
+    --set resources.limits.memory=128Mi \
+    --set resources.limits.cpu=200m \
     --wait


### PR DESCRIPTION
## Summary
Reduced resource requests and limits for both the learn-language-server and learn-language-client deployments to optimize cluster resource utilization.

## Key Changes
- **Server deployment**: Reduced resource allocations
  - Memory requests: 1Gi → 640Mi
  - CPU requests: 1 → 50m
  - Memory limits: 2Gi → 1Gi
  - CPU limits: 2 → 1

- **Client deployment**: Added explicit resource constraints (previously unset)
  - Memory requests: 32Mi
  - CPU requests: 10m
  - Memory limits: 128Mi
  - CPU limits: 200m

## Implementation Details
These changes align resource requests and limits with actual application requirements, reducing unnecessary resource reservation and improving cluster efficiency. The client deployment now has defined resource boundaries to prevent unbounded resource consumption.

https://claude.ai/code/session_01YB91TkDMUZCTvrEBAh5go5