### PR TITLE
Replace mat-spinner with bt-bar-loader for loading states

### DIFF
--- a/client/src/app/bulk-card-creation-fab/bulk-card-creation-fab.component.html
+++ b/client/src/app/bulk-card-creation-fab/bulk-card-creation-fab.component.html
@@ -9,15 +9,14 @@
     [matTooltip]="imageLimitTooltip()"
     aria-label="Create cards in bulk"
   >
-    @if (isDetectingDuplicates()) {
-      <mat-spinner diameter="20"></mat-spinner>
-    } @else {
-      <mat-icon>add_circle</mat-icon>
-    }
+    <mat-icon>add_circle</mat-icon>
     @if (isDetectingDuplicates()) {
       Checking duplicates...
     } @else {
       Create {{ candidatesService.candidatesCount() }} Cards
     }
   </button>
+  @if (isDetectingDuplicates()) {
+    <bt-bar-loader class="page-loader" label="Checking duplicates" />
+  }
 }

--- a/client/src/app/bulk-card-creation-fab/bulk-card-creation-fab.component.ts
+++ b/client/src/app/bulk-card-creation-fab/bulk-card-creation-fab.component.ts
@@ -5,7 +5,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatBadgeModule } from '@angular/material/badge';
 import { MatDialog } from '@angular/material/dialog';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { BarLoaderComponent } from '@mucsi96/angular-material-theme';
 import { CommonModule } from '@angular/common';
 import { firstValueFrom } from 'rxjs';
 import { CardCandidatesService } from '../card-candidates.service';
@@ -28,7 +28,7 @@ import {
 @Component({
   selector: 'app-bulk-card-creation-fab',
   standalone: true,
-  imports: [CommonModule, MatButtonModule, MatIconModule, MatBadgeModule, MatTooltipModule, MatProgressSpinnerModule],
+  imports: [CommonModule, MatButtonModule, MatIconModule, MatBadgeModule, MatTooltipModule, BarLoaderComponent],
   templateUrl: './bulk-card-creation-fab.component.html',
   styleUrl: './bulk-card-creation-fab.component.css',
 })

--- a/client/src/app/parser/page/page.component.css
+++ b/client/src/app/parser/page/page.component.css
@@ -32,20 +32,6 @@
   }
 }
 
-.area-loading {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  z-index: 10;
-  background-color: var(--mat-app-background-color);
-  border-radius: 50%;
-  padding: 1rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
 .hidden-file-input {
   display: none;
 }

--- a/client/src/app/parser/page/page.component.html
+++ b/client/src/app/parser/page/page.component.html
@@ -53,11 +53,7 @@
     (click)="pdfFileInput.click()"
     [disabled]="uploading()"
   >
-    @if (uploading()) {
-    <mat-spinner diameter="18"></mat-spinner>
-    } @else {
     <mat-icon>add</mat-icon>
-    }
     Add PDF
   </button>
   <input
@@ -76,6 +72,8 @@
   </button>
   }
 </div>
+} @if (uploading()) {
+<bt-bar-loader class="page-loader" label="Uploading" />
 } @if (pageLoading()) {
 <bt-bar-loader class="page-loader" label="Loading page" />
 } @else if (isEmptyImageSource()) {
@@ -88,9 +86,7 @@
   (dragleave)="onDragLeave($event)"
   (drop)="onDrop($event)"
 >
-  @if (uploading()) {
-  <mat-spinner></mat-spinner>
-  } @else {
+  @if (!uploading()) {
   <mat-icon class="upload-icon">add_photo_alternate</mat-icon>
   <p class="dropzone-text">
     Drag and drop an image here or
@@ -124,9 +120,7 @@
   [style.background-size]="'100% 100%'"
 >
   @if (selectionRegionsLoading()) {
-  <div class="area-loading">
-    <mat-spinner></mat-spinner>
-  </div>
+  <bt-bar-loader class="page-loader" label="Loading regions" />
   }
   @for (region of extractionRegions(); track $index) {
   <div

--- a/client/src/app/parser/page/page.component.ts
+++ b/client/src/app/parser/page/page.component.ts
@@ -19,7 +19,6 @@ import { DraggableSelectionDirective } from '../../draggable-selection.directive
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatFormFieldModule, MatLabel } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatChipsModule } from '@angular/material/chips';
@@ -47,7 +46,6 @@ import { SelectionActionsComponent } from '../../selection-actions/selection-act
     MatButtonModule,
     MatIconModule,
     MatMenuModule,
-    MatProgressSpinnerModule,
     MatFormFieldModule,
     MatLabel,
     MatInputModule,


### PR DESCRIPTION
## Summary
Refactored loading indicators throughout the application to use the `bt-bar-loader` component instead of Material's `mat-spinner`, providing a more consistent and visually cohesive loading experience.

## Key Changes
- **Page Component**: Replaced inline spinners in the PDF upload button and dropzone with a centralized `bt-bar-loader` component positioned at the page level
- **Page Component**: Replaced the circular spinner in the selection regions loading state with `bt-bar-loader`
- **Bulk Card Creation FAB**: Moved the duplicate detection spinner from the button to a separate `bt-bar-loader` component below the button
- **Removed CSS**: Deleted the `.area-loading` class that was used for positioning the circular spinner
- **Updated Imports**: Removed `MatProgressSpinnerModule` imports and added `BarLoaderComponent` from `@mucsi96/angular-material-theme`

## Implementation Details
- The `bt-bar-loader` component is now used consistently across all loading states with appropriate labels ("Uploading", "Loading page", "Loading regions", "Checking duplicates")
- Loading indicators are now positioned at the page/component level rather than inline with buttons or in the dropzone, improving visual hierarchy
- The refactoring maintains the same functionality while improving the UI consistency

https://claude.ai/code/session_0194Z4AogrTymQyzxMnkhiXM