### PR TITLE
Improve source dialog layout and spacing

### DIFF
--- a/client/src/app/admin/admin.component.ts
+++ b/client/src/app/admin/admin.component.ts
@@ -105,7 +105,7 @@ export class AdminComponent {
 
   async openAddSourceDialog(): Promise<void> {
     const dialogRef = this.dialog.open(SourceDialogComponent, {
-      width: '700px',
+      width: '900px',
       data: { mode: 'create' },
     });
 
@@ -126,7 +126,7 @@ export class AdminComponent {
     }
 
     const dialogRef = this.dialog.open(SourceDialogComponent, {
-      width: '700px',
+      width: '900px',
       data: { source, mode: 'edit' },
     });
 

--- a/client/src/app/shared/source-dialog/source-dialog.component.css
+++ b/client/src/app/shared/source-dialog/source-dialog.component.css
@@ -1,18 +1,18 @@
 mat-dialog-content {
-  min-width: 600px;
+  min-width: 800px;
   padding: 20px;
 }
 
 form {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 24px;
 }
 
 .form-section {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
 }
 
 .section-title {
@@ -27,7 +27,7 @@ form {
 .form-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 0 16px;
+  gap: 12px 16px;
 }
 
 mat-dialog-actions {


### PR DESCRIPTION
## Summary
Adjusted the source dialog component's dimensions and internal spacing to provide a better user experience with improved visual hierarchy and breathing room between form elements.

## Changes
- **Dialog width**: Increased from 700px to 900px in both create and edit modes to accommodate form content more comfortably
- **CSS spacing adjustments**:
  - Increased `mat-dialog-content` min-width from 600px to 800px
  - Increased form gap from 8px to 24px for better separation between form sections
  - Increased `.form-section` gap from 8px to 12px for improved spacing within sections
  - Added vertical gap (12px) to `.form-grid` in addition to existing horizontal gap (16px)

## Implementation Details
These changes work together to create a more spacious and organized form layout. The increased dialog width accommodates the larger internal spacing, while the graduated gap sizes (24px between sections, 12px within sections) establish a clear visual hierarchy.

https://claude.ai/code/session_01LTYTS1hS5t8AfPSQwDqFXx