### PR TITLE
Upgrade @mucsi96/angular-material-theme to v1.8.0

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser": "21.2.13",
         "@angular/platform-browser-dynamic": "21.2.13",
         "@angular/router": "21.2.13",
-        "@mucsi96/angular-material-theme": "^1.6.0",
+        "@mucsi96/angular-material-theme": "^1.8.0",
         "ag-grid-angular": "^35.0.1",
         "ag-grid-community": "^35.0.1",
         "angular-auth-oidc-client": "^21.0.1",
@@ -4095,9 +4095,9 @@
       ]
     },
     "node_modules/@mucsi96/angular-material-theme": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@mucsi96/angular-material-theme/-/angular-material-theme-1.6.0.tgz",
-      "integrity": "sha512-8iLCbv/YGT+ku2p3ULc/p3vH0pY7gf6dHDls/Z0oVmluJnJKIAj2efHk1LxnpayaraD7hIQIx/vhDoxCbNqi8Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@mucsi96/angular-material-theme/-/angular-material-theme-1.8.0.tgz",
+      "integrity": "sha512-sFVzXKL6TqUJXCsTGxx0R9TtCG97EZtbcu9dPelX1TarASB/6Pm7OJlVG5ZVaB0Ra5Gls81ajbogdCSc2StVmg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,7 @@
     "@angular/platform-browser": "21.2.13",
     "@angular/platform-browser-dynamic": "21.2.13",
     "@angular/router": "21.2.13",
-    "@mucsi96/angular-material-theme": "^1.6.0",
+    "@mucsi96/angular-material-theme": "^1.8.0",
     "ag-grid-angular": "^35.0.1",
     "ag-grid-community": "^35.0.1",
     "angular-auth-oidc-client": "^21.0.1",


### PR DESCRIPTION
## Summary
Updates the `@mucsi96/angular-material-theme` dependency from v1.6.0 to v1.8.0 to incorporate the latest improvements and fixes from the theme library.

## Changes
- Bumped `@mucsi96/angular-material-theme` from `^1.6.0` to `^1.8.0` in client dependencies

## Notes
This is a minor version upgrade within the same major version, ensuring backward compatibility while providing access to new features and bug fixes from the theme library.

https://claude.ai/code/session_01RpJCF3dzwZLspHTP4WbPaE