### PR TITLE
Style known words actions with success color

### DIFF
--- a/client/src/app/cards-table/cards-table.component.html
+++ b/client/src/app/cards-table/cards-table.component.html
@@ -156,8 +156,8 @@
         <button
           mat-fab
           extended
-          color="primary"
           class="action-fab"
+          style="--mat-fab-container-color: var(--bt-success); --mat-fab-foreground-color: var(--bt-text-on-brand);"
           (click)="markSelectedAsKnown()"
         >
           <mat-icon>check_circle</mat-icon>

--- a/client/src/app/parser/page/page.component.html
+++ b/client/src/app/parser/page/page.component.html
@@ -185,8 +185,8 @@
       {{ candidatesService.getItemLabel(item) }}
     </button>
     <mat-menu #itemMenu="matMenu">
-      <button mat-menu-item (click)="addToKnownWords(candidatesService.getItemLabel(item), item.id)">
-        <mat-icon>check_circle</mat-icon>
+      <button mat-menu-item (click)="addToKnownWords(candidatesService.getItemLabel(item), item.id)" style="color: var(--bt-success);">
+        <mat-icon style="color: var(--bt-success);">check_circle</mat-icon>
         <span>Add to known words</span>
       </button>
       <button mat-menu-item (click)="ignoreItem(item.id)">


### PR DESCRIPTION
## Summary
Updated the styling of "Add to known words" actions across the parser and cards table components to use the success color scheme for better visual consistency and improved UX.

## Changes
- **Parser page component**: Applied success color styling to the "Add to known words" menu button and its icon using CSS custom properties (`--bt-success`)
- **Cards table component**: Replaced the `color="primary"` attribute on the "Mark as known" FAB button with inline styles using Material Design tokens (`--mat-fab-container-color` and `--mat-fab-foreground-color`) to apply the success color scheme

## Implementation Details
- Used CSS custom variables (`var(--bt-success)` and `var(--bt-text-on-brand)`) for consistent theming
- Maintained Material Design button component structure while customizing colors through inline styles
- Ensures visual consistency between the parser and cards table interfaces for the same action

https://claude.ai/code/session_01F6Z7VywJivGzwUf1V7Jc1H