### PR TITLE
Migrate to custom design tokens for consistent theming

### DIFF
--- a/client/src/app/app.component.css
+++ b/client/src/app/app.component.css
@@ -1,5 +1,5 @@
 .header {
-  border-bottom: 1px solid hsl(215, 14%, 34%);
+  border-bottom: 1px solid var(--bt-outline);
   display: block;
   padding: env(safe-area-inset-top) 0 0;
 
@@ -11,6 +11,10 @@
     justify-content: space-between;
     align-items: center;
     height: 100%;
+
+    a[mat-button] {
+      font-size: 16px;
+    }
   }
 }
 

--- a/client/src/app/header/header.component.css
+++ b/client/src/app/header/header.component.css
@@ -1,13 +1,13 @@
 .avatar {
   display: inline-flex;
   user-select: none;
-  background-color: hsl(215, 14%, 34%);
+  background-color: var(--bt-outline);
   border-radius: 50%;
   height: 40px;
   justify-content: center;
   align-items: center;
   aspect-ratio: 1;
-  color: white;
+  color: var(--bt-text-on-brand);
   font-size: 18px;
   border: unset;
 }
@@ -23,5 +23,5 @@
   padding-left: var(--mat-menu-item-leading-spacing);
   padding-right: var(--mat-menu-item-trailing-spacing);
   min-height: 36px;
-  color: var(--mat-sys-on-surface);
+  color: var(--bt-text-default);
 }

--- a/client/src/app/home/home.component.css
+++ b/client/src/app/home/home.component.css
@@ -6,12 +6,12 @@
 }
 
 h1 {
-  color: var(--mat-sys-on-surface);
+  color: var(--bt-text-strong);
   margin-bottom: 0.5rem;
 }
 
 p {
-  color: var(--mat-app-text-color);
+  color: var(--bt-text-muted);
   margin-bottom: 2rem;
 }
 
@@ -39,8 +39,8 @@ p {
 }
 
 .sources mat-card {
-  background: var(--mat-sys-surface);
-  border: 1px solid var(--mat-sys-surface-container);
+  background: var(--bt-surface-1);
+  border: 1px solid var(--bt-outline);
   width: 100%;
   height: 100%;
 }
@@ -59,7 +59,7 @@ p {
 }
 
 .sources mat-card h2 {
-  color: var(--mat-sys-on-surface);
+  color: var(--bt-text-strong);
   margin-bottom: 1.5rem;
   font-size: 1.25rem;
 }


### PR DESCRIPTION
## Summary
Replaced Material Design System (MDC) CSS variables and hardcoded color values with custom design tokens (`--bt-*` variables) across multiple components to establish a consistent, maintainable theming system.

## Key Changes
- **home.component.css**: Updated text colors to use `--bt-text-strong` and `--bt-text-muted`, and surface colors to use `--bt-surface-1` and `--bt-outline`
- **app.component.css**: Replaced hardcoded border color with `--bt-outline` variable and added font-size styling for mat-button links
- **header.component.css**: Migrated avatar background and text colors to use `--bt-outline` and `--bt-text-on-brand`, and updated menu item text color to `--bt-text-default`

## Implementation Details
- All Material Design System variables (`--mat-sys-*`, `--mat-app-*`) have been replaced with custom brand tokens
- Hardcoded HSL color values have been consolidated into the `--bt-outline` token
- This change enables easier theme customization and maintenance through a single token definition system

https://claude.ai/code/session_01GNigc4qtxqgzofS18rzX6t