### PR TITLE
Upgrade @mucsi96/angular-material-theme to v1.6.0

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser": "21.2.12",
         "@angular/platform-browser-dynamic": "21.2.12",
         "@angular/router": "21.2.12",
-        "@mucsi96/angular-material-theme": "^1.4.0",
+        "@mucsi96/angular-material-theme": "^1.6.0",
         "ag-grid-angular": "^35.0.1",
         "ag-grid-community": "^35.0.1",
         "angular-auth-oidc-client": "^21.0.1",
@@ -4095,9 +4095,9 @@
       ]
     },
     "node_modules/@mucsi96/angular-material-theme": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@mucsi96/angular-material-theme/-/angular-material-theme-1.4.0.tgz",
-      "integrity": "sha512-w7SiqaSW3z2YZXb3WRwKJf93ZSGrMyYgFK0JbPLHcsg1QsGl2LjlPZl2ICuZfa0110pRpt8mtbb7QtntibMmKA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@mucsi96/angular-material-theme/-/angular-material-theme-1.6.0.tgz",
+      "integrity": "sha512-8iLCbv/YGT+ku2p3ULc/p3vH0pY7gf6dHDls/Z0oVmluJnJKIAj2efHk1LxnpayaraD7hIQIx/vhDoxCbNqi8Q==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,7 @@
     "@angular/platform-browser": "21.2.12",
     "@angular/platform-browser-dynamic": "21.2.12",
     "@angular/router": "21.2.12",
-    "@mucsi96/angular-material-theme": "^1.4.0",
+    "@mucsi96/angular-material-theme": "^1.6.0",
     "ag-grid-angular": "^35.0.1",
     "ag-grid-community": "^35.0.1",
     "angular-auth-oidc-client": "^21.0.1",


### PR DESCRIPTION
## Summary
Updates the `@mucsi96/angular-material-theme` dependency from v1.4.0 to v1.6.0 to leverage improvements and fixes in the newer version.

## Changes
- Bumped `@mucsi96/angular-material-theme` from `^1.4.0` to `^1.6.0` in client dependencies

## Notes
This is a minor version upgrade within the same major version, ensuring backward compatibility while providing access to bug fixes and enhancements introduced in v1.5.0 and v1.6.0.

https://claude.ai/code/session_01N44gCv2qq54evZ1TjZon1f