### PR TITLE
Remove image generation from grammar cards

### DIFF
--- a/client/src/app/cardTypes/grammar-card-type.strategy.ts
+++ b/client/src/app/cardTypes/grammar-card-type.strategy.ts
@@ -16,9 +16,6 @@ import {
 } from '../parser/types';
 import { LANGUAGE_CODES } from '../shared/types/audio-generation.types';
 import { nonNullable } from '../utils/type-guards';
-import { ENVIRONMENT_CONFIG } from '../environment/environment.config';
-import { generateExampleImages } from '../utils/image-generation.util';
-import { RateLimitTokenService } from '../rate-limit-token.service';
 
 interface SentenceIdResponse {
   id: string;
@@ -37,8 +34,6 @@ export class GrammarCardType implements CardTypeStrategy {
 
   private readonly http = inject(HttpClient);
   private readonly multiModelService = inject(MultiModelService);
-  private readonly environmentConfig = inject(ENVIRONMENT_CONFIG);
-  private readonly rateLimitTokenService = inject(RateLimitTokenService);
 
   async extractItems(request: ExtractionRequest): Promise<ExtractedItem[]> {
     const { sourceId, regions } = request;
@@ -111,6 +106,8 @@ export class GrammarCardType implements CardTypeStrategy {
       throw new Error('Card data is missing required sentence (examples[0].de)');
     }
 
+    onToolsRequested();
+
     try {
       progressCallback(30, 'Translating to English...');
       const englishResult =
@@ -128,20 +125,6 @@ export class GrammarCardType implements CardTypeStrategy {
             )
         );
 
-      progressCallback(60, 'Generating images...');
-
-      const imageInputs = englishResult.response.translation
-        ? [{ exampleIndex: 0, englishTranslation: englishResult.response.translation }]
-        : [];
-
-      const imagesMap = await generateExampleImages(
-        this.http,
-        this.environmentConfig.imageModels,
-        imageInputs,
-        this.rateLimitTokenService.imagePool,
-        onToolsRequested
-      );
-
       progressCallback(90, 'Preparing grammar card data...');
 
       return {
@@ -150,7 +133,6 @@ export class GrammarCardType implements CardTypeStrategy {
             de: sentence,
             en: englishResult.response.translation,
             isSelected: true,
-            images: imagesMap.get(0) ?? [],
           },
         ],
         translationModel: englishResult.model,

--- a/client/src/app/parser/edit-card/edit-grammar-card/edit-grammar-card.component.css
+++ b/client/src/app/parser/edit-card/edit-grammar-card/edit-grammar-card.component.css
@@ -55,13 +55,3 @@
   line-height: 1.6;
   letter-spacing: 0.05em;
 }
-
-.images-section {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.images-section h2 {
-  margin: 0;
-}

--- a/client/src/app/parser/edit-card/edit-grammar-card/edit-grammar-card.component.html
+++ b/client/src/app/parser/edit-card/edit-grammar-card/edit-grammar-card.component.html
@@ -52,24 +52,3 @@
   <h3>Preview (with gaps)</h3>
   <p class="sentence-preview">{{ sentenceWithGaps() }}</p>
 </div>
-
-<div class="images-section">
-  <h2>Images</h2>
-  <button
-    mat-icon-button
-    (click)="addImage()"
-    aria-label="Add image"
-    [disabled]="areImagesLoading() || dailyUsageService.isImageLimitReached()"
-    [matTooltip]="dailyUsageService.imageLimitTooltip()"
-  >
-    <mat-icon>add_photo_alternate</mat-icon>
-  </button>
-</div>
-@let imgs = images();
-@if (imgs && imgs.length) {
-  <app-image-grid
-    [images]="imgs"
-    [altText]="formModel().sentence"
-    (favoriteToggled)="onFavoriteToggled($event)"
-  />
-}

--- a/client/src/app/parser/edit-card/edit-grammar-card/edit-grammar-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-grammar-card/edit-grammar-card.component.ts
@@ -3,9 +3,7 @@ import {
   input,
   output,
   computed,
-  inject,
   linkedSignal,
-  untracked,
   effect,
   viewChild,
   ElementRef,
@@ -18,12 +16,6 @@ import { MatIcon } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatChipsModule } from '@angular/material/chips';
 import { Card, CardData } from '../../types';
-import {
-  ImageGridComponent,
-  GridImageResource,
-} from '../../../shared/image-grid/image-grid.component';
-import { ImageResourceService } from '../../../shared/image-resource.service';
-import { DailyUsageService } from '../../../daily-usage.service';
 import { createGrammarGapRegex } from '../../../shared/constants/grammar.constants';
 
 @Component({
@@ -37,7 +29,6 @@ import { createGrammarGapRegex } from '../../../shared/constants/grammar.constan
     MatIcon,
     MatTooltipModule,
     MatChipsModule,
-    ImageGridComponent,
   ],
   templateUrl: './edit-grammar-card.component.html',
   styleUrl: './edit-grammar-card.component.css',
@@ -51,8 +42,6 @@ export class EditGrammarCardComponent {
   saveRequested = output<void>();
   markAsReviewedAvailable = output<boolean>();
 
-  private readonly imageResourceService = inject(ImageResourceService);
-  readonly dailyUsageService = inject(DailyUsageService);
   private readonly sentenceInput = viewChild<ElementRef<HTMLTextAreaElement>>('sentenceInput');
 
   readonly formModel = linkedSignal(() => ({
@@ -74,35 +63,12 @@ export class EditGrammarCardComponent {
     return sentence.replace(createGrammarGapRegex(), (_match, content) => '_'.repeat(content.length));
   });
 
-  readonly images = linkedSignal<GridImageResource[]>(() => {
-    return untracked(() => {
-      if (!this.selectedCardId()) {
-        return [];
-      }
-
-      const example = this.card()?.data.examples?.[0];
-      return (
-        example?.images?.map((image) =>
-          this.imageResourceService.createResource(image)
-        ) ?? []
-      );
-    });
-  });
-
   readonly canMarkAsReviewed = computed(() => {
     if (this.card()?.readiness !== 'IN_REVIEW') {
       return false;
     }
 
-    const currentImages = this.images();
-    if (!currentImages || currentImages.length === 0) {
-      return false;
-    }
-
-    return currentImages.some((imageResource) => {
-      const imageValue = imageResource.value();
-      return imageValue?.isFavorite === true;
-    });
+    return this.gapsDisplay().length > 0;
   });
 
   constructor() {
@@ -159,41 +125,6 @@ export class EditGrammarCardComponent {
     this.formModel.update((m) => ({ ...m, sentence: newSentence }));
   }
 
-  async addImage() {
-    const englishTranslation = this.formModel().englishTranslation;
-    if (!englishTranslation) return;
-
-    const { placeholders, done } =
-      this.imageResourceService.generateImages(englishTranslation);
-
-    this.images.update((imgs) => [...imgs, ...placeholders]);
-
-    await done;
-    this.dailyUsageService.reload();
-
-    const cardData = this.getCardData();
-    if (cardData) {
-      this.cardUpdate.emit(cardData);
-    }
-    this.saveRequested.emit();
-  }
-
-  areImagesLoading() {
-    const imgs = this.images() || [];
-    return imgs.some((image) => image.isLoading());
-  }
-
-  onFavoriteToggled(imageIdx: number) {
-    const imgs = this.images();
-    if (!imgs?.length) return;
-
-    const image = imgs[imageIdx];
-    if (!image || image.isLoading()) return;
-
-    this.imageResourceService.toggleFavorite(image);
-    this.images.update((currentImages) => [...currentImages]);
-  }
-
   private getCardData():
     | Omit<
         Card,
@@ -225,7 +156,6 @@ export class EditGrammarCardComponent {
           de: sentence,
           en: englishTranslation,
           isSelected: true,
-          images: this.imageResourceService.toExampleImages(this.images()),
         },
       ],
       audio: this.card()?.data.audio || [],

--- a/client/src/app/study/learn-grammar-card/learn-grammar-card.component.css
+++ b/client/src/app/study/learn-grammar-card/learn-grammar-card.component.css
@@ -4,37 +4,13 @@
   position: relative;
 }
 
-.image-section {
-  position: relative;
-  width: 100%;
-  padding-top: 75%;
-  overflow: hidden;
-}
-
-.image-gallery {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
-}
-
-.learn-card-image {
-  max-width: 100%;
-  max-height: 100%;
-  object-fit: contain;
-}
-
 .content-section {
   position: relative;
   padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  flex: 1;
 }
 
 .sentence-section {
@@ -79,45 +55,10 @@
   padding: 0 1em;
 }
 
-.skeleton {
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(
-    90deg,
-    var(--mat-sys-surface-container) 25%,
-    var(--mat-sys-surface-container-high) 50%,
-    var(--mat-sys-surface-container) 75%
-  );
-  background-size: 200% 100%;
-  animation: shimmer 1.5s infinite;
-}
-
-@keyframes shimmer {
-  0% {
-    background-position: 200% 0;
-  }
-  100% {
-    background-position: -200% 0;
-  }
-}
-
 @media (min-width: 768px) {
-  :host {
-    flex-direction: row;
-  }
-
-  .image-section {
-    flex: none;
-    width: 55%;
-    padding-top: 55%;
-  }
-
   .content-section {
-    flex: 1;
-    min-width: 0;
     overflow-y: auto;
     overflow-x: hidden;
-    border-radius: 0 16px 16px 0;
     padding: 1.5rem;
     gap: 1.5rem;
   }

--- a/client/src/app/study/learn-grammar-card/learn-grammar-card.component.html
+++ b/client/src/app/study/learn-grammar-card/learn-grammar-card.component.html
@@ -1,15 +1,3 @@
-<div class="image-section">
-  @if (exampleImages().length > 0) {
-  <div class="image-gallery">
-    @for (imageResource of exampleImages(); track $index) { @if (imageResource.value()?.url) {
-    <img [src]="imageResource.value()?.url" [alt]="sentence()" class="learn-card-image" />
-    } @else if (imageResource.isLoading()) {
-    <div class="skeleton"></div>
-    } }
-  </div>
-  }
-</div>
-
 <div class="content-section">
   <div class="chips-corner">
     @let state = card()?.value()?.state; @if (state !== undefined) {

--- a/client/src/app/study/learn-grammar-card/learn-grammar-card.component.ts
+++ b/client/src/app/study/learn-grammar-card/learn-grammar-card.component.ts
@@ -3,22 +3,13 @@ import {
   computed,
   inject,
   input,
-  Injector,
-  resource,
-  linkedSignal,
-  untracked,
   effect,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { HttpClient } from '@angular/common/http';
-import { fetchAsset } from '../../utils/fetchAsset';
-import { ExampleImage } from '../../parser/types';
 import { StateComponent } from '../../shared/state/state.component';
 import { CardResourceLike } from '../../shared/types/card-resource.types';
 import { createGrammarGapRegex } from '../../shared/constants/grammar.constants';
 import { VoiceConfigService } from '../../voice-config/voice-config.service';
-
-type ImageResource = ExampleImage & { url: string };
 
 type SentencePart = {
   text: string;
@@ -38,8 +29,6 @@ export class LearnGrammarCardComponent {
   isRevealed = input<boolean>(false);
   onPlayAudio = input<((texts: string[]) => void) | null>(null);
 
-  private readonly http = inject(HttpClient);
-  private readonly injector = inject(Injector);
   private readonly voiceConfigService = inject(VoiceConfigService);
 
   readonly selectedExample = computed(() =>
@@ -56,31 +45,6 @@ export class LearnGrammarCardComponent {
   readonly sentenceParts = computed(() => {
     const sentence = this.sentence();
     return this.buildSentenceParts(sentence);
-  });
-
-  readonly exampleImages = linkedSignal(() => {
-    const example = this.selectedExample();
-
-    return untracked(() => {
-      if (!example?.images?.length) return [];
-
-      return example.images
-        .filter((img) => img.isFavorite)
-        .map((image) =>
-          resource<ImageResource, never>({
-            injector: this.injector,
-            loader: async () => {
-              return {
-                ...image,
-                url: await fetchAsset(
-                  this.http,
-                  `/api/image/${image.id}`
-                ),
-              };
-            },
-          })
-        );
-    });
   });
 
   constructor() {


### PR DESCRIPTION
## Summary
This PR removes image generation and display functionality from grammar card components, simplifying the card editing and learning experience by focusing on text-based grammar instruction.

## Key Changes
- **EditGrammarCardComponent**: Removed image management logic including:
  - Image resource service and daily usage service injections
  - `images` linked signal and related image handling methods (`addImage()`, `areImagesLoading()`, `onFavoriteToggled()`)
  - Image grid component integration from template and imports
  - Image data from card data serialization

- **LearnGrammarCardComponent**: Removed image display logic including:
  - HTTP client and injector dependencies
  - `exampleImages` linked signal with resource loading
  - Image rendering from template
  - Related type definitions and asset fetching

- **GrammarCardTypeStrategy**: Removed image generation during card creation:
  - Removed image generation step from card preparation workflow
  - Removed environment config and rate limit token service injections
  - Removed image generation utility calls and progress callbacks

- **Styling**: Cleaned up CSS for both components:
  - Removed image section layout styles from learn card
  - Removed skeleton loading animation
  - Removed image gallery positioning and sizing
  - Simplified content section layout

- **Card Validation**: Updated `canMarkAsReviewed` logic to check for grammar gaps instead of favorite images

## Implementation Details
The removal is comprehensive across the card creation, editing, and learning workflows. The `canMarkAsReviewed` computed signal now validates based on the presence of grammar gaps rather than image favorites, maintaining the review validation requirement while aligning with the text-focused approach.

https://claude.ai/code/session_01K9ZCikfHL3jTyS8abtSbVD