### PR TITLE
Consolidate FAB button styling with primary color scheme

### DIFF
--- a/client/src/app/admin/admin.component.css
+++ b/client/src/app/admin/admin.component.css
@@ -212,14 +212,14 @@ p {
               0 10px 15px -5px rgba(0, 0, 0, 0.4);
 }
 
-.action-fab:not(.delete-fab) {
-  --mat-fab-container-color: var(--mat-sys-primary-container);
-  --mat-fab-foreground-color: var(--mat-sys-on-primary-container);
+.action-fab.edit-fab {
+  --mat-fab-container-color: var(--bt-warn);
+  --mat-fab-foreground-color: var(--bt-surface-0);
 }
 
-.delete-fab {
-  --mat-fab-container-color: var(--mat-sys-error-container);
-  --mat-fab-foreground-color: var(--mat-sys-on-error-container);
+.action-fab.delete-fab {
+  --mat-fab-container-color: var(--bt-error);
+  --mat-fab-foreground-color: var(--bt-text-on-brand);
 }
 
 .empty-state {

--- a/client/src/app/admin/admin.component.css
+++ b/client/src/app/admin/admin.component.css
@@ -212,14 +212,9 @@ p {
               0 10px 15px -5px rgba(0, 0, 0, 0.4);
 }
 
-.cards-fab {
-  --mat-fab-container-color: var(--mat-sys-secondary-container);
-  --mat-fab-foreground-color: var(--mat-sys-on-secondary-container);
-}
-
-.edit-fab {
-  --mat-fab-container-color: var(--mat-sys-tertiary-container);
-  --mat-fab-foreground-color: var(--mat-sys-on-tertiary-container);
+.action-fab:not(.delete-fab) {
+  --mat-fab-container-color: var(--mat-sys-primary-container);
+  --mat-fab-foreground-color: var(--mat-sys-on-primary-container);
 }
 
 .delete-fab {

--- a/client/src/app/admin/admin.component.html
+++ b/client/src/app/admin/admin.component.html
@@ -111,7 +111,7 @@
   <button
     mat-fab
     extended
-    class="action-fab cards-fab"
+    class="action-fab"
     (click)="navigateToCards()"
   >
     <mat-icon>style</mat-icon>

--- a/client/src/app/admin/admin.component.html
+++ b/client/src/app/admin/admin.component.html
@@ -121,7 +121,6 @@
   <button
     mat-fab
     extended
-    color="primary"
     class="action-fab"
     (click)="navigateToPages()"
   >


### PR DESCRIPTION
## Summary
Unified the styling of action FAB buttons by consolidating separate `.cards-fab` and `.edit-fab` classes into a single `.action-fab:not(.delete-fab)` selector that uses the primary color scheme instead of secondary and tertiary variants.

## Changes
- **CSS**: Merged two FAB button style classes into one selector using `:not(.delete-fab)` pseudo-class to exclude delete buttons
  - Removed `.cards-fab` class with secondary container colors
  - Removed `.edit-fab` class with tertiary container colors
  - Created unified `.action-fab:not(.delete-fab)` class using primary container colors
- **HTML**: Removed redundant `color="primary"` attribute from the pages navigation FAB button, relying on the CSS class styling instead

## Implementation Details
The change simplifies the styling architecture by reducing CSS class duplication while maintaining visual distinction between action buttons (primary) and delete buttons (secondary). The `:not(.delete-fab)` selector ensures the primary styling applies to all action FABs except the delete button, which retains its own styling rules.

https://claude.ai/code/session_018fRHXDmorLrv9eoudUyu6r