### PR TITLE
Move turn indicator from card to source selector header

### DIFF
--- a/client/src/app/shared/source-selector/source-selector.component.css
+++ b/client/src/app/shared/source-selector/source-selector.component.css
@@ -17,6 +17,15 @@
   align-items: center;
 }
 
+.turn-indicator {
+  padding: 4px 10px;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--mat-sys-on-surface-variant);
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
 .source-link {
   gap: 1rem;
   display: flex;

--- a/client/src/app/shared/source-selector/source-selector.component.html
+++ b/client/src/app/shared/source-selector/source-selector.component.html
@@ -2,6 +2,11 @@
   @if(loading()) {
   <div class="loading-placeholder"></div>
   } @else { @if(selectedSourceId() && mode() === 'study') {
+  @if (isStudyingWithPartner()) {
+  <span class="turn-indicator" role="status" aria-label="Current turn" aria-live="polite">
+    {{ currentTurn().name }}
+  </span>
+  }
   <div class="stats-container">
     @for (dueCount of getDueCounts(selectedSourceId()!); track dueCount.state) {
     <app-state [state]="dueCount.state" [count]="dueCount.count" />

--- a/client/src/app/shared/source-selector/source-selector.component.ts
+++ b/client/src/app/shared/source-selector/source-selector.component.ts
@@ -7,6 +7,7 @@ import { RouterLink } from '@angular/router';
 import { injectParams, injectRouteData } from '../../utils/inject-params';
 import { SourcesService } from '../../sources.service';
 import { DueCardsService } from '../../due-cards.service';
+import { StudySessionService } from '../../study-session.service';
 import { CardState } from '../state/card-state';
 import { StateComponent } from '../state/state.component';
 import { Source } from '../../parser/types';
@@ -44,9 +45,14 @@ export class SourceSelectorComponent {
 
   private readonly sourcesService = inject(SourcesService);
   private readonly dueCardsService = inject(DueCardsService);
+  private readonly studySessionService = inject(StudySessionService);
 
   readonly sources = this.sourcesService.sources.value;
   readonly dueCounts = this.dueCardsService.dueCounts.value;
+  readonly currentTurn = this.studySessionService.currentTurn;
+  readonly isStudyingWithPartner = computed(
+    () => this.studySessionService.currentCard.value()?.studyMode === 'WITH_PARTNER'
+  );
 
   readonly loading = computed(
     () =>

--- a/client/src/app/study/learn-card/learn-card.component.css
+++ b/client/src/app/study/learn-card/learn-card.component.css
@@ -6,29 +6,6 @@
   max-width: 1200px;
 }
 
-.card-bottom-controls {
-  position: absolute;
-  bottom: 12px;
-  right: 12px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  z-index: 10;
-}
-
-.card-bottom-controls app-card-actions {
-  display: contents;
-}
-
-.turn-indicator {
-  padding: 4px 10px;
-  background: rgba(255, 255, 255, 0.1);
-  color: var(--mat-sys-on-surface-variant);
-  border-radius: 12px;
-  font-size: 0.75rem;
-  font-weight: 500;
-}
-
 .learn-card {
   position: relative;
   width: 100%;
@@ -41,7 +18,7 @@
   margin-bottom: 1rem;
 }
 
-.learn-card:active:not(:has(.card-bottom-controls:active)) {
+.learn-card:active {
   transform: scale(0.98);
 }
 

--- a/client/src/app/study/learn-card/learn-card.component.html
+++ b/client/src/app/study/learn-card/learn-card.component.html
@@ -61,14 +61,6 @@
     [class.revealed]="isRevealed()"
     (click)="toggleReveal()"
   >
-    @if (isStudyingWithPartner() && !isRevealed()) {
-    <div class="card-bottom-controls">
-      <span class="turn-indicator" role="status" aria-label="Current turn" aria-live="polite">
-        {{ currentTurn().name }}
-      </span>
-    </div>
-    }
-
     @switch (currentCardType()) {
       @case ('vocabulary') {
         <app-learn-vocabulary-card

--- a/client/src/app/study/learn-card/learn-card.component.ts
+++ b/client/src/app/study/learn-card/learn-card.component.ts
@@ -92,11 +92,6 @@ export class LearnCardComponent implements OnDestroy {
     return strategy.getLanguageTexts(card);
   });
 
-  readonly isStudyingWithPartner = computed(() => {
-    const cardData = this.currentCardData.value();
-    return cardData?.studyMode === 'WITH_PARTNER';
-  });
-
   readonly currentTurn = this.studySessionService.currentTurn;
   private readonly cardShownAt = signal<number | null>(null);
   readonly reviewDuration = signal<number | null>(null);

--- a/test/tests/learning-partners.spec.ts
+++ b/test/tests/learning-partners.spec.ts
@@ -79,7 +79,7 @@ test('study page shows turn indicator when source has learning partner', async (
   await expect(page.getByRole('status', { name: 'Current turn' })).toBeVisible();
 });
 
-test('study page hides turn indicator when card is revealed', async ({ page }) => {
+test('study page keeps turn indicator visible when card is revealed', async ({ page }) => {
   const aliceId = await createLearningPartner({ name: 'Alice' });
   await setSourceLearningPartner('goethe-a1', aliceId);
   await createCard({
@@ -102,7 +102,7 @@ test('study page hides turn indicator when card is revealed', async ({ page }) =
 
   await page.getByRole('heading', { name: 'tanulni' }).click();
 
-  await expect(turnIndicator).not.toBeVisible();
+  await expect(turnIndicator).toBeVisible();
 });
 
 test('study page alternates between user and source partner', async ({ page }) => {


### PR DESCRIPTION
## Summary
Relocates the turn indicator UI element from the learn card component to the source selector component header. This improves the layout by keeping the turn indicator visible even when cards are revealed, and centralizes partner-related UI in a more appropriate location.

## Key Changes
- **Removed from learn-card component:**
  - Deleted `.card-bottom-controls` and `.turn-indicator` CSS styles
  - Removed turn indicator HTML markup and associated conditional rendering
  - Removed `isStudyingWithPartner` computed signal (now in source-selector)
  - Simplified `.learn-card:active` selector

- **Added to source-selector component:**
  - Moved `.turn-indicator` CSS styles to source-selector stylesheet
  - Added turn indicator HTML markup in the header (visible during study mode with partner)
  - Injected `StudySessionService` to access `currentTurn` and study mode state
  - Added `isStudyingWithPartner` computed signal to determine visibility

- **Test updates:**
  - Updated test expectations to reflect that turn indicator remains visible when card is revealed (previously expected it to hide)

## Implementation Details
The turn indicator now displays in the source selector header when studying with a learning partner, making it persistently visible throughout the card interaction lifecycle rather than only when the card is unrevealed. This provides better UX by maintaining context about whose turn it is regardless of card state.

https://claude.ai/code/session_01McdtPGVrTvSs5ZMRzz725C