### PR TITLE
Count cards due by end of day instead of next hour

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
@@ -35,12 +35,12 @@ public interface CardRepository
             SELECT source_id, state,
                    ROW_NUMBER() OVER (PARTITION BY source_id ORDER BY due ASC) AS row_num
             FROM learn_language.cards
-            WHERE readiness = 'READY' AND due < :endOfDayUtc
+            WHERE readiness = 'READY' AND due < :startOfNextDayUtc
         ) AS ranked
         WHERE row_num <= 50
         GROUP BY source_id, state
         """, nativeQuery = true)
-    List<SourceStateCountProjection> findTop50MostDueGroupedByStateAndSourceId(@Param("endOfDayUtc") LocalDateTime endOfDayUtc);
+    List<SourceStateCountProjection> findTop50MostDueGroupedByStateAndSourceId(@Param("startOfNextDayUtc") LocalDateTime startOfNextDayUtc);
 
     @Query(value = """
         SELECT source_id AS sourceId, state AS state, COUNT(*) AS count
@@ -48,14 +48,14 @@ public interface CardRepository
             SELECT source_id, state,
                    ROW_NUMBER() OVER (PARTITION BY source_id ORDER BY due ASC) AS row_num
             FROM learn_language.cards
-            WHERE readiness = 'READY' AND due < :endOfDayUtc
+            WHERE readiness = 'READY' AND due < :startOfNextDayUtc
                   AND source_id NOT IN (:excludedSourceIds)
         ) AS ranked
         WHERE row_num <= 50
         GROUP BY source_id, state
         """, nativeQuery = true)
     List<SourceStateCountProjection> findTop50MostDueGroupedByStateAndSourceIdExcludingSources(
-            @Param("endOfDayUtc") LocalDateTime endOfDayUtc,
+            @Param("startOfNextDayUtc") LocalDateTime startOfNextDayUtc,
             @Param("excludedSourceIds") List<String> excludedSourceIds);
 
     @Query(value = """

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
@@ -12,7 +12,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 @Repository
@@ -35,12 +35,12 @@ public interface CardRepository
             SELECT source_id, state,
                    ROW_NUMBER() OVER (PARTITION BY source_id ORDER BY due ASC) AS row_num
             FROM learn_language.cards
-            WHERE readiness = 'READY' AND due < :startOfNextDayUtc
+            WHERE readiness = 'READY' AND due AT TIME ZONE 'UTC' < :startOfNextDayUtc
         ) AS ranked
         WHERE row_num <= 50
         GROUP BY source_id, state
         """, nativeQuery = true)
-    List<SourceStateCountProjection> findTop50MostDueGroupedByStateAndSourceId(@Param("startOfNextDayUtc") LocalDateTime startOfNextDayUtc);
+    List<SourceStateCountProjection> findTop50MostDueGroupedByStateAndSourceId(@Param("startOfNextDayUtc") Instant startOfNextDayUtc);
 
     @Query(value = """
         SELECT source_id AS sourceId, state AS state, COUNT(*) AS count
@@ -48,14 +48,14 @@ public interface CardRepository
             SELECT source_id, state,
                    ROW_NUMBER() OVER (PARTITION BY source_id ORDER BY due ASC) AS row_num
             FROM learn_language.cards
-            WHERE readiness = 'READY' AND due < :startOfNextDayUtc
+            WHERE readiness = 'READY' AND due AT TIME ZONE 'UTC' < :startOfNextDayUtc
                   AND source_id NOT IN (:excludedSourceIds)
         ) AS ranked
         WHERE row_num <= 50
         GROUP BY source_id, state
         """, nativeQuery = true)
     List<SourceStateCountProjection> findTop50MostDueGroupedByStateAndSourceIdExcludingSources(
-            @Param("startOfNextDayUtc") LocalDateTime startOfNextDayUtc,
+            @Param("startOfNextDayUtc") Instant startOfNextDayUtc,
             @Param("excludedSourceIds") List<String> excludedSourceIds);
 
     @Query(value = """

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -34,12 +35,12 @@ public interface CardRepository
             SELECT source_id, state,
                    ROW_NUMBER() OVER (PARTITION BY source_id ORDER BY due ASC) AS row_num
             FROM learn_language.cards
