### PR TITLE
Update OpenAI configuration to use OpenAiCommonProperties

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/config/AIConfiguration.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/config/AIConfiguration.java
@@ -3,7 +3,7 @@ package io.github.mucsi96.learnlanguage.config;
 import org.springframework.ai.elevenlabs.api.ElevenLabsVoicesApi;
 import org.springframework.ai.model.elevenlabs.autoconfigure.ElevenLabsConnectionProperties;
 import org.springframework.ai.model.google.genai.autoconfigure.chat.GoogleGenAiConnectionProperties;
-import org.springframework.ai.model.openai.autoconfigure.OpenAiConnectionProperties;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiCommonProperties;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,7 +21,7 @@ public class AIConfiguration {
   }
 
   @Bean
-  OpenAIClient openAIClient(OpenAiConnectionProperties connectionProperties) {
+  OpenAIClient openAIClient(OpenAiCommonProperties connectionProperties) {
     var clientBuilder = OpenAIOkHttpClient.builder().apiKey(connectionProperties.getApiKey());
 
     if (connectionProperties.getBaseUrl() != null && !connectionProperties.getBaseUrl().isEmpty()) {


### PR DESCRIPTION
## Summary
Updated the AIConfiguration class to use `OpenAiCommonProperties` instead of the deprecated `OpenAiConnectionProperties` class for OpenAI client configuration.

## Key Changes
- Changed import from `OpenAiConnectionProperties` to `OpenAiCommonProperties`
- Updated the `openAIClient` bean method parameter type from `OpenAiConnectionProperties` to `OpenAiCommonProperties`

## Implementation Details
The change maintains backward compatibility as `OpenAiCommonProperties` provides the same `getApiKey()` and `getBaseUrl()` methods used by the OpenAI client builder. This update aligns with the latest Spring AI framework conventions for OpenAI configuration properties.

https://claude.ai/code/session_012c8F9MBUQkNaZwXXWZvFVw