### PR TITLE
Exclude Google GenAI embedding auto-configurations

### DIFF
--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 storage:
   directory: ${STORAGE_DIRECTORY}
 spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.ai.model.google.genai.autoconfigure.embedding.GoogleGenAiEmbeddingConnectionAutoConfiguration
+      - org.springframework.ai.model.google.genai.autoconfigure.embedding.GoogleGenAiTextEmbeddingAutoConfiguration
   servlet:
     multipart:
       max-file-size: 10MB


### PR DESCRIPTION
## Summary
Disable Spring AI's Google GenAI embedding auto-configurations to prevent unwanted automatic initialization of embedding-related beans.

## Changes
- Excluded `GoogleGenAiEmbeddingConnectionAutoConfiguration` from Spring Boot auto-configuration
- Excluded `GoogleGenAiTextEmbeddingAutoConfiguration` from Spring Boot auto-configuration

These configurations are now explicitly disabled in `application.yml` to give the application more control over embedding initialization and prevent potential conflicts or unnecessary bean creation.

https://claude.ai/code/session_017xgUr93KPQxurZ8rJAVCVR