### PR TITLE
Add photo grammar card flow with mobile-to-desktop handoff

### DIFF
--- a/client/src/app/bulk-card-creation-fab/bulk-card-creation-fab.component.ts
+++ b/client/src/app/bulk-card-creation-fab/bulk-card-creation-fab.component.ts
@@ -168,18 +168,24 @@ export class BulkCardCreationFabComponent {
     this.inReviewCardsService.refetchCards();
 
     if (result.succeeded > 0) {
-      const regions = selections.map(sel => ({
-        pageNumber: sel.pageNumber,
-        x: sel.rectangle.x,
-        y: sel.rectangle.y,
-        width: sel.rectangle.width,
-        height: sel.rectangle.height,
-      }));
+      if (selections.length > 0) {
+        const regions = selections.map(sel => ({
+          pageNumber: sel.pageNumber,
+          x: sel.rectangle.x,
+          y: sel.rectangle.y,
+          width: sel.rectangle.width,
+          height: sel.rectangle.height,
+        }));
 
-      await fetchJson(this.http, `/api/source/${selectedSource.sourceId}/extraction-regions`, {
-        body: { documentId: page?.documentId, regions },
-        method: 'POST',
-      });
+        await fetchJson(this.http, `/api/source/${selectedSource.sourceId}/extraction-regions`, {
+          body: { documentId: page?.documentId, regions },
+          method: 'POST',
+        });
+      }
+
+      if (this.candidatesService.hasExternalItems()) {
+        this.candidatesService.clearExternalItems();
+      }
 
       this.pageService.reload();
     }

--- a/client/src/app/bulk-card-creation-fab/bulk-card-creation-fab.component.ts
+++ b/client/src/app/bulk-card-creation-fab/bulk-card-creation-fab.component.ts
@@ -183,10 +183,7 @@ export class BulkCardCreationFabComponent {
         });
       }
 
-      if (this.candidatesService.hasExternalItems()) {
-        this.candidatesService.clearExternalItems();
-      }
-
+      this.candidatesService.clearExternalItems();
       this.pageService.reload();
     }
   }

