### PR TITLE
Refactor OIDC auth config to use makeEnvironmentProviders

### DIFF
--- a/client/src/app/auth.config.ts
+++ b/client/src/app/auth.config.ts
@@ -1,5 +1,7 @@
-import { EnvironmentProviders } from '@angular/core';
+import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
 import {
+  AbstractSecurityStorage,
+  DefaultLocalStorageService,
   LogLevel,
   provideAuth,
   withAppInitializerAuthCheck,
@@ -19,46 +21,53 @@ export function provideOidcAuth(
 function provideAzureAdOidcConfig(
   config: EnvironmentConfig
 ): EnvironmentProviders {
-  return provideAuth(
-    {
-      config: {
-        authority: `https://login.microsoftonline.com/${config.tenantId}/v2.0`,
-        authWellknownEndpointUrl: `https://login.microsoftonline.com/${config.tenantId}/v2.0`,
-        redirectUrl: window.location.origin,
-        postLogoutRedirectUri: window.location.origin,
-        clientId: config.clientId,
-        scope: `openid profile offline_access ${config.apiClientId}/readDecks ${config.apiClientId}/createDeck`,
-        responseType: 'code',
-        silentRenew: true,
-        useRefreshToken: true,
-        autoUserInfo: false,
-        disableIatOffsetValidation: true,
-        logLevel: LogLevel.Debug,
-        secureRoutes: ['/api'],
+  return makeEnvironmentProviders([
+    provideAuth(
+      {
+        config: {
+          authority: `https://login.microsoftonline.com/${config.tenantId}/v2.0`,
+          authWellknownEndpointUrl: `https://login.microsoftonline.com/${config.tenantId}/v2.0`,
+          redirectUrl: window.location.origin,
+          postLogoutRedirectUri: window.location.origin,
+          clientId: config.clientId,
+          scope: `openid profile offline_access ${config.apiClientId}/readDecks ${config.apiClientId}/createDeck`,
+          responseType: 'code',
+          silentRenew: true,
+          useRefreshToken: true,
+          renewTimeBeforeTokenExpiresInSeconds: 60,
+          autoUserInfo: false,
+          disableIatOffsetValidation: true,
+          logLevel: LogLevel.Warn,
+          secureRoutes: ['/api'],
+        },
       },
-    },
-    withAppInitializerAuthCheck()
-  );
+      withAppInitializerAuthCheck()
+    ),
+    { provide: AbstractSecurityStorage, useClass: DefaultLocalStorageService },
+  ]);
 }
 
 function provideMockOidcConfig(
   config: EnvironmentConfig
 ): EnvironmentProviders {
-  return provideAuth(
-    {
-      config: {
-        authority: `${config.mockOAuth2ServerUri}/default`,
-        redirectUrl: window.location.origin,
-        postLogoutRedirectUri: window.location.origin,
-        clientId: 'mock-client-id',
-        scope: 'openid profile',
-        responseType: 'code',
-        silentRenew: false,
-        autoUserInfo: false,
-        logLevel: LogLevel.Debug,
-        secureRoutes: ['/api'],
+  return makeEnvironmentProviders([
+    provideAuth(
+      {
+        config: {
+          authority: `${config.mockOAuth2ServerUri}/default`,
+          redirectUrl: window.location.origin,
+          postLogoutRedirectUri: window.location.origin,
+          clientId: 'mock-client-id',
+          scope: 'openid profile',
+          responseType: 'code',
+          silentRenew: false,
+          autoUserInfo: false,
+          logLevel: LogLevel.Warn,
+          secureRoutes: ['/api'],
+        },
       },
-    },
-    withAppInitializerAuthCheck()
-  );
+      withAppInitializerAuthCheck()
+    ),
+    { provide: AbstractSecurityStorage, useClass: DefaultLocalStorageService },
+  ]);
 }


### PR DESCRIPTION
## Summary
Refactored the OIDC authentication configuration to use Angular's `makeEnvironmentProviders` API, enabling composition of multiple providers and explicit storage service configuration.

## Key Changes
- Wrapped `provideAuth()` calls with `makeEnvironmentProviders()` to support provider composition
- Added explicit `AbstractSecurityStorage` provider using `DefaultLocalStorageService` for both Azure AD and mock OIDC configurations
- Changed log level from `LogLevel.Debug` to `LogLevel.Warn` in both configurations to reduce verbosity
- Added `renewTimeBeforeTokenExpiresInSeconds: 60` configuration to Azure AD OIDC setup for proactive token refresh

## Implementation Details
- Both `provideAzureAdOidcConfig()` and `provideMockOidcConfig()` now return an array of providers wrapped in `makeEnvironmentProviders()`
- The storage service is now explicitly configured rather than relying on defaults, improving clarity and testability
- Token renewal timing is now explicitly configured for Azure AD to refresh tokens 60 seconds before expiration

https://claude.ai/code/session_018zJeuQ7sEXbzXuLyRyMApE