### PR TITLE
Refactor vocabulary card grid layout for better responsiveness

### DIFF
--- a/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.css
+++ b/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.css
@@ -18,10 +18,12 @@
 }
 
 .word,
-.forms {
+.forms,
+.example-fields {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   column-gap: 1rem;
+  row-gap: 0.5rem;
 }
 
 .example {
@@ -34,12 +36,6 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-}
-
-.example-fields {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  column-gap: 1rem;
 }
 
 .delete-button {


### PR DESCRIPTION
## Summary
Consolidated and improved the CSS grid layout for the vocabulary card edit form to be more responsive and maintainable.

## Key Changes
- Merged `.example-fields` grid styles into the shared `.word, .forms, .example-fields` selector to reduce duplication
- Updated grid layout from fixed 3-column (`repeat(3, 1fr)`) to responsive auto-fit layout (`repeat(auto-fit, minmax(200px, 1fr))`)
- Added consistent row gap (`0.5rem`) across all grid containers for uniform spacing
- Removed duplicate `.example-fields` rule that was previously defined separately

## Implementation Details
The responsive grid now automatically adjusts the number of columns based on available space, with each column having a minimum width of 200px. This provides better adaptability across different screen sizes while maintaining consistent spacing throughout the form.

https://claude.ai/code/session_01CbjnbxJ21BjfpKZauBtyZH