### PR TITLE
Auto-generate source IDs from names using slugify

### DIFF
--- a/client/src/app/shared/source-dialog/source-dialog.component.html
+++ b/client/src/app/shared/source-dialog/source-dialog.component.html
@@ -5,14 +5,6 @@
       <h3 class="section-title">General</h3>
       <div class="form-grid">
         <mat-form-field appearance="fill">
-          <mat-label>Source ID</mat-label>
-          <input
-            matInput
-            [formField]="sourceForm.id"
-          />
-        </mat-form-field>
-
-        <mat-form-field appearance="fill">
           <mat-label>Name</mat-label>
           <input matInput [formField]="sourceForm.name" />
         </mat-form-field>

--- a/client/src/app/shared/source-dialog/source-dialog.component.ts
+++ b/client/src/app/shared/source-dialog/source-dialog.component.ts
@@ -19,6 +19,19 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { ENVIRONMENT_CONFIG } from '../../environment/environment.config';
 import { LearningPartnersService } from '../../learning-partners/learning-partners.service';
 
+const SLUG_MAX_LENGTH = 50;
+
+const slugify = (input: string): string =>
+  input
+    .normalize('NFKD')
+    .replace(/ß/g, 'ss')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, SLUG_MAX_LENGTH)
+    .replace(/-+$/g, '');
+
 @Component({
   selector: 'app-source-dialog',
   templateUrl: './source-dialog.component.html',
@@ -55,7 +68,6 @@ export class SourceDialogComponent {
   ];
 
   readonly formModel = signal<{
-    id: string;
     name: string;
     sourceType: SourceType | '';
     fileName: string;
@@ -67,7 +79,6 @@ export class SourceDialogComponent {
     newCardLimit: number;
     learningPartnerId: number | null;
   }>({
-    id: this.data.source?.id || '',
     name: this.data.source?.name || '',
     sourceType: this.data.source?.sourceType ?? '',
     fileName: '',
@@ -80,7 +91,6 @@ export class SourceDialogComponent {
     learningPartnerId: this.data.source?.learningPartnerId ?? null,
   });
   readonly sourceForm = form(this.formModel, (path) => {
-    required(path.id);
     required(path.name);
     required(path.cardType);
     required(path.languageLevel);
@@ -95,7 +105,6 @@ export class SourceDialogComponent {
       }
       return undefined;
     });
-    disabled(path.id, () => this.data.mode === 'edit');
     disabled(path.cardType, () => this.data.mode === 'edit');
     disabled(path.sourceType, () => this.data.mode === 'edit');
   });
@@ -125,8 +134,11 @@ export class SourceDialogComponent {
         }
       }
       const result = this.formModel();
+      const id = this.data.mode === 'edit'
+        ? this.data.source?.id
+        : slugify(result.name);
       const formData: Partial<Source> & { fileName?: string } = {
-        id: result.id,
+        id,
         name: result.name,
         sourceType: result.sourceType || undefined,
         fileName: result.fileName,

--- a/test/tests/image-sources.spec.ts
+++ b/test/tests/image-sources.spec.ts
@@ -14,7 +14,6 @@ test('can create an image source', async ({ page }) => {
 
   await page.getByRole('button', { name: 'Add Source' }).click();
 
-  await page.getByLabel('Source ID').fill('test-image-source');
   await page.getByRole('textbox', { name: 'Name', exact: true }).fill('Test Image Source');
 
   await page.getByLabel('Card Type').click();

--- a/test/tests/sources.spec.ts
+++ b/test/tests/sources.spec.ts
@@ -261,7 +261,6 @@ test('can create a new source', async ({ page }) => {
 
   await page.getByRole('button', { name: 'Add Source' }).click();
 
-  await page.getByLabel('Source ID').fill('test-source');
   await page.getByRole('textbox', { name: 'Name', exact: true }).fill('Test Source');
 
   await page.getByLabel('Card Type').click();
@@ -312,7 +311,7 @@ test('can edit an existing source', async ({ page }) => {
   await page.getByRole('button', { name: 'Edit' }).click();
 
   await expect(page.getByRole('heading', { name: 'Edit Source' })).toBeVisible();
-  await expect(page.getByLabel('Source ID')).toBeDisabled();
+  await expect(page.getByLabel('Source ID')).not.toBeVisible();
   await expect(page.getByRole('textbox', { name: 'Name', exact: true })).toHaveValue('Goethe A1');
 
   const nameField = page.getByRole('textbox', { name: 'Name', exact: true });
@@ -378,7 +377,6 @@ test('can cancel source creation', async ({ page }) => {
 
   await page.getByRole('button', { name: 'Add Source' }).click();
 
-  await page.getByLabel('Source ID').fill('test-cancelled');
   await page.getByRole('textbox', { name: 'Name', exact: true }).fill('Test Cancelled');
 
   await page.getByRole('button', { name: 'Cancel' }).click();
@@ -399,8 +397,6 @@ test('validates required fields when creating source', async ({ page }) => {
 
   const createButton = page.getByRole('button', { name: 'Create' });
   await expect(createButton).toBeDisabled();
-
-  await page.getByLabel('Source ID').fill('test-id');
 
   await page.getByLabel('Card Type').click();
   await page.getByRole('option', { name: 'Vocabulary' }).click();
@@ -445,7 +441,6 @@ test('can create a speech source with image collection', async ({ page }) => {
 
   await page.getByRole('button', { name: 'Add Source' }).click();
 
-  await page.getByLabel('Source ID').fill('test-speech-source');
   await page.getByRole('textbox', { name: 'Name', exact: true }).fill('Test Speech Source');
 
   await page.getByLabel('Card Type').click();
@@ -477,7 +472,6 @@ test('can create a grammar source with image collection', async ({ page }) => {
 
   await page.getByRole('button', { name: 'Add Source' }).click();
 
-  await page.getByLabel('Source ID').fill('test-grammar-source');
   await page.getByRole('textbox', { name: 'Name', exact: true }).fill('Test Grammar Source');
 
   await page.getByLabel('Card Type').click();


### PR DESCRIPTION
## Summary
Removes manual source ID input from the source creation dialog and automatically generates IDs from source names using a slugify function. This simplifies the user experience by eliminating a required field while maintaining unique, URL-friendly identifiers.

## Key Changes
- Added `slugify()` utility function that normalizes input strings to create URL-friendly identifiers (max 50 characters)
- Removed the `id` field from the source dialog form model and UI
- Changed ID generation logic:
  - **Create mode**: Auto-generates ID by slugifying the source name
  - **Edit mode**: Preserves the existing source ID (read-only)
- Updated form validation to remove the `id` field requirement
- Removed the disabled state constraint on the `id` field
- Updated all related tests to remove manual ID input steps and verify the field is no longer visible

## Implementation Details
The `slugify` function:
- Normalizes Unicode characters (NFKD)
- Converts German ß to ss
- Removes diacritical marks
- Converts to lowercase
- Replaces non-alphanumeric characters with hyphens
- Removes leading/trailing hyphens
- Enforces a 50-character maximum length

https://claude.ai/code/session_01ArKUiXDGwFR98UX5Zuhfhk