### PR TITLE
Add bottom margin to vocabulary card fields

### DIFF
--- a/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.css
+++ b/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.css
@@ -15,15 +15,14 @@
 
 .field {
   width: 100%;
+  margin-bottom: 1rem;
 }
 
 .word,
-.forms,
-.example-fields {
+.forms {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   column-gap: 1rem;
-  row-gap: 0.5rem;
 }
 
 .example {
@@ -36,6 +35,12 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+
+.example-fields {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  column-gap: 1rem;
 }
 
 .delete-button {


### PR DESCRIPTION
Revert the grid layout change and instead give .field a bottom margin so form inputs have consistent vertical spacing.