-            WHERE readiness = 'READY' AND due at time zone 'UTC' <= NOW() + INTERVAL '1 hour'
+            WHERE readiness = 'READY' AND due < :endOfDayUtc
         ) AS ranked
         WHERE row_num <= 50
         GROUP BY source_id, state
         """, nativeQuery = true)
-    List<SourceStateCountProjection> findTop50MostDueGroupedByStateAndSourceId();
+    List<SourceStateCountProjection> findTop50MostDueGroupedByStateAndSourceId(@Param("endOfDayUtc") LocalDateTime endOfDayUtc);
 
     @Query(value = """
         SELECT source_id AS sourceId, state AS state, COUNT(*) AS count
@@ -47,13 +48,15 @@ public interface CardRepository
             SELECT source_id, state,
                    ROW_NUMBER() OVER (PARTITION BY source_id ORDER BY due ASC) AS row_num
             FROM learn_language.cards
-            WHERE readiness = 'READY' AND due at time zone 'UTC' <= NOW() + INTERVAL '1 hour'
+            WHERE readiness = 'READY' AND due < :endOfDayUtc
                   AND source_id NOT IN (:excludedSourceIds)
         ) AS ranked
         WHERE row_num <= 50
         GROUP BY source_id, state
         """, nativeQuery = true)
-    List<SourceStateCountProjection> findTop50MostDueGroupedByStateAndSourceIdExcludingSources(@Param("excludedSourceIds") List<String> excludedSourceIds);
+    List<SourceStateCountProjection> findTop50MostDueGroupedByStateAndSourceIdExcludingSources(
+            @Param("endOfDayUtc") LocalDateTime endOfDayUtc,
+            @Param("excludedSourceIds") List<String> excludedSourceIds);
 
     @Query(value = """
         SELECT c.source_id AS sourceId, c.readiness AS readiness, c.state AS state,

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/specification/CardViewSpecifications.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/specification/CardViewSpecifications.java
@@ -6,7 +6,6 @@ import io.github.mucsi96.learnlanguage.model.CardReadiness;
 import org.springframework.data.jpa.domain.PredicateSpecification;
 
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.List;
 
 public class CardViewSpecifications {
@@ -56,10 +55,6 @@ public class CardViewSpecifications {
         };
     }
 
-    public static PredicateSpecification<CardView> isDueBefore(LocalDateTime cutoff) {
-        return (root, cb) -> cb.lessThanOrEqualTo(root.get(CardView_.due), cutoff);
-    }
-
     public static PredicateSpecification<CardView> isFlagged() {
         return (root, cb) -> cb.isTrue(root.get(CardView_.flagged));
     }
