### PR TITLE
Change study session card filtering from 1-hour lookahead to end-of-day

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
@@ -2,8 +2,10 @@ package io.github.mucsi96.learnlanguage.controller;
 
 import static io.github.mucsi96.learnlanguage.util.TimezoneUtils.parseTimezone;
 import static io.github.mucsi96.learnlanguage.util.TimezoneUtils.startOfDayUtc;
+import static io.github.mucsi96.learnlanguage.util.TimezoneUtils.startOfNextDayUtc;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -276,7 +278,8 @@ public class SourceController {
   @GetMapping("/sources/due-cards-count")
   public List<SourceDueCardCountResponse> getDueCardsCountBySource(
       @RequestHeader("X-Timezone") String timezone) {
-    return cardService.getDueCardCountsBySource(startOfDayUtc(parseTimezone(timezone)));
+    final ZoneId zone = parseTimezone(timezone);
+    return cardService.getDueCardCountsBySource(startOfDayUtc(zone), startOfNextDayUtc(zone));
   }
 
   @PostMapping("/source")

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/StudySessionController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/StudySessionController.java
@@ -2,6 +2,9 @@ package io.github.mucsi96.learnlanguage.controller;
 
 import static io.github.mucsi96.learnlanguage.util.TimezoneUtils.parseTimezone;
 import static io.github.mucsi96.learnlanguage.util.TimezoneUtils.startOfDayUtc;
+import static io.github.mucsi96.learnlanguage.util.TimezoneUtils.startOfNextDayUtc;
+
+import java.time.ZoneId;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -42,7 +45,9 @@ public class StudySessionController {
     public ResponseEntity<StudySessionResponse> createSession(
             @PathVariable String sourceId,
             @RequestHeader("X-Timezone") String timezone) {
-        return ResponseEntity.ok(studySessionService.createSession(sourceId, startOfDayUtc(parseTimezone(timezone))));
+        final ZoneId zone = parseTimezone(timezone);
+        return ResponseEntity.ok(
+                studySessionService.createSession(sourceId, startOfDayUtc(zone), startOfNextDayUtc(zone)));
     }
 
     @GetMapping("/source/{sourceId}/study-session/current-card")
@@ -50,7 +55,8 @@ public class StudySessionController {
     public ResponseEntity<StudySessionCardResponse> getCurrentCardBySource(
             @PathVariable String sourceId,
             @RequestHeader("X-Timezone") String timezone) {
-        return studySessionService.getCurrentCardBySourceId(sourceId, startOfDayUtc(parseTimezone(timezone)))
+        final ZoneId zone = parseTimezone(timezone);
+        return studySessionService.getCurrentCardBySourceId(sourceId, startOfDayUtc(zone), startOfNextDayUtc(zone))
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.noContent().build());
     }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/specification/CardSpecifications.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/specification/CardSpecifications.java
@@ -7,7 +7,6 @@ import io.github.mucsi96.learnlanguage.model.CardReadiness;
 import org.springframework.data.jpa.domain.PredicateSpecification;
 
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 
 public class CardSpecifications {
 
@@ -19,19 +18,16 @@ public class CardSpecifications {
     }
 
     public static PredicateSpecification<Card> isDueBefore(LocalDateTime cutoff) {
-        return (root, cb) -> cb.lessThanOrEqualTo(root.get(Card_.due), cutoff);
+        return (root, cb) -> cb.lessThan(root.get(Card_.due), cutoff);
     }
 
     public static PredicateSpecification<Card> hasSourceId(String sourceId) {
         return (root, cb) -> cb.equal(root.get(Card_.source).get(Source_.id), sourceId);
     }
 
-    public static PredicateSpecification<Card> isDue() {
-        final LocalDateTime cutoff = LocalDateTime.now(ZoneOffset.UTC).plusHours(1);
-        return hasReadiness(CardReadiness.READY).and(isDueBefore(cutoff));
-    }
-
-    public static PredicateSpecification<Card> isDueForSource(String sourceId) {
-        return isDue().and(hasSourceId(sourceId));
+    public static PredicateSpecification<Card> isDueForSource(String sourceId, LocalDateTime cutoff) {
+        return hasReadiness(CardReadiness.READY)
+                .and(isDueBefore(cutoff))
+                .and(hasSourceId(sourceId));
     }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -29,7 +29,6 @@ import org.springframework.util.StringUtils;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
@@ -83,7 +82,7 @@ public class CardService {
   public List<SourceDueCardCountResponse> getDueCardCountsBySource(LocalDateTime startOfDay) {
     final List<StudySession> activeSessions = studySessionRepository.findAll(createdOnOrAfter(startOfDay));
 
-    final LocalDateTime cutoff = LocalDateTime.now(ZoneOffset.UTC).plusHours(1);
+    final LocalDateTime startOfNextDay = startOfDay.plusDays(1);
 
     final List<SourceDueCardCountResponse> sessionCounts = activeSessions.stream()
         .flatMap(session -> studySessionRepository.findWithCardsById(session.getId())
@@ -91,7 +90,7 @@ public class CardService {
             .flatMap(loaded -> loaded.getCards().stream()
                 .map(StudySessionCard::getCard)
                 .filter(Card::isReady)
-                .filter(card -> !card.getDue().isAfter(cutoff))
+                .filter(card -> card.getDue().isBefore(startOfNextDay))
                 .collect(Collectors.groupingBy(Card::getState, Collectors.counting()))
                 .entrySet().stream()
                 .map(entry -> SourceDueCardCountResponse.builder()

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -79,10 +79,9 @@ public class CardService {
     cardRepository.deleteById(id);
   }
 
-  public List<SourceDueCardCountResponse> getDueCardCountsBySource(LocalDateTime startOfDay) {
+  public List<SourceDueCardCountResponse> getDueCardCountsBySource(LocalDateTime startOfDay,
+      LocalDateTime startOfNextDay) {
     final List<StudySession> activeSessions = studySessionRepository.findAll(createdOnOrAfter(startOfDay));
-
-    final LocalDateTime startOfNextDay = startOfDay.plusDays(1);
 
     final List<SourceDueCardCountResponse> sessionCounts = activeSessions.stream()
         .flatMap(session -> studySessionRepository.findWithCardsById(session.getId())

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/StudySessionService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/StudySessionService.java
@@ -1,6 +1,5 @@
 package io.github.mucsi96.learnlanguage.service;
 
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -50,8 +49,6 @@ import static io.github.mucsi96.learnlanguage.repository.specification.StudySess
 @RequiredArgsConstructor
 public class StudySessionService {
 
-    private static final Duration DUE_CARD_LOOKAHEAD = Duration.ofHours(1);
-
     private final CardRepository cardRepository;
     private final SourceRepository sourceRepository;
     private final StudySessionRepository studySessionRepository;
@@ -81,12 +78,13 @@ public class StudySessionService {
                     .build();
         }
 
+        final LocalDateTime startOfNextDay = startOfDay.plusDays(1);
         final List<Card> allDueCards = source.getCardLimit() != null
                 ? cardRepository.findAll(
-                        Specification.where(isDueForSource(sourceId)),
+                        Specification.where(isDueForSource(sourceId, startOfNextDay)),
                         PageRequest.of(0, source.getCardLimit(), Sort.by("due"))).getContent()
                 : cardRepository.findAll(
-                        Specification.where(isDueForSource(sourceId)), Sort.by("due"));
+                        Specification.where(isDueForSource(sourceId, startOfNextDay)), Sort.by("due"));
         final List<Card> dueCards = source.getNewCardLimit() != null
                 ? applyNewCardLimit(allDueCards, source.getNewCardLimit())
                 : allDueCards;
@@ -306,16 +304,15 @@ public class StudySessionService {
     public Optional<StudySessionCardResponse> getCurrentCardBySourceId(String sourceId, LocalDateTime startOfDay) {
         return studySessionRepository.findOne(hasSourceId(sourceId).and(createdOnOrAfter(startOfDay)))
                 .flatMap(session -> studySessionRepository.findWithCardsById(session.getId()))
-                .flatMap(this::findNextCard);
+                .flatMap(loaded -> findNextCard(loaded, startOfDay));
     }
 
-    private Optional<StudySessionCardResponse> findNextCard(StudySession session) {
-        final LocalDateTime now = LocalDateTime.now();
-        final LocalDateTime lookaheadCutoff = now.plus(DUE_CARD_LOOKAHEAD);
+    private Optional<StudySessionCardResponse> findNextCard(StudySession session, LocalDateTime startOfDay) {
+        final LocalDateTime startOfNextDay = startOfDay.plusDays(1);
 
         final List<StudySessionCard> eligibleCards = session.getCards().stream()
                 .filter(c -> c.getCard().isReady())
-                .filter(c -> !c.getCard().getDue().isAfter(lookaheadCutoff))
+                .filter(c -> c.getCard().getDue().isBefore(startOfNextDay))
                 .toList();
 
         final Optional<StudySessionCard> nextCard = eligibleCards.stream()

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/StudySessionService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/StudySessionService.java
@@ -64,7 +64,7 @@ public class StudySessionService {
     }
 
     @Transactional
-    public StudySessionResponse createSession(String sourceId, LocalDateTime startOfDay) {
+    public StudySessionResponse createSession(String sourceId, LocalDateTime startOfDay, LocalDateTime startOfNextDay) {
         final Source source = sourceRepository.findByIdWithLock(sourceId)
                 .orElseThrow(() -> new ResourceNotFoundException("Source not found: " + sourceId));
 
@@ -78,7 +78,6 @@ public class StudySessionService {
                     .build();
         }
 
-        final LocalDateTime startOfNextDay = startOfDay.plusDays(1);
         final List<Card> allDueCards = source.getCardLimit() != null
                 ? cardRepository.findAll(
                         Specification.where(isDueForSource(sourceId, startOfNextDay)),
@@ -301,15 +300,14 @@ public class StudySessionService {
     }
 
     @Transactional
-    public Optional<StudySessionCardResponse> getCurrentCardBySourceId(String sourceId, LocalDateTime startOfDay) {
+    public Optional<StudySessionCardResponse> getCurrentCardBySourceId(String sourceId, LocalDateTime startOfDay,
+            LocalDateTime startOfNextDay) {
         return studySessionRepository.findOne(hasSourceId(sourceId).and(createdOnOrAfter(startOfDay)))
                 .flatMap(session -> studySessionRepository.findWithCardsById(session.getId()))
-                .flatMap(loaded -> findNextCard(loaded, startOfDay));
+                .flatMap(loaded -> findNextCard(loaded, startOfNextDay));
     }
 
-    private Optional<StudySessionCardResponse> findNextCard(StudySession session, LocalDateTime startOfDay) {
-        final LocalDateTime startOfNextDay = startOfDay.plusDays(1);
-
+    private Optional<StudySessionCardResponse> findNextCard(StudySession session, LocalDateTime startOfNextDay) {
         final List<StudySessionCard> eligibleCards = session.getCards().stream()
                 .filter(c -> c.getCard().isReady())
                 .filter(c -> c.getCard().getDue().isBefore(startOfNextDay))

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/util/TimezoneUtils.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/util/TimezoneUtils.java
@@ -29,4 +29,12 @@ public class TimezoneUtils {
                 .withZoneSameInstant(ZoneOffset.UTC)
                 .toLocalDateTime();
     }
+
+    public static LocalDateTime startOfNextDayUtc(ZoneId timezone) {
+        return LocalDate.now(timezone)
+                .plusDays(1)
+                .atStartOfDay(timezone)
+                .withZoneSameInstant(ZoneOffset.UTC)
+                .toLocalDateTime();
+    }
 }

--- a/test/tests/study-page.spec.ts
+++ b/test/tests/study-page.spec.ts
@@ -975,12 +975,16 @@ test('cards due later today are included but cards due tomorrow are not', async 
   await expect(flashcard.getByRole('heading', { name: 'most' })).toBeVisible();
   await flashcard.getByRole('heading', { name: 'most' }).click();
   await page.getByRole('button', { name: 'Correct', exact: true }).click();
-  await flashcard.getByRole('heading', { name: 'most' }).click();
-  await page.getByRole('button', { name: 'Correct', exact: true }).click();
 
   await expect(flashcard.getByRole('heading', { name: 'később' })).toBeVisible();
   await flashcard.getByRole('heading', { name: 'később' }).click();
   await page.getByRole('button', { name: 'Correct', exact: true }).click();
+
+  await expect(flashcard.getByRole('heading', { name: 'most' })).toBeVisible();
+  await flashcard.getByRole('heading', { name: 'most' }).click();
+  await page.getByRole('button', { name: 'Correct', exact: true }).click();
+
+  await expect(flashcard.getByRole('heading', { name: 'később' })).toBeVisible();
   await flashcard.getByRole('heading', { name: 'később' }).click();
   await page.getByRole('button', { name: 'Correct', exact: true }).click();
 

--- a/test/tests/study-page.spec.ts
+++ b/test/tests/study-page.spec.ts
@@ -924,10 +924,12 @@ test('confetti celebration appears when all cards are caught up', async ({ page 
   await expect(page.locator('app-confetti canvas')).toBeVisible();
 });
 
-test('cards due more than 1 hour from now are removed from session', async ({ page }) => {
+test('cards due later today are included but cards due tomorrow are not', async ({ page }) => {
   const now = new Date();
   const yesterday = new Date(now.getTime() - 86400000);
-  const twoHoursFromNow = new Date(now.getTime() + 2 * 60 * 60 * 1000);
+  const endOfToday = new Date(now);
+  endOfToday.setHours(23, 59, 0, 0);
+  const tomorrow = new Date(now.getTime() + 86400000);
 
   await createCard({
     cardId: 'jetzt-most',
@@ -950,7 +952,19 @@ test('cards due more than 1 hour from now are removed from session', async ({ pa
       type: 'ADVERB',
       translation: { en: 'later', hu: 'később', ch: 'spöter' },
     },
-    due: twoHoursFromNow,
+    due: endOfToday,
+  });
+
+  await createCard({
+    cardId: 'morgen-holnap',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 62,
+    data: {
+      word: 'morgen',
+      type: 'ADVERB',
+      translation: { en: 'tomorrow', hu: 'holnap', ch: 'morn' },
+    },
+    due: tomorrow,
   });
 
   await page.goto('/sources/goethe-a1/study');
@@ -959,17 +973,19 @@ test('cards due more than 1 hour from now are removed from session', async ({ pa
   const flashcard = page.getByRole('article', { name: 'Flashcard' });
 
   await expect(flashcard.getByRole('heading', { name: 'most' })).toBeVisible();
-
-  await expect(flashcard.getByLabel('State: New')).toBeVisible();
+  await flashcard.getByRole('heading', { name: 'most' }).click();
+  await page.getByRole('button', { name: 'Correct', exact: true }).click();
   await flashcard.getByRole('heading', { name: 'most' }).click();
   await page.getByRole('button', { name: 'Correct', exact: true }).click();
 
-  await expect(flashcard.getByLabel('State: Learning')).toBeVisible();
-  await flashcard.getByRole('heading', { name: 'most' }).click();
+  await expect(flashcard.getByRole('heading', { name: 'később' })).toBeVisible();
+  await flashcard.getByRole('heading', { name: 'később' }).click();
+  await page.getByRole('button', { name: 'Correct', exact: true }).click();
+  await flashcard.getByRole('heading', { name: 'később' }).click();
   await page.getByRole('button', { name: 'Correct', exact: true }).click();
 
   await expect(page.getByText('All caught up!')).toBeVisible();
-  await expect(flashcard.getByRole('heading', { name: 'később' })).not.toBeVisible();
+  await expect(flashcard.getByRole('heading', { name: 'holnap' })).not.toBeVisible();
 });
 
 test('most recently reviewed card moves to back of queue', async ({ page }) => {


### PR DESCRIPTION
## Summary
This change modifies the study session card filtering logic to include all cards due by the end of the current day, rather than only cards due within the next hour. This allows users to review cards that are due later today during their study session.

## Key Changes
- **StudySessionService**: Removed the hardcoded 1-hour lookahead duration and replaced it with end-of-day filtering based on the study session's start date
  - Updated `createSession()` to pass `startOfNextDay` cutoff to the card specification
  - Modified `findNextCard()` to accept `startOfDay` parameter and filter cards due before the start of the next day
  
- **CardSpecifications**: Made the card filtering more flexible by accepting a cutoff parameter
  - Changed `isDueBefore()` from `<=` to `<` comparison for stricter boundary checking
  - Removed hardcoded `isDue()` method that used UTC time with 1-hour offset
  - Updated `isDueForSource()` to accept a `cutoff` parameter instead of calculating it internally

- **CardService**: Updated `getDueCardCountsBySource()` to use end-of-day filtering instead of 1-hour lookahead

- **Test**: Updated `study-page.spec.ts` to reflect the new behavior
  - Changed test name to clarify the new filtering logic
  - Added a card due tomorrow to verify it's excluded from the session
  - Simplified test assertions by removing state-checking expectations
  - Verified that cards due later today are included while cards due tomorrow are not

## Implementation Details
The filtering now uses the study session's `startOfDay` to determine the cutoff (start of next day), ensuring consistent behavior throughout the day regardless of the current time. This approach is more predictable for users and aligns with typical study session expectations.

https://claude.ai/code/session_012qcGVKmX9qEiifdUCufVnW