### PR TITLE
Upgrade @mucsi96/angular-material-theme to v1.4.0

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser": "21.2.12",
         "@angular/platform-browser-dynamic": "21.2.12",
         "@angular/router": "21.2.12",
-        "@mucsi96/angular-material-theme": "^1.2.0",
+        "@mucsi96/angular-material-theme": "^1.4.0",
         "ag-grid-angular": "^35.0.1",
         "ag-grid-community": "^35.0.1",
         "angular-auth-oidc-client": "^21.0.1",
@@ -4095,9 +4095,9 @@
       ]
     },
     "node_modules/@mucsi96/angular-material-theme": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@mucsi96/angular-material-theme/-/angular-material-theme-1.2.0.tgz",
-      "integrity": "sha512-af8vEaGje7VhNFZxTLhdFxCJ8r9mKG9eBWRh9NQ7139BMXr+wPXZwuaJXfRcKjRWMWsgwzCcMRG648YIgTpI4w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@mucsi96/angular-material-theme/-/angular-material-theme-1.4.0.tgz",
+      "integrity": "sha512-w7SiqaSW3z2YZXb3WRwKJf93ZSGrMyYgFK0JbPLHcsg1QsGl2LjlPZl2ICuZfa0110pRpt8mtbb7QtntibMmKA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,7 @@
     "@angular/platform-browser": "21.2.12",
     "@angular/platform-browser-dynamic": "21.2.12",
     "@angular/router": "21.2.12",
-    "@mucsi96/angular-material-theme": "^1.2.0",
+    "@mucsi96/angular-material-theme": "^1.4.0",
     "ag-grid-angular": "^35.0.1",
     "ag-grid-community": "^35.0.1",
     "angular-auth-oidc-client": "^21.0.1",


### PR DESCRIPTION
## Summary
Upgrades the `@mucsi96/angular-material-theme` dependency from v1.2.0 to v1.4.0 to incorporate the latest features and improvements from the theme package.

## Changes
- Updated `@mucsi96/angular-material-theme` version constraint from `^1.2.0` to `^1.4.0` in client dependencies

## Notes
This is a minor version bump that maintains backward compatibility while providing access to new features and bug fixes available in v1.4.0.

https://claude.ai/code/session_01TNSNAFGufqktTe5QbdLrgr