@@ -70,14 +65,5 @@ public class CardViewSpecifications {
 
     public static PredicateSpecification<CardView> isSuggestedKnown() {
         return (root, cb) -> cb.isTrue(root.get(CardView_.isSuggestedKnown));
-    }
-
-    public static PredicateSpecification<CardView> isDue() {
-        final LocalDateTime cutoff = LocalDateTime.now(ZoneOffset.UTC).plusHours(1);
-        return hasReadinessIn(List.of(CardReadiness.READY)).and(isDueBefore(cutoff));
-    }
-
-    public static PredicateSpecification<CardView> isDueForSource(String sourceId) {
-        return isDue().and(hasSourceId(sourceId));
     }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -27,8 +27,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
@@ -103,8 +105,10 @@ public class CardService {
         .map(session -> session.getSource().getId())
         .toList();
 
+    final Instant startOfNextDayUtc = startOfNextDay.toInstant(ZoneOffset.UTC);
+
     final List<SourceDueCardCountResponse> nonSessionCounts = sessionSourceIds.isEmpty()
-        ? cardRepository.findTop50MostDueGroupedByStateAndSourceId(startOfNextDay).stream()
+        ? cardRepository.findTop50MostDueGroupedByStateAndSourceId(startOfNextDayUtc).stream()
             .map(row -> SourceDueCardCountResponse.builder()
                 .sourceId(row.getSourceId())
                 .state(row.getState())
@@ -112,7 +116,7 @@ public class CardService {
                 .build())
             .toList()
         : cardRepository
-            .findTop50MostDueGroupedByStateAndSourceIdExcludingSources(startOfNextDay, sessionSourceIds)
+            .findTop50MostDueGroupedByStateAndSourceIdExcludingSources(startOfNextDayUtc, sessionSourceIds)
             .stream()
             .map(row -> SourceDueCardCountResponse.builder()
                 .sourceId(row.getSourceId())

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -104,14 +104,16 @@ public class CardService {
         .toList();
 
     final List<SourceDueCardCountResponse> nonSessionCounts = sessionSourceIds.isEmpty()
-        ? cardRepository.findTop50MostDueGroupedByStateAndSourceId().stream()
+        ? cardRepository.findTop50MostDueGroupedByStateAndSourceId(startOfNextDay).stream()
             .map(row -> SourceDueCardCountResponse.builder()
                 .sourceId(row.getSourceId())
                 .state(row.getState())
                 .count(row.getCount())
                 .build())
             .toList()
-        : cardRepository.findTop50MostDueGroupedByStateAndSourceIdExcludingSources(sessionSourceIds).stream()
+        : cardRepository
+            .findTop50MostDueGroupedByStateAndSourceIdExcludingSources(startOfNextDay, sessionSourceIds)
+            .stream()
             .map(row -> SourceDueCardCountResponse.builder()
                 .sourceId(row.getSourceId())
                 .state(row.getState())

--- a/test/tests/home-page.spec.ts
+++ b/test/tests/home-page.spec.ts
@@ -99,6 +99,39 @@ test('due card counts are independent per source when study session exists', asy
   await expect(goetheA2Card.getByTitle('Review', { exact: true })).toContainText('1');
 });
 
+test('cards due later today are counted regardless of time of day', async ({ page }) => {
+  const now = new Date();
+  const endOfToday = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+    23,
+    59,
+    0,
+    0,
+  );
+  const startOfTomorrow = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate() + 1,
+    0,
+    1,
+    0,
+    0,
+  );
+
+  await createCardsWithStates('goethe-a1', [
+    { state: 'NEW', count: 1, due_date: endOfToday },
+    { state: 'REVIEW', count: 1, due_date: startOfTomorrow },
+  ]);
+
+  await page.goto('/');
+
+  const goetheA1Card = page.getByRole('heading', { name: 'Goethe A1' });
+  await expect(goetheA1Card.getByTitle('New', { exact: true })).toContainText('1');
+  await expect(goetheA1Card.getByTitle('Review', { exact: true })).not.toBeVisible();
+});
+
 test('in review cards not on home page', async ({ page }) => {
   await createCard({
     cardId: uuidv4(),


### PR DESCRIPTION
## Summary
Changed the card due date logic to count cards due by the end of the current day (in UTC) rather than within the next hour. This ensures cards scheduled for later today are properly included in due card counts regardless of the current time of day.

## Key Changes
- Updated `CardRepository` queries to accept `endOfDayUtc` parameter instead of using a hardcoded `NOW() + INTERVAL '1 hour'` calculation
- Modified `CardService.getDueCardCountsBySource()` to pass `startOfNextDay` (end of current day) to repository methods
- Removed unused `isDueBefore()`, `isDue()`, and `isDueForSource()` methods from `CardViewSpecifications`
- Added test case verifying that cards due later today are counted while cards due tomorrow are not

## Implementation Details
- The `startOfNextDay` parameter (representing the end of the current UTC day) is now passed to both `findTop50MostDueGroupedByStateAndSourceId()` queries
- This change makes the due date filtering more explicit and testable by accepting the cutoff time as a parameter rather than calculating it within the query
- The behavior now correctly handles edge cases where cards are scheduled for later in the same day

https://claude.ai/code/session_01Q9tBjJ468rjCRJr1Dej8mU