--- a/client/src/app/card-candidates.service.ts
+++ b/client/src/app/card-candidates.service.ts
@@ -10,24 +10,26 @@ export class CardCandidatesService {
   private readonly pageService = inject(PageService);
   private readonly strategyRegistry = inject(CardTypeRegistry);
   private readonly ignoredIds = signal<Set<string>>(new Set());
+  private readonly externalItems = signal<ExtractedItem[]>([]);
+
+  readonly hasExternalItems = computed(() => this.externalItems().length > 0);
 
   readonly allExtractedItems = computed(() => {
     const selectionRegions = this.pageService.selectionRegions();
 
-    if (!selectionRegions || selectionRegions.length === 0) {
-      return [];
-    }
-
-    const allItems: ExtractedItem[] = [];
-
-    for (const region of selectionRegions) {
-      const result = region.value();
-      if (result) {
-        allItems.push(...result.items);
+    const regionItems: ExtractedItem[] = [];
+    if (selectionRegions && selectionRegions.length > 0) {
+      for (const region of selectionRegions) {
+        const result = region.value();
+        if (result) {
+          regionItems.push(...result.items);
+        }
       }
     }
 
-    const uniqueItems = allItems.filter((item, index, array) =>
+    const merged = [...regionItems, ...this.externalItems()];
+
+    const uniqueItems = merged.filter((item, index, array) =>
       array.findIndex(i => i.id === item.id) === index
     );
 
@@ -65,5 +67,13 @@ export class CardCandidatesService {
 
   clearIgnoredItems(): void {
     this.ignoredIds.set(new Set());
+  }
+
+  setExternalItems(items: ExtractedItem[]): void {
+    this.externalItems.set(items);
+  }
+
+  clearExternalItems(): void {
+    this.externalItems.set([]);
   }
 }

--- a/client/src/app/card-candidates.service.ts
+++ b/client/src/app/card-candidates.service.ts
@@ -15,25 +15,14 @@ export class CardCandidatesService {
   readonly hasExternalItems = computed(() => this.externalItems().length > 0);
 
   readonly allExtractedItems = computed(() => {
-    const selectionRegions = this.pageService.selectionRegions();
-
-    const regionItems: ExtractedItem[] = [];
-    if (selectionRegions && selectionRegions.length > 0) {
-      for (const region of selectionRegions) {
-        const result = region.value();
-        if (result) {
-          regionItems.push(...result.items);
-        }
-      }
-    }
+    const regionItems = this.pageService.selectionRegions()
+      ?.flatMap((region) => region.value()?.items ?? []) ?? [];
 
     const merged = [...regionItems, ...this.externalItems()];
 
-    const uniqueItems = merged.filter((item, index, array) =>
-      array.findIndex(i => i.id === item.id) === index
+    return merged.filter((item, index, array) =>
+      array.findIndex((i) => i.id === item.id) === index
     );
-
-    return uniqueItems;
   });
 
   readonly candidates = computed(() => {

--- a/client/src/app/parser/page/page.component.html
+++ b/client/src/app/parser/page/page.component.html
@@ -71,7 +71,30 @@
     Delete image
   </button>
   }
+  @if (isPhotoGrammarSource()) {
+  <button
+    mat-button
+    aria-label="Capture photo for grammar cards"
+    (click)="photoCaptureInput.click()"
+    [disabled]="photoCaptureUploading()"
+  >
+    <mat-icon>photo_camera</mat-icon>
+    Capture photo
+  </button>
+  <input
+    #photoCaptureInput
+    type="file"
+    accept="image/*"
+    capture="environment"
+    (change)="onPhotoCaptureFileSelected($event, photoCaptureInput)"
+    class="hidden-file-input"
+    aria-label="Capture or upload grammar lesson photo"
+  />
+  }
 </div>
+@if (isPhotoGrammarSource() && pendingPhotoService.hasPending() && selectedSourceId(); as sid) {
+<app-photo-grammar-banner [sourceId]="sid"></app-photo-grammar-banner>
+}
 } @if (uploading()) {
 <bt-bar-loader class="page-loader" label="Uploading" />
 } @if (pageLoading()) {
@@ -178,7 +201,8 @@
 
 @if (selectionStateService.hasSelections()) {
 <app-selection-actions></app-selection-actions>
-} @else if (hasExtractionStarted()) {
-<app-bulk-card-creation-fab></app-bulk-card-creation-fab>
 }
+}
+@if (!selectionStateService.hasSelections() && (hasExtractionStarted() || candidatesService.hasExternalItems())) {
+<app-bulk-card-creation-fab></app-bulk-card-creation-fab>
 }

--- a/client/src/app/parser/page/page.component.ts
+++ b/client/src/app/parser/page/page.component.ts
@@ -35,6 +35,9 @@ import { injectParams } from '../../utils/inject-params';
 import { injectQueryParams } from '../../utils/inject-query-params';
 import { SelectionRectangleComponent } from '../selection-rectangle/selection-rectangle.component';
 import { SelectionActionsComponent } from '../../selection-actions/selection-actions.component';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { PendingPhotoService } from '../../pending-photo.service';
+import { PhotoGrammarBannerComponent } from '../../photo-grammar-banner/photo-grammar-banner.component';
 
 @Component({
   selector: 'app-page',
@@ -55,6 +58,7 @@ import { SelectionActionsComponent } from '../../selection-actions/selection-act
     BulkCardCreationFabComponent,
     SelectionRectangleComponent,
     SelectionActionsComponent,
+    PhotoGrammarBannerComponent,
   ],
   templateUrl: './page.component.html',
   styleUrl: './page.component.css',
@@ -71,6 +75,8 @@ export class PageComponent implements AfterViewInit, OnDestroy {
   readonly candidatesService = inject(CardCandidatesService);
   private readonly knownWordsService = inject(KnownWordsService);
   readonly selectionStateService = inject(SelectionStateService);
+  readonly pendingPhotoService = inject(PendingPhotoService);
+  private readonly snackBar = inject(MatSnackBar);
   readonly sources = this.sourcesService.sources.value;
   readonly extractedCandidates = this.candidatesService.candidates;
   readonly pageNumber = linkedSignal(
@@ -124,6 +130,10 @@ export class PageComponent implements AfterViewInit, OnDestroy {
   readonly isEmptyImageSource = computed(() =>
     this.sourceType() === 'images' && !this.hasImage()
   );
+  readonly isPhotoGrammarSource = computed(() =>
+    this.sourceType() === 'images' && this.cardType() === 'grammar'
+  );
+  readonly photoCaptureUploading = signal(false);
   readonly currentPageSelections = computed(() => {
     const sourceId = this.selectedSourceId();
     const pageNumber = this.pageNumber();
@@ -159,6 +169,14 @@ export class PageComponent implements AfterViewInit, OnDestroy {
           Number(pageNumber),
           documentId ? Number(documentId) : undefined
         );
+      }
+    });
+
+    effect(() => {
+      if (this.isPhotoGrammarSource()) {
+        this.pendingPhotoService.setSource(this.selectedSourceId());
+      } else {
+        this.pendingPhotoService.setSource(undefined);
       }
     });
 
@@ -350,5 +368,50 @@ export class PageComponent implements AfterViewInit, OnDestroy {
 
   ignoreItem(itemId: string): void {
     this.candidatesService.ignoreItem(itemId);
+  }
+
+  onPhotoCaptureFileSelected(event: Event, fileInput: HTMLInputElement): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) {
+      return;
+    }
+    this.uploadPhotoCapture(file).finally(() => {
+      fileInput.value = '';
+    });
+  }
+
+  private async uploadPhotoCapture(file: File): Promise<void> {
+    const sourceId = this.selectedSourceId();
+    if (!sourceId) {
+      return;
+    }
+
+    const validExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.webp'];
+    const fileName = file.name.toLowerCase();
+    if (!validExtensions.some((ext) => fileName.endsWith(ext))) {
+      this.snackBar.open(
+        'Only image files (PNG, JPG, JPEG, GIF, WEBP) are allowed',
+        'Dismiss',
+        { duration: 5000 }
+      );
+      return;
+    }
+
+    this.photoCaptureUploading.set(true);
+
+    try {
+      await this.pendingPhotoService.upload(sourceId, file);
+      this.snackBar.open(
+        'Photo ready - open this source on your computer to create cards',
+        'OK',
+        { duration: 8000 }
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Photo upload failed';
+      this.snackBar.open(message, 'Dismiss', { duration: 5000 });
+    } finally {
+      this.photoCaptureUploading.set(false);
+    }
   }
 }

--- a/client/src/app/pending-photo.service.ts
+++ b/client/src/app/pending-photo.service.ts
@@ -9,6 +9,7 @@ import {
 } from '@angular/core';
 import { ENVIRONMENT_CONFIG } from './environment/environment.config';
 import { SentenceList } from './parser/types';
+import { fetchAsset } from './utils/fetchAsset';
 import { fetchJson } from './utils/fetchJson';
 import { uploadDocument } from './utils/uploadDocument';
 
@@ -47,14 +48,26 @@ export class PendingPhotoService {
   readonly hasPending = computed(() => !!this.status.value()?.hasPending);
   readonly expiresAt = computed(() => this.status.value()?.expiresAt);
 
-  readonly previewUrl = computed(() => {
-    const sid = this.sourceId();
-    if (!sid || !this.hasPending()) {
-      return undefined;
-    }
-    const cacheBuster = this.status.value()?.createdAt ?? '';
-    return `/api/source/${sid}/pending-photo/image?t=${encodeURIComponent(cacheBuster)}`;
+  readonly previewImage = resource<string | undefined, {
+    sourceId: string | undefined;
+    createdAt: string | undefined;
+  }>({
+    params: () => ({
+      sourceId: this.hasPending() ? this.sourceId() : undefined,
+      createdAt: this.status.value()?.createdAt,
+    }),
+    loader: async ({ params }) => {
+      if (!params.sourceId) {
+        return undefined;
+      }
+      return fetchAsset(
+        this.http,
+        `/api/source/${params.sourceId}/pending-photo/image`
+      );
+    },
   });
+
+  readonly previewUrl = computed(() => this.previewImage.value());
 
   constructor() {
     const intervalId = setInterval(() => {

--- a/client/src/app/pending-photo.service.ts
+++ b/client/src/app/pending-photo.service.ts
@@ -7,7 +7,6 @@ import {
   resource,
   signal,
 } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
 import { ENVIRONMENT_CONFIG } from './environment/environment.config';
 import { SentenceList } from './parser/types';
 import { fetchJson } from './utils/fetchJson';
@@ -91,9 +90,9 @@ export class PendingPhotoService {
   }
 
   async discard(sourceId: string): Promise<void> {
-    await firstValueFrom(
-      this.http.delete(`/api/source/${sourceId}/pending-photo`)
-    );
+    await fetchJson(this.http, `/api/source/${sourceId}/pending-photo`, {
+      method: 'DELETE',
+    });
     if (this.sourceId() === sourceId) {
       this.refresh();
     }

--- a/client/src/app/pending-photo.service.ts
+++ b/client/src/app/pending-photo.service.ts
@@ -1,0 +1,125 @@
+import { HttpClient } from '@angular/common/http';
+import {
+  computed,
+  effect,
+  inject,
+  Injectable,
+  resource,
+  signal,
+} from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { ENVIRONMENT_CONFIG } from './environment/environment.config';
+import { SentenceList } from './parser/types';
+import { fetchJson } from './utils/fetchJson';
+import { uploadDocument } from './utils/uploadDocument';
+
+export type PendingPhotoStatus = {
+  hasPending: boolean;
+  createdAt?: string;
+  expiresAt?: string;
+};
+
+const POLL_INTERVAL_MS = 10_000;
+
+@Injectable({ providedIn: 'root' })
+export class PendingPhotoService {
+  private readonly http = inject(HttpClient);
+  private readonly environmentConfig = inject(ENVIRONMENT_CONFIG);
+
+  private readonly sourceId = signal<string | undefined>(undefined);
+  private readonly pollTick = signal(0);
+
+  readonly status = resource<PendingPhotoStatus | undefined, {
+    sourceId: string | undefined;
+    pollTick: number;
+  }>({
+    params: () => ({ sourceId: this.sourceId(), pollTick: this.pollTick() }),
+    loader: async ({ params }) => {
+      if (!params.sourceId) {
+        return undefined;
+      }
+      return fetchJson<PendingPhotoStatus>(
+        this.http,
+        `/api/source/${params.sourceId}/pending-photo`
+      );
+    },
+  });
+
+  readonly hasPending = computed(() => !!this.status.value()?.hasPending);
+  readonly expiresAt = computed(() => this.status.value()?.expiresAt);
+
+  readonly previewUrl = computed(() => {
+    const sid = this.sourceId();
+    if (!sid || !this.hasPending()) {
+      return undefined;
+    }
+    const cacheBuster = this.status.value()?.createdAt ?? '';
+    return `/api/source/${sid}/pending-photo/image?t=${encodeURIComponent(cacheBuster)}`;
+  });
+
+  constructor() {
+    const intervalId = setInterval(() => {
+      if (this.sourceId()) {
+        this.pollTick.update((n) => n + 1);
+      }
+    }, POLL_INTERVAL_MS);
+
+    effect((onCleanup) => {
+      onCleanup(() => clearInterval(intervalId));
+    });
+  }
+
+  setSource(sourceId: string | undefined) {
+    if (this.sourceId() !== sourceId) {
+      this.sourceId.set(sourceId);
+    }
+  }
+
+  refresh() {
+    this.pollTick.update((n) => n + 1);
+  }
+
+  async upload(sourceId: string, file: File): Promise<void> {
+    await uploadDocument<{ detail: string; expiresAt: string }>(
+      this.http,
+      `/api/source/${sourceId}/pending-photo`,
+      file
+    );
+    if (this.sourceId() === sourceId) {
+      this.refresh();
+    }
+  }
+
+  async discard(sourceId: string): Promise<void> {
+    await firstValueFrom(
+      this.http.delete(`/api/source/${sourceId}/pending-photo`)
+    );
+    if (this.sourceId() === sourceId) {
+      this.refresh();
+    }
+  }
+
+  async consume(
+    sourceId: string,
+    cardCount: number
+  ): Promise<{ sentences: string[]; model: string }> {
+    const model = this.environmentConfig.primaryModelByOperation['extraction'];
+    if (!model) {
+      throw new Error('No primary extraction model is configured');
+    }
+    const operationHeaders = { 'X-Operation-ID': crypto.randomUUID() };
+    const response = await fetchJson<SentenceList>(
+      this.http,
+      `/api/source/${sourceId}/pending-photo/consume`,
+      {
+        body: { model, cardCount },
+        method: 'POST',
+        headers: operationHeaders,
+      }
+    );
+    if (this.sourceId() === sourceId) {
+      this.refresh();
+    }
+    return { sentences: response.sentences, model };
+  }
+}

--- a/client/src/app/photo-grammar-banner/photo-grammar-banner.component.css
+++ b/client/src/app/photo-grammar-banner/photo-grammar-banner.component.css
@@ -1,0 +1,30 @@
+.photo-banner {
+  margin: 1rem 0;
+  max-width: 720px;
+}
+
+.photo-preview {
+  display: block;
+  max-width: 100%;
+  max-height: 280px;
+  margin: 0 auto 1rem auto;
+  border-radius: 4px;
+  object-fit: contain;
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.card-count-field {
+  width: 100%;
+  max-width: 240px;
+}
+
+.error-message {
+  color: var(--mat-sys-error);
+  margin: 0.5rem 0 0 0;
+}
+
+mat-card-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}

--- a/client/src/app/photo-grammar-banner/photo-grammar-banner.component.html
+++ b/client/src/app/photo-grammar-banner/photo-grammar-banner.component.html
@@ -1,0 +1,62 @@
+<mat-card class="photo-banner" role="region" aria-label="Pending photo for grammar cards">
+  <mat-card-header>
+    <mat-icon mat-card-avatar>photo_camera</mat-icon>
+    <mat-card-title>Photo ready for grammar cards</mat-card-title>
+    <mat-card-subtitle>
+      A photo of a grammar lesson is waiting. Choose how many cards to generate.
+    </mat-card-subtitle>
+  </mat-card-header>
+
+  @if (previewUrl(); as url) {
+    <img
+      class="photo-preview"
+      [src]="url"
+      alt="Pending grammar lesson photo"
+    />
+  }
+
+  <mat-card-content>
+    <mat-form-field appearance="outline" class="card-count-field">
+      <mat-label>How many cards?</mat-label>
+      <mat-select
+        [ngModel]="cardCount()"
+        (ngModelChange)="cardCount.set($event)"
+        [disabled]="isCreating()"
+      >
+        @for (option of cardCountOptions; track option) {
+          <mat-option [value]="option">{{ option }} cards</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+
+    @if (errorMessage(); as message) {
+      <p class="error-message" role="alert">{{ message }}</p>
+    }
+
+    @if (isCreating()) {
+      <mat-progress-bar mode="indeterminate" aria-label="Generating cards"></mat-progress-bar>
+    }
+  </mat-card-content>
+
+  <mat-card-actions>
+    <button
+      mat-flat-button
+      color="primary"
+      (click)="createCards()"
+      [disabled]="isCreating()"
+      aria-label="Create grammar cards from this photo"
+    >
+      <mat-icon>auto_awesome</mat-icon>
+      Create grammar cards
+    </button>
+    <button
+      mat-stroked-button
+      (click)="discard()"
+      [disabled]="isCreating()"
+      aria-label="Discard pending photo"
+    >
+      <mat-icon>delete_outline</mat-icon>
+      Discard photo
+    </button>
+  </mat-card-actions>
+</mat-card>

--- a/client/src/app/photo-grammar-banner/photo-grammar-banner.component.ts
+++ b/client/src/app/photo-grammar-banner/photo-grammar-banner.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { Component, computed, inject, input, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
@@ -21,7 +20,6 @@ const CARD_COUNT_OPTIONS = [5, 10, 15, 20, 30] as const;
   selector: 'app-photo-grammar-banner',
   standalone: true,
   imports: [
-    CommonModule,
     FormsModule,
     MatCardModule,
     MatButtonModule,
@@ -81,6 +79,7 @@ export class PhotoGrammarBannerComponent {
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to create cards';
       this.errorMessage.set(message);
+    } finally {
       this.isCreating.set(false);
     }
   }

--- a/client/src/app/photo-grammar-banner/photo-grammar-banner.component.ts
+++ b/client/src/app/photo-grammar-banner/photo-grammar-banner.component.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { Component, computed, inject, input, signal } from '@angular/core';
+import { Component, inject, input, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -43,7 +43,7 @@ export class PhotoGrammarBannerComponent {
   readonly isCreating = signal(false);
   readonly errorMessage = signal<string | null>(null);
 
-  readonly previewUrl = computed(() => this.pendingPhotoService.previewUrl());
+  readonly previewUrl = this.pendingPhotoService.previewUrl;
 
   async createCards(): Promise<void> {
     const count = this.cardCount();

--- a/client/src/app/photo-grammar-banner/photo-grammar-banner.component.ts
+++ b/client/src/app/photo-grammar-banner/photo-grammar-banner.component.ts
@@ -1,0 +1,97 @@
+import { CommonModule } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { Component, computed, inject, input, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatSelectModule } from '@angular/material/select';
+import { CardCandidatesService } from '../card-candidates.service';
+import { ExtractedItem } from '../parser/types';
+import { PendingPhotoService } from '../pending-photo.service';
+import { fetchJson } from '../utils/fetchJson';
+
+type SentenceIdResponse = { id: string; exists: boolean };
+
+const CARD_COUNT_OPTIONS = [5, 10, 15, 20, 30] as const;
+
+@Component({
+  selector: 'app-photo-grammar-banner',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    MatProgressBarModule,
+  ],
+  templateUrl: './photo-grammar-banner.component.html',
+  styleUrl: './photo-grammar-banner.component.css',
+})
+export class PhotoGrammarBannerComponent {
+  private readonly http = inject(HttpClient);
+  private readonly pendingPhotoService = inject(PendingPhotoService);
+  private readonly candidatesService = inject(CardCandidatesService);
+
+  readonly sourceId = input.required<string>();
+
+  readonly cardCountOptions = CARD_COUNT_OPTIONS;
+  readonly cardCount = signal<number>(10);
+  readonly isCreating = signal(false);
+  readonly errorMessage = signal<string | null>(null);
+
+  readonly previewUrl = computed(() => this.pendingPhotoService.previewUrl());
+
+  async createCards(): Promise<void> {
+    const count = this.cardCount();
+    const sid = this.sourceId();
+
+    if (!count || count < 1) {
+      return;
+    }
+
+    this.isCreating.set(true);
+    this.errorMessage.set(null);
+
+    try {
+      const { sentences, model } = await this.pendingPhotoService.consume(sid, count);
+
+      const items = await Promise.all(
+        sentences.map(async (sentence): Promise<ExtractedItem & { sentence: string }> => {
+          const idResp = await fetchJson<SentenceIdResponse>(
+            this.http,
+            '/api/sentence-id',
+            { body: { germanSentence: sentence }, method: 'POST' }
+          );
+          return {
+            id: idResp.id,
+            exists: idResp.exists,
+            extractionModel: model,
+            sentence,
+          };
+        })
+      );
+
+      this.candidatesService.setExternalItems(items);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to create cards';
+      this.errorMessage.set(message);
+      this.isCreating.set(false);
+    }
+  }
+
+  async discard(): Promise<void> {
+    this.errorMessage.set(null);
+    try {
+      await this.pendingPhotoService.discard(this.sourceId());
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to discard photo';
+      this.errorMessage.set(message);
+    }
+  }
+}

--- a/mock_google_ai_server/src/chatHandler.ts
+++ b/mock_google_ai_server/src/chatHandler.ts
@@ -188,6 +188,23 @@ export class ChatHandler {
     return null;
   }
 
+  async handlePhotoGrammarConceptExtraction(request: GeminiRequest): Promise<any | null> {
+    if (
+      await imageRequestMatch(
+        request,
+        'You are an expert German language teacher',
+        'photo of the grammar lesson page',
+        ['Paco', 'Frau Wachter']
+      )
+    ) {
+      return createGeminiResponse({
+        sentences: GRAMMAR_SENTENCE_LISTS['photo_grammar_concept_sentences'],
+      });
+    }
+
+    return null;
+  }
+
   handleDictionaryLookup(request: GeminiRequest): any | null {
     const systemContent = request.systemInstruction?.parts?.[0]?.text || '';
     const userContent = getTextContent(request);
@@ -339,6 +356,9 @@ export class ChatHandler {
 
     const grammarExtractionResponse = await this.handleGrammarExtraction(request);
     if (grammarExtractionResponse) return grammarExtractionResponse;
+
+    const photoGrammarResponse = await this.handlePhotoGrammarConceptExtraction(request);
+    if (photoGrammarResponse) return photoGrammarResponse;
 
     const sentenceTranslationResponse = this.handleSentenceTranslation(request);
     if (sentenceTranslationResponse) return sentenceTranslationResponse;

--- a/mock_google_ai_server/src/data.ts
+++ b/mock_google_ai_server/src/data.ts
@@ -260,6 +260,11 @@ export const GRAMMAR_SENTENCE_LISTS: Record<string, string[]> = {
     'Das [ist] Paco.',
     'Und [das] ist Frau Wachter.',
   ],
+  photo_grammar_concept_sentences: [
+    'Heute [bin] ich müde.',
+    'Sie [ist] meine Lehrerin.',
+    'Wir [sind] in Berlin.',
+  ],
 };
 
 interface DictionaryLookup {
@@ -322,5 +327,8 @@ export const SENTENCE_TRANSLATIONS: Record<string, Record<string, string>> = {
     'Wie heißt das Lied?': 'What is the name of the song?',
     'Das [ist] Paco.': 'This is Paco.',
     'Und [das] ist Frau Wachter.': 'And this is Frau Wachter.',
+    'Heute [bin] ich müde.': 'Today I am tired.',
+    'Sie [ist] meine Lehrerin.': 'She is my teacher.',
+    'Wir [sind] in Berlin.': 'We are in Berlin.',
   },
 };

--- a/mock_google_ai_server/src/index.ts
+++ b/mock_google_ai_server/src/index.ts
@@ -6,7 +6,7 @@ const app = express();
 const imageHandler = new ImageGenerationHandler();
 const chatHandler = new ChatHandler();
 
-app.use(express.json());
+app.use(express.json({ limit: '25mb' }));
 
 // Middleware to log access details
 app.use((req, res, next) => {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/LearnLanguageApplication.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/LearnLanguageApplication.java
@@ -3,11 +3,13 @@ package io.github.mucsi96.learnlanguage;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import io.github.mucsi96.learnlanguage.config.DatabaseStartupInitializer;
 
 @SpringBootApplication
 @EnableAsync
+@EnableScheduling
 public class LearnLanguageApplication {
 
 	public static void main(String[] args) {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
@@ -10,8 +10,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,14 +24,19 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import io.github.mucsi96.learnlanguage.entity.Document;
 import io.github.mucsi96.learnlanguage.entity.ExtractionRegion;
 import io.github.mucsi96.learnlanguage.entity.LearningPartner;
+import io.github.mucsi96.learnlanguage.entity.PendingPhoto;
 import io.github.mucsi96.learnlanguage.entity.Source;
 import io.github.mucsi96.learnlanguage.exception.ResourceNotFoundException;
+import io.github.mucsi96.learnlanguage.model.CardType;
 import io.github.mucsi96.learnlanguage.model.ExtractionRegionCreateRequest;
 import io.github.mucsi96.learnlanguage.model.PageResponse;
+import io.github.mucsi96.learnlanguage.model.PendingPhotoConsumeRequest;
+import io.github.mucsi96.learnlanguage.model.PendingPhotoStatusResponse;
 import io.github.mucsi96.learnlanguage.model.RegionExtractionRequest;
 import io.github.mucsi96.learnlanguage.model.SourceDueCardCountResponse;
 import io.github.mucsi96.learnlanguage.model.SourceRequest;
@@ -47,6 +55,8 @@ import io.github.mucsi96.learnlanguage.service.DocumentProcessorService;
 import io.github.mucsi96.learnlanguage.service.FileStorageService;
 import io.github.mucsi96.learnlanguage.service.KnownWordService;
 import io.github.mucsi96.learnlanguage.service.LearningPartnerService;
+import io.github.mucsi96.learnlanguage.service.PendingPhotoService;
+import io.github.mucsi96.learnlanguage.service.PhotoGrammarConceptService;
 import io.github.mucsi96.learnlanguage.service.SourceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
@@ -69,6 +79,8 @@ public class SourceController {
   private final ExtractionRegionRepository extractionRegionRepository;
   private final KnownWordService knownWordService;
   private final LearningPartnerService learningPartnerService;
+  private final PendingPhotoService pendingPhotoService;
+  private final PhotoGrammarConceptService photoGrammarConceptService;
 
   @PreAuthorize("hasAuthority('APPROLE_DeckReader') and hasAuthority('SCOPE_readDecks')")
   @GetMapping("/sources")
@@ -472,6 +484,125 @@ public class SourceController {
         .contentType(mediaType)
         .header("Cache-Control", "public, max-age=31536000, immutable")
         .body(imageData);
+  }
+
+  @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
+  @PostMapping("/source/{sourceId}/pending-photo")
+  public ResponseEntity<Map<String, Object>> uploadPendingPhoto(
+      @PathVariable String sourceId,
+      @RequestParam("file") MultipartFile file,
+      @AuthenticationPrincipal Jwt jwt) throws IOException {
+    final Source source = requirePhotoGrammarSource(sourceId);
+    final String originalFilename = file.getOriginalFilename();
+
+    if (originalFilename == null || !isImageFile(originalFilename)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+          "Only image files (PNG, JPG, JPEG, GIF, WEBP) are allowed");
+    }
+
+    final String contentType = file.getContentType() != null
+        ? file.getContentType()
+        : getMediaTypeForFile(originalFilename).toString();
+
+    final PendingPhoto saved = pendingPhotoService.upsert(
+        resolveUserId(jwt), source, file.getBytes(), contentType);
+
+    return ResponseEntity.ok(Map.<String, Object>of(
+        "detail", "Pending photo stored",
+        "expiresAt", saved.getExpiresAt().toString()));
+  }
+
+  @PreAuthorize("hasAuthority('APPROLE_DeckReader') and hasAuthority('SCOPE_readDecks')")
+  @GetMapping("/source/{sourceId}/pending-photo")
+  public PendingPhotoStatusResponse getPendingPhotoStatus(
+      @PathVariable String sourceId,
+      @AuthenticationPrincipal Jwt jwt) {
+    final Source source = requirePhotoGrammarSource(sourceId);
+
+    return pendingPhotoService.getActive(resolveUserId(jwt), source)
+        .map(photo -> PendingPhotoStatusResponse.builder()
+            .hasPending(true)
+            .createdAt(photo.getCreatedAt())
+            .expiresAt(photo.getExpiresAt())
+            .build())
+        .orElseGet(() -> PendingPhotoStatusResponse.builder().hasPending(false).build());
+  }
+
+  @PreAuthorize("hasAuthority('APPROLE_DeckReader') and hasAuthority('SCOPE_readDecks')")
+  @GetMapping("/source/{sourceId}/pending-photo/image")
+  public ResponseEntity<byte[]> getPendingPhotoImage(
+      @PathVariable String sourceId,
+      @AuthenticationPrincipal Jwt jwt) {
+    final Source source = requirePhotoGrammarSource(sourceId);
+
+    final PendingPhoto photo = pendingPhotoService.getActive(resolveUserId(jwt), source)
+        .orElseThrow(() -> new ResourceNotFoundException("No pending photo for this source"));
+
+    return ResponseEntity.ok()
+        .contentType(MediaType.parseMediaType(photo.getContentType()))
+        .header("Cache-Control", "no-store")
+        .body(photo.getImageData());
+  }
+
+  @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
+  @PostMapping("/source/{sourceId}/pending-photo/consume")
+  public SentenceListResponse consumePendingPhoto(
+      @PathVariable String sourceId,
+      @RequestBody PendingPhotoConsumeRequest request,
+      @AuthenticationPrincipal Jwt jwt) {
+    if (request.getModel() == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "model is required");
+    }
+    final int cardCount = request.getCardCount() != null ? request.getCardCount() : 0;
+    if (cardCount < 1 || cardCount > 50) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "cardCount must be between 1 and 50");
+    }
+
+    final Source source = requirePhotoGrammarSource(sourceId);
+    final String userId = resolveUserId(jwt);
+
+    final PendingPhoto photo = pendingPhotoService.getActive(userId, source)
+        .orElseThrow(() -> new ResourceNotFoundException("No pending photo for this source"));
+
+    final List<String> sentences = photoGrammarConceptService.generateConceptCards(
+        photo.getImageData(),
+        photo.getContentType(),
+        request.getModel(),
+        source.getLanguageLevel(),
+        cardCount);
+
+    pendingPhotoService.delete(photo);
+
+    return SentenceListResponse.builder().sentences(sentences).build();
+  }
+
+  @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
+  @DeleteMapping("/source/{sourceId}/pending-photo")
+  public ResponseEntity<Map<String, String>> discardPendingPhoto(
+      @PathVariable String sourceId,
+      @AuthenticationPrincipal Jwt jwt) {
+    final Source source = requirePhotoGrammarSource(sourceId);
+    pendingPhotoService.discard(resolveUserId(jwt), source);
+    return ResponseEntity.ok(Map.of("detail", "Pending photo discarded"));
+  }
+
+  private Source requirePhotoGrammarSource(String sourceId) {
+    final Source source = sourceService.getSourceById(sourceId)
+        .orElseThrow(() -> new ResourceNotFoundException("Source not found with id: " + sourceId));
+
+    if (source.getSourceType() != SourceType.IMAGES || source.getCardType() != CardType.GRAMMAR) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+          "Photo grammar cards are only supported on IMAGES sources with cardType=grammar");
+    }
+    return source;
+  }
+
+  private String resolveUserId(Jwt jwt) {
+    if (jwt == null) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Missing authenticated principal");
+    }
+    final String oid = jwt.getClaimAsString("oid");
+    return oid != null ? oid : jwt.getSubject();
   }
 
   private MediaType getMediaTypeForFile(String fileName) {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
@@ -519,11 +519,11 @@ public class SourceController {
       @AuthenticationPrincipal Jwt jwt) {
     final Source source = requirePhotoGrammarSource(sourceId);
 
-    return pendingPhotoService.getActive(resolveUserId(jwt), source)
-        .map(photo -> PendingPhotoStatusResponse.builder()
+    return pendingPhotoService.getActiveMeta(resolveUserId(jwt), source)
+        .map(meta -> PendingPhotoStatusResponse.builder()
             .hasPending(true)
-            .createdAt(photo.getCreatedAt())
-            .expiresAt(photo.getExpiresAt())
+            .createdAt(meta.getCreatedAt())
+            .expiresAt(meta.getExpiresAt())
             .build())
         .orElseGet(() -> PendingPhotoStatusResponse.builder().hasPending(false).build());
   }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
@@ -16,6 +16,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.server.ResponseStatusException;
 
 import io.github.mucsi96.learnlanguage.entity.Document;
@@ -67,6 +69,8 @@ import com.azure.core.util.BinaryData;
 @RestController
 @RequiredArgsConstructor
 public class SourceController {
+
+  private static final long MAX_PENDING_PHOTO_BYTES = 10L * 1024 * 1024;
 
   private final SourceService sourceService;
   private final CardService cardService;
@@ -500,6 +504,11 @@ public class SourceController {
           "Only image files (PNG, JPG, JPEG, GIF, WEBP) are allowed");
     }
 
+    if (file.getSize() > MAX_PENDING_PHOTO_BYTES) {
+      throw new ResponseStatusException(HttpStatus.PAYLOAD_TOO_LARGE,
+          "Photo must be under 10 MB");
+    }
+
     final String contentType = file.getContentType() != null
         ? file.getContentType()
         : getMediaTypeForFile(originalFilename).toString();
@@ -584,6 +593,12 @@ public class SourceController {
     final Source source = requirePhotoGrammarSource(sourceId);
     pendingPhotoService.discard(resolveUserId(jwt), source);
     return ResponseEntity.ok(Map.of("detail", "Pending photo discarded"));
+  }
+
+  @ExceptionHandler(MaxUploadSizeExceededException.class)
+  public ResponseEntity<Map<String, String>> handleUploadTooLarge(MaxUploadSizeExceededException ex) {
+    return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE)
+        .body(Map.of("error", "Uploaded file exceeds the maximum allowed size"));
   }
 
   private Source requirePhotoGrammarSource(String sourceId) {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/entity/PendingPhoto.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/entity/PendingPhoto.java
@@ -1,0 +1,56 @@
+package io.github.mucsi96.learnlanguage.entity;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "pending_photos",
+    schema = "learn_language",
+    uniqueConstraints = @UniqueConstraint(
+        name = "pending_photos_user_source_unique",
+        columnNames = {"user_id", "source_id"}))
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PendingPhoto {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID id;
+
+  @Column(name = "user_id", nullable = false)
+  private String userId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "source_id", nullable = false)
+  private Source source;
+
+  @Column(name = "image_data", nullable = false, columnDefinition = "bytea")
+  private byte[] imageData;
+
+  @Column(name = "content_type", nullable = false)
+  private String contentType;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  @Column(name = "expires_at", nullable = false)
+  private Instant expiresAt;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/PendingPhotoConsumeRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/PendingPhotoConsumeRequest.java
@@ -1,0 +1,9 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import lombok.Data;
+
+@Data
+public class PendingPhotoConsumeRequest {
+  private ChatModel model;
+  private Integer cardCount;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/PendingPhotoStatusResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/PendingPhotoStatusResponse.java
@@ -1,0 +1,14 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import java.time.Instant;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PendingPhotoStatusResponse {
+  private boolean hasPending;
+  private Instant createdAt;
+  private Instant expiresAt;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/PendingPhotoMetaProjection.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/PendingPhotoMetaProjection.java
@@ -1,0 +1,12 @@
+package io.github.mucsi96.learnlanguage.repository;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public interface PendingPhotoMetaProjection {
+  UUID getId();
+
+  Instant getCreatedAt();
+
+  Instant getExpiresAt();
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/PendingPhotoRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/PendingPhotoRepository.java
@@ -1,0 +1,25 @@
+package io.github.mucsi96.learnlanguage.repository;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import io.github.mucsi96.learnlanguage.entity.PendingPhoto;
+import io.github.mucsi96.learnlanguage.entity.Source;
+
+public interface PendingPhotoRepository extends JpaRepository<PendingPhoto, UUID> {
+  Optional<PendingPhoto> findByUserIdAndSource(String userId, Source source);
+
+  @Modifying
+  @Query("delete from PendingPhoto p where p.userId = :userId and p.source = :source")
+  void deleteByUserIdAndSource(@Param("userId") String userId, @Param("source") Source source);
+
+  @Modifying
+  @Query("delete from PendingPhoto p where p.expiresAt < :cutoff")
+  int deleteByExpiresAtBefore(@Param("cutoff") Instant cutoff);
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/PendingPhotoRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/PendingPhotoRepository.java
@@ -15,7 +15,11 @@ import io.github.mucsi96.learnlanguage.entity.Source;
 public interface PendingPhotoRepository extends JpaRepository<PendingPhoto, UUID> {
   Optional<PendingPhoto> findByUserIdAndSource(String userId, Source source);
 
-  Optional<PendingPhotoMetaProjection> findMetaByUserIdAndSource(String userId, Source source);
+  @Query("select p.id as id, p.createdAt as createdAt, p.expiresAt as expiresAt "
+      + "from PendingPhoto p where p.userId = :userId and p.source = :source")
+  Optional<PendingPhotoMetaProjection> findMetaByUserIdAndSource(
+      @Param("userId") String userId,
+      @Param("source") Source source);
 
   @Modifying
   @Query("delete from PendingPhoto p where p.userId = :userId and p.source = :source")
@@ -25,7 +29,7 @@ public interface PendingPhotoRepository extends JpaRepository<PendingPhoto, UUID
   @Query("delete from PendingPhoto p where p.id = :id")
   void deleteByIdSkippingLoad(@Param("id") UUID id);
 
-  @Modifying
+  @Modifying(clearAutomatically = true)
   @Query("delete from PendingPhoto p where p.expiresAt < :cutoff")
   int deleteByExpiresAtBefore(@Param("cutoff") Instant cutoff);
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/PendingPhotoRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/PendingPhotoRepository.java
@@ -15,9 +15,15 @@ import io.github.mucsi96.learnlanguage.entity.Source;
 public interface PendingPhotoRepository extends JpaRepository<PendingPhoto, UUID> {
   Optional<PendingPhoto> findByUserIdAndSource(String userId, Source source);
 
+  Optional<PendingPhotoMetaProjection> findMetaByUserIdAndSource(String userId, Source source);
+
   @Modifying
   @Query("delete from PendingPhoto p where p.userId = :userId and p.source = :source")
   void deleteByUserIdAndSource(@Param("userId") String userId, @Param("source") Source source);
+
+  @Modifying
+  @Query("delete from PendingPhoto p where p.id = :id")
+  void deleteByIdSkippingLoad(@Param("id") UUID id);
 
   @Modifying
   @Query("delete from PendingPhoto p where p.expiresAt < :cutoff")

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/PendingPhotoService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/PendingPhotoService.java
@@ -1,0 +1,73 @@
+package io.github.mucsi96.learnlanguage.service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.github.mucsi96.learnlanguage.entity.PendingPhoto;
+import io.github.mucsi96.learnlanguage.entity.Source;
+import io.github.mucsi96.learnlanguage.repository.PendingPhotoRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PendingPhotoService {
+
+  static final Duration TTL = Duration.ofHours(24);
+
+  private final PendingPhotoRepository pendingPhotoRepository;
+
+  @Transactional
+  public PendingPhoto upsert(String userId, Source source, byte[] bytes, String contentType) {
+    pendingPhotoRepository.deleteByUserIdAndSource(userId, source);
+    pendingPhotoRepository.flush();
+
+    final Instant now = Instant.now();
+    return pendingPhotoRepository.save(PendingPhoto.builder()
+        .userId(userId)
+        .source(source)
+        .imageData(bytes)
+        .contentType(contentType)
+        .createdAt(now)
+        .expiresAt(now.plus(TTL))
+        .build());
+  }
+
+  @Transactional
+  public Optional<PendingPhoto> getActive(String userId, Source source) {
+    final Optional<PendingPhoto> existing = pendingPhotoRepository.findByUserIdAndSource(userId, source);
+
+    return existing.flatMap(photo -> {
+      if (photo.getExpiresAt().isBefore(Instant.now())) {
+        pendingPhotoRepository.delete(photo);
+        return Optional.empty();
+      }
+      return Optional.of(photo);
+    });
+  }
+
+  @Transactional
+  public void discard(String userId, Source source) {
+    pendingPhotoRepository.deleteByUserIdAndSource(userId, source);
+  }
+
+  @Transactional
+  public void delete(PendingPhoto photo) {
+    pendingPhotoRepository.delete(photo);
+  }
+
+  @Scheduled(fixedRate = 3_600_000L)
+  @Transactional
+  public void cleanupExpired() {
+    final int removed = pendingPhotoRepository.deleteByExpiresAtBefore(Instant.now());
+    if (removed > 0) {
+      log.info("Cleaned up {} expired pending photo(s)", removed);
+    }
+  }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/PendingPhotoService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/PendingPhotoService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import io.github.mucsi96.learnlanguage.entity.PendingPhoto;
 import io.github.mucsi96.learnlanguage.entity.Source;
+import io.github.mucsi96.learnlanguage.repository.PendingPhotoMetaProjection;
 import io.github.mucsi96.learnlanguage.repository.PendingPhotoRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,16 +41,27 @@ public class PendingPhotoService {
   }
 
   @Transactional
-  public Optional<PendingPhoto> getActive(String userId, Source source) {
-    final Optional<PendingPhoto> existing = pendingPhotoRepository.findByUserIdAndSource(userId, source);
+  public Optional<PendingPhotoMetaProjection> getActiveMeta(String userId, Source source) {
+    return pendingPhotoRepository.findMetaByUserIdAndSource(userId, source)
+        .flatMap(meta -> {
+          if (meta.getExpiresAt().isBefore(Instant.now())) {
+            pendingPhotoRepository.deleteByIdSkippingLoad(meta.getId());
+            return Optional.empty();
+          }
+          return Optional.of(meta);
+        });
+  }
 
-    return existing.flatMap(photo -> {
-      if (photo.getExpiresAt().isBefore(Instant.now())) {
-        pendingPhotoRepository.delete(photo);
-        return Optional.empty();
-      }
-      return Optional.of(photo);
-    });
+  @Transactional
+  public Optional<PendingPhoto> getActive(String userId, Source source) {
+    return pendingPhotoRepository.findByUserIdAndSource(userId, source)
+        .flatMap(photo -> {
+          if (photo.getExpiresAt().isBefore(Instant.now())) {
+            pendingPhotoRepository.delete(photo);
+            return Optional.empty();
+          }
+          return Optional.of(photo);
+        });
   }
 
   @Transactional

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/PhotoGrammarConceptService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/PhotoGrammarConceptService.java
@@ -33,7 +33,7 @@ public class PhotoGrammarConceptService {
 
         Rules:
         - !IMPORTANT! Do NOT copy the printed exercise sentences from the photo verbatim. Produce fresh, original sentences that exercise the same concepts.
-        - Each sentence has exactly one blank, marked by wrapping the target word or form in square brackets. Example: "Ich gehe jeden [Tag] in die Schule.", "Der Hund [läuft] schnell durch [den] Park." - in the second example there are two brackets only if a single concept requires more than one blank to express; prefer ONE blank per sentence.
+        - Each sentence must have EXACTLY ONE blank, marked by wrapping the target word or form in square brackets. Example: "Ich gehe jeden [Tag] in die Schule."
         - Each sentence must be a complete standalone German sentence with proper capitalisation and punctuation.
         - Sentences must be appropriate for %s level learners.
         - Skip any handwritten text on the photo.
@@ -42,7 +42,7 @@ public class PhotoGrammarConceptService {
 
     final ConceptSentences example = new ConceptSentences(List.of(
         "Ich gehe jeden [Tag] in die Schule.",
-        "Der Hund läuft schnell durch [den] Park."));
+        "Der Hund läuft schnell durch den [Park]."));
 
     final String exampleJson = jsonMapper.writeValueAsString(example);
     return basePrompt + "\nExample JSON response shape:\n" + exampleJson;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/PhotoGrammarConceptService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/PhotoGrammarConceptService.java
@@ -1,0 +1,76 @@
+package io.github.mucsi96.learnlanguage.service;
+
+import java.util.List;
+
+import org.springframework.ai.content.Media;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MimeType;
+import org.springframework.util.MimeTypeUtils;
+
+import io.github.mucsi96.learnlanguage.model.ChatModel;
+import io.github.mucsi96.learnlanguage.model.LanguageLevel;
+import io.github.mucsi96.learnlanguage.model.OperationType;
+import lombok.RequiredArgsConstructor;
+import tools.jackson.databind.json.JsonMapper;
+
+@Service
+@RequiredArgsConstructor
+public class PhotoGrammarConceptService {
+
+  record ConceptSentences(List<String> sentences) {
+  }
+
+  private final JsonMapper jsonMapper;
+  private final ChatService chatService;
+
+  private String buildSystemPrompt(LanguageLevel languageLevel, int cardCount) {
+    final String basePrompt = """
+        You are an expert German language teacher. You are looking at a photo of a page from a German grammar textbook lesson.
+
+        Your task:
+        1. Identify the grammatical concepts the lesson is teaching (rules, paradigms, exceptions, vocabulary in scope, sentence patterns). Examples: dative prepositions, modal verb conjugation, separable verbs in Perfekt, adjective endings, two-way prepositions, relative clauses, reflexive verbs, etc.
+        2. Generate exactly %d original German practice sentences at language level %s. The sentences together must cover the breadth of the concepts you identified - distribute coverage across all concepts and avoid repeating the same pattern.
+
+        Rules:
+        - !IMPORTANT! Do NOT copy the printed exercise sentences from the photo verbatim. Produce fresh, original sentences that exercise the same concepts.
+        - Each sentence has exactly one blank, marked by wrapping the target word or form in square brackets. Example: "Ich gehe jeden [Tag] in die Schule.", "Der Hund [läuft] schnell durch [den] Park." - in the second example there are two brackets only if a single concept requires more than one blank to express; prefer ONE blank per sentence.
+        - Each sentence must be a complete standalone German sentence with proper capitalisation and punctuation.
+        - Sentences must be appropriate for %s level learners.
+        - Skip any handwritten text on the photo.
+        - !IMPORTANT! Respond ONLY with JSON in the form {"sentences": [...]} matching the example below.
+        """.formatted(cardCount, languageLevel.name(), languageLevel.name());
+
+    final ConceptSentences example = new ConceptSentences(List.of(
+        "Ich gehe jeden [Tag] in die Schule.",
+        "Der Hund läuft schnell durch [den] Park."));
+
+    final String exampleJson = jsonMapper.writeValueAsString(example);
+    return basePrompt + "\nExample JSON response shape:\n" + exampleJson;
+  }
+
+  public List<String> generateConceptCards(
+      byte[] imageData,
+      String contentType,
+      ChatModel model,
+      LanguageLevel languageLevel,
+      int cardCount) {
+    final MimeType mimeType = contentType != null && !contentType.isBlank()
+        ? MimeTypeUtils.parseMimeType(contentType)
+        : MimeTypeUtils.IMAGE_PNG;
+
+    final var result = chatService.callWithLoggingAndMedia(
+        model,
+        OperationType.EXTRACTION,
+        buildSystemPrompt(languageLevel, cardCount),
+        imageData,
+        u -> u
+            .text("Here is the photo of the grammar lesson page. Generate exactly %d sentences.".formatted(cardCount))
+            .media(Media.builder()
+                .data(imageData)
+                .mimeType(mimeType)
+                .build()),
+        ConceptSentences.class);
+
+    return result.sentences;
+  }
+}

--- a/server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -844,3 +844,59 @@ databaseChangeLog:
                     nullable: false
                     unique: true
                     uniqueConstraintName: grammar_topics_name_unique
+  - changeSet:
+      id: 26-create-pending-photos-table
+      author: mucsi96
+      changes:
+        - createTable:
+            tableName: pending_photos
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    primaryKey: true
+                    primaryKeyName: pending_photos_pkey
+              - column:
+                  name: user_id
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: source_id
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+                    foreignKeyName: pending_photo_source_fkey
+                    references: sources(id)
+                    deleteCascade: true
+              - column:
+                  name: image_data
+                  type: bytea
+                  constraints:
+                    nullable: false
+              - column:
+                  name: content_type
+                  type: varchar(100)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: timestamp(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: expires_at
+                  type: timestamp(6)
+                  constraints:
+                    nullable: false
+        - addUniqueConstraint:
+            tableName: pending_photos
+            columnNames: user_id, source_id
+            constraintName: pending_photos_user_source_unique
+        - createIndex:
+            tableName: pending_photos
+            indexName: pending_photos_expires_at_idx
+            columns:
+              - column:
+                  name: expires_at

--- a/test/tests/photo-grammar.spec.ts
+++ b/test/tests/photo-grammar.spec.ts
@@ -1,0 +1,169 @@
+import { test, expect } from '../fixtures';
+import {
+  createGrammarTopic,
+  createRateLimitSetting,
+  getPendingPhotos,
+  menschenA1GrammarImage,
+  setupDefaultChatModelSettings,
+  setupDefaultImageModelSettings,
+  withDbConnection,
+} from '../utils';
+
+const PHOTO_FILENAME = 'photo-grammar-lesson.png';
+
+test('capture photo button is hidden on non-grammar sources', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await setupDefaultImageModelSettings();
+  await page.goto('/sources');
+  await page.getByRole('article', { name: 'Goethe A1' }).click();
+  await page.getByRole('button', { name: 'Pages' }).click();
+
+  await expect(
+    page.getByRole('button', { name: 'Capture photo for grammar cards' })
+  ).not.toBeVisible();
+});
+
+test('capture photo button is visible on grammar IMAGES source and uploading produces a pending photo', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await setupDefaultImageModelSettings();
+  await createRateLimitSetting({ key: 'image-per-minute', value: 60 });
+  await page.goto('/sources');
+  await page.getByRole('article', { name: 'Grammar A1' }).click();
+  await page.getByRole('button', { name: 'Pages' }).click();
+
+  const captureButton = page.getByRole('button', {
+    name: 'Capture photo for grammar cards',
+  });
+  await expect(captureButton).toBeVisible();
+
+  await page.getByLabel('Capture or upload grammar lesson photo').setInputFiles({
+    name: PHOTO_FILENAME,
+    mimeType: 'image/png',
+    buffer: menschenA1GrammarImage,
+  });
+
+  await expect(
+    page.getByText('Photo ready - open this source on your computer to create cards')
+  ).toBeVisible();
+
+  const stored = await getPendingPhotos('grammar-a1');
+  expect(stored.length).toBe(1);
+  expect(stored[0].contentType).toContain('image');
+  expect(stored[0].imageDataLength).toBe(menschenA1GrammarImage.length);
+});
+
+test('pending photo banner consumes photo and creates grammar cards', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await setupDefaultImageModelSettings();
+  await createRateLimitSetting({ key: 'image-per-minute', value: 60 });
+  await createGrammarTopic({ name: 'Sein conjugation' });
+
+  await page.goto('/sources');
+  await page.getByRole('article', { name: 'Grammar A1' }).click();
+  await page.getByRole('button', { name: 'Pages' }).click();
+
+  await page.getByLabel('Capture or upload grammar lesson photo').setInputFiles({
+    name: PHOTO_FILENAME,
+    mimeType: 'image/png',
+    buffer: menschenA1GrammarImage,
+  });
+
+  await expect(
+    page.getByRole('region', { name: 'Pending photo for grammar cards' })
+  ).toBeVisible();
+
+  await expect(
+    page.getByAltText('Pending grammar lesson photo')
+  ).toBeVisible();
+
+  await page.getByRole('combobox', { name: 'How many cards?' }).click();
+  await page.getByRole('option', { name: '5 cards' }).click();
+
+  await page
+    .getByRole('button', { name: 'Create grammar cards from this photo' })
+    .click();
+
+  await expect(
+    page.getByRole('button', { name: 'Create cards in bulk' })
+  ).toBeVisible();
+
+  await page.getByRole('button', { name: 'Create cards in bulk' }).click();
+
+  const topicDialog = page.getByRole('dialog', { name: 'Choose Grammar Topic' });
+  await expect(topicDialog).toBeVisible();
+  await topicDialog.getByLabel('Grammar topic').click();
+  await page.getByRole('option', { name: 'Sein conjugation' }).click();
+  await topicDialog.getByRole('button', { name: 'Continue' }).click();
+
+  await expect(
+    page.getByRole('dialog').getByRole('button', { name: 'Close' })
+  ).toBeVisible();
+  await page.getByRole('button', { name: 'Close' }).click();
+
+  const cards = await withDbConnection(async (client) => {
+    const result = await client.query(
+      `SELECT id, data, source_id, source_page_number, state, readiness
+       FROM learn_language.cards WHERE source_id = 'grammar-a1'`
+    );
+    return result.rows;
+  });
+
+  expect(cards.length).toBe(3);
+
+  const sentences = cards
+    .map((row) => row.data.examples?.[0]?.de as string)
+    .sort();
+  expect(sentences).toEqual(
+    ['Heute [bin] ich müde.', 'Sie [ist] meine Lehrerin.', 'Wir [sind] in Berlin.'].sort()
+  );
+
+  for (const card of cards) {
+    expect(card.data.grammarTopic).toBe('Sein conjugation');
+    expect(card.readiness).toBe('IN_REVIEW');
+    expect(card.data.extractionModel).toBe('gemini-3.1-pro-preview');
+  }
+
+  const stored = await getPendingPhotos('grammar-a1');
+  expect(stored.length).toBe(0);
+
+  await expect(
+    page.getByRole('region', { name: 'Pending photo for grammar cards' })
+  ).not.toBeVisible();
+});
+
+test('discarding the pending photo banner removes the photo and no cards are created', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await setupDefaultImageModelSettings();
+  await createRateLimitSetting({ key: 'image-per-minute', value: 60 });
+
+  await page.goto('/sources');
+  await page.getByRole('article', { name: 'Grammar A1' }).click();
+  await page.getByRole('button', { name: 'Pages' }).click();
+
+  await page.getByLabel('Capture or upload grammar lesson photo').setInputFiles({
+    name: PHOTO_FILENAME,
+    mimeType: 'image/png',
+    buffer: menschenA1GrammarImage,
+  });
+
+  await expect(
+    page.getByRole('region', { name: 'Pending photo for grammar cards' })
+  ).toBeVisible();
+
+  await page.getByRole('button', { name: 'Discard pending photo' }).click();
+
+  await expect(
+    page.getByRole('region', { name: 'Pending photo for grammar cards' })
+  ).not.toBeVisible();
+
+  const stored = await getPendingPhotos('grammar-a1');
+  expect(stored.length).toBe(0);
+
+  const cards = await withDbConnection(async (client) => {
+    const result = await client.query(
+      `SELECT id FROM learn_language.cards WHERE source_id = 'grammar-a1'`
+    );
+    return result.rows;
+  });
+  expect(cards.length).toBe(0);
+});

--- a/test/tests/photo-grammar.spec.ts
+++ b/test/tests/photo-grammar.spec.ts
@@ -77,7 +77,7 @@ test('pending photo banner consumes photo and creates grammar cards', async ({ p
   ).toBeVisible();
 
   await page.getByRole('combobox', { name: 'How many cards?' }).click();
-  await page.getByRole('option', { name: '5 cards' }).click();
+  await page.getByRole('option', { name: '5 cards', exact: true }).click();
 
   await page
     .getByRole('button', { name: 'Create grammar cards from this photo' })

--- a/test/tests/photo-grammar.spec.ts
+++ b/test/tests/photo-grammar.spec.ts
@@ -83,10 +83,6 @@ test('pending photo banner consumes photo and creates grammar cards', async ({ p
     .getByRole('button', { name: 'Create grammar cards from this photo' })
     .click();
 
-  await expect(
-    page.getByRole('button', { name: 'Create cards in bulk' })
-  ).toBeVisible();
-
   await page.getByRole('button', { name: 'Create cards in bulk' }).click();
 
   const topicDialog = page.getByRole('dialog', { name: 'Choose Grammar Topic' });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1125,6 +1125,27 @@ export async function getLearningPartners(): Promise<
   });
 }
 
+export async function getPendingPhotos(sourceId: string): Promise<
+  Array<{
+    id: string;
+    userId: string;
+    sourceId: string;
+    contentType: string;
+    imageDataLength: number;
+  }>
+> {
+  return await withDbConnection(async (client) => {
+    const result = await client.query(
+      `SELECT id::text as id, user_id as "userId", source_id as "sourceId",
+              content_type as "contentType", octet_length(image_data) as "imageDataLength"
+       FROM learn_language.pending_photos
+       WHERE source_id = $1`,
+      [sourceId]
+    );
+    return result.rows;
+  });
+}
+
 export async function createGrammarTopic(params: { name: string }): Promise<number> {
   const { name } = params;
 


### PR DESCRIPTION
Capture a phone photo of a grammar lesson on mobile, then create cards
covering the lesson's concepts on desktop. The image lives briefly in
a dedicated pending_photo row (24h TTL, cleaned on success or by a
scheduled task) - never as a stored Document.

The AI is prompted to identify the grammatical concepts in the photo
and generate fresh practice sentences rather than copying printed
exercises verbatim. The user picks how many cards to generate.

The feature is gated to IMAGES sources with cardType=grammar.

https://claude.ai/code/session_0158WgHEyRzaWBfhEVte1BQD