### PR TITLE
Add optional German hint to photo-grammar cards

### DIFF
--- a/client/src/app/cardTypes/grammar-card-type.strategy.ts
+++ b/client/src/app/cardTypes/grammar-card-type.strategy.ts
@@ -93,11 +93,12 @@ export class GrammarCardType implements CardTypeStrategy {
   }
 
   createDraftCardData(item: ExtractedItem, context?: BulkCreationContext): CardData {
-    const sentence = item as ExtractedItem & { sentence: string };
+    const sentence = item as ExtractedItem & { sentence: string; hint?: string };
     return {
       examples: [{ de: sentence.sentence }],
       extractionModel: sentence.extractionModel,
       ...(context?.grammarTopic ? { grammarTopic: context.grammarTopic } : {}),
+      ...(sentence.hint ? { hint: sentence.hint } : {}),
     };
   }
 
@@ -156,6 +157,7 @@ export class GrammarCardType implements CardTypeStrategy {
         translationModel: englishResult.model,
         extractionModel: cardData.extractionModel,
         ...(cardData.grammarTopic ? { grammarTopic: cardData.grammarTopic } : {}),
+        ...(cardData.hint ? { hint: cardData.hint } : {}),
       };
     } catch (error) {
       throw new Error(

--- a/client/src/app/parser/edit-card/edit-grammar-card/edit-grammar-card.component.html
+++ b/client/src/app/parser/edit-card/edit-grammar-card/edit-grammar-card.component.html
@@ -18,6 +18,14 @@
       rows="3"
     ></textarea>
   </mat-form-field>
+  <mat-form-field class="field">
+    <mat-label>Hint (German)</mat-label>
+    <input
+      matInput
+      [formField]="grammarForm.hint"
+      aria-label="Hint in German"
+    />
+  </mat-form-field>
   <div class="gap-controls">
     <button
       mat-stroked-button

--- a/client/src/app/parser/edit-card/edit-grammar-card/edit-grammar-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-grammar-card/edit-grammar-card.component.ts
@@ -58,6 +58,7 @@ export class EditGrammarCardComponent {
   readonly formModel = linkedSignal(() => ({
     sentence: this.card()?.data.examples?.[0]?.de ?? '',
     englishTranslation: this.card()?.data.examples?.[0]?.en ?? '',
+    hint: this.card()?.data.hint ?? '',
   }));
   readonly grammarForm = form(this.formModel);
 
@@ -212,13 +213,14 @@ export class EditGrammarCardComponent {
     const sourceId = this.selectedSourceId();
     const pageNumber = this.selectedPageNumber();
     const cardId = this.selectedCardId();
-    const { sentence, englishTranslation } = this.formModel();
+    const { sentence, englishTranslation, hint } = this.formModel();
 
     if (!cardId || !sentence || !sourceId || !pageNumber) {
       return;
     }
 
     const existingGrammarTopic = this.card()?.data.grammarTopic;
+    const trimmedHint = hint.trim();
     const data: CardData = {
       examples: [
         {
@@ -230,6 +232,7 @@ export class EditGrammarCardComponent {
       ],
       audio: this.card()?.data.audio || [],
       ...(existingGrammarTopic ? { grammarTopic: existingGrammarTopic } : {}),
+      ...(trimmedHint ? { hint: trimmedHint } : {}),
     };
 
     return {

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -57,6 +57,7 @@ export type CardData = {
   classificationModel?: string;
   extractionModel?: string;
   grammarTopic?: string;
+  hint?: string;
 };
 
 export type Card = {
@@ -147,6 +148,15 @@ export type Sentence = ExtractedItem & {
 
 export type SentenceList = {
   sentences: string[];
+};
+
+export type SentenceWithHint = {
+  sentence: string;
+  hint?: string;
+};
+
+export type PhotoGrammarSentenceList = {
+  sentences: SentenceWithHint[];
 };
 
 export type ExtractionRegionSelection = {

--- a/client/src/app/pending-photo.service.ts
+++ b/client/src/app/pending-photo.service.ts
@@ -8,7 +8,7 @@ import {
   signal,
 } from '@angular/core';
 import { ENVIRONMENT_CONFIG } from './environment/environment.config';
-import { SentenceList } from './parser/types';
+import { PhotoGrammarSentenceList, SentenceWithHint } from './parser/types';
 import { fetchAsset } from './utils/fetchAsset';
 import { fetchJson } from './utils/fetchJson';
 import { uploadDocument } from './utils/uploadDocument';
@@ -114,13 +114,13 @@ export class PendingPhotoService {
   async consume(
     sourceId: string,
     cardCount: number
-  ): Promise<{ sentences: string[]; model: string }> {
+  ): Promise<{ sentences: SentenceWithHint[]; model: string }> {
     const model = this.environmentConfig.primaryModelByOperation['extraction'];
     if (!model) {
       throw new Error('No primary extraction model is configured');
     }
     const operationHeaders = { 'X-Operation-ID': crypto.randomUUID() };
-    const response = await fetchJson<SentenceList>(
+    const response = await fetchJson<PhotoGrammarSentenceList>(
       this.http,
       `/api/source/${sourceId}/pending-photo/consume`,
       {

--- a/client/src/app/photo-grammar-banner/photo-grammar-banner.component.ts
+++ b/client/src/app/photo-grammar-banner/photo-grammar-banner.component.ts
@@ -60,7 +60,7 @@ export class PhotoGrammarBannerComponent {
       const { sentences, model } = await this.pendingPhotoService.consume(sid, count);
 
       const items = await Promise.all(
-        sentences.map(async (sentence): Promise<ExtractedItem & { sentence: string }> => {
+        sentences.map(async ({ sentence, hint }): Promise<ExtractedItem & { sentence: string; hint?: string }> => {
           const idResp = await fetchJson<SentenceIdResponse>(
             this.http,
             '/api/sentence-id',
@@ -71,6 +71,7 @@ export class PhotoGrammarBannerComponent {
             exists: idResp.exists,
             extractionModel: model,
             sentence,
+            ...(hint ? { hint } : {}),
           };
         })
       );

--- a/client/src/app/study/learn-grammar-card/learn-grammar-card.component.css
+++ b/client/src/app/study/learn-grammar-card/learn-grammar-card.component.css
@@ -66,6 +66,14 @@
   text-align: center;
 }
 
+.hint-text {
+  font-size: 1rem;
+  margin: 0;
+  color: var(--mat-sys-on-surface-variant);
+  font-style: italic;
+  text-align: center;
+}
+
 .gap-word.masked {
   background: rgba(255, 255, 255, 0.1);
   color: transparent;

--- a/client/src/app/study/learn-grammar-card/learn-grammar-card.component.html
+++ b/client/src/app/study/learn-grammar-card/learn-grammar-card.component.html
@@ -23,5 +23,8 @@
         [class.masked]="part.isGap && !isRevealed()"
         [class.highlighted]="part.isGap && isRevealed()"
       >{{ part.text }}</span>}</p>
+    @if (hint()) {
+      <p class="hint-text" aria-label="Hint">{{ hint() }}</p>
+    }
   </div>
 </div>

--- a/client/src/app/study/learn-grammar-card/learn-grammar-card.component.ts
+++ b/client/src/app/study/learn-grammar-card/learn-grammar-card.component.ts
@@ -48,6 +48,8 @@ export class LearnGrammarCardComponent {
 
   readonly sentence = computed(() => this.selectedExample()?.de ?? '');
 
+  readonly hint = computed(() => this.card()?.value()?.data.hint);
+
   readonly audioSentence = computed(() => {
     if (!this.isRevealed()) return undefined;
     return this.sentence().replace(createGrammarGapRegex(), '$1');

--- a/mock_google_ai_server/src/chatHandler.ts
+++ b/mock_google_ai_server/src/chatHandler.ts
@@ -7,6 +7,7 @@ import {
   SENTENCE_LISTS,
   SENTENCE_TRANSLATIONS,
   GRAMMAR_SENTENCE_LISTS,
+  PHOTO_GRAMMAR_CONCEPT_SENTENCES,
   DICTIONARY_LOOKUPS,
   NORMALIZATIONS,
 } from './data';
@@ -198,7 +199,7 @@ export class ChatHandler {
       )
     ) {
       return createGeminiResponse({
-        sentences: GRAMMAR_SENTENCE_LISTS['photo_grammar_concept_sentences'],
+        sentences: PHOTO_GRAMMAR_CONCEPT_SENTENCES,
       });
     }
 

--- a/mock_google_ai_server/src/data.ts
+++ b/mock_google_ai_server/src/data.ts
@@ -334,7 +334,7 @@ export const SENTENCE_TRANSLATIONS: Record<string, Record<string, string>> = {
     'Das [ist] Paco.': 'This is Paco.',
     'Und [das] ist Frau Wachter.': 'And this is Frau Wachter.',
     'Heute [bin] ich müde.': 'Today I am tired.',
-    'Sie [ist] meine Lehrerin.': 'She is my teacher.',
-    'Wir [sind] in Berlin.': 'We are in Berlin.',
+    '[Der] Mann gibt [dem] Kind das Buch.': 'The man gives the child the book.',
+    'Der Hund läuft schnell durch den [Park].': 'The dog runs quickly through the park.',
   },
 };

--- a/mock_google_ai_server/src/data.ts
+++ b/mock_google_ai_server/src/data.ts
@@ -260,12 +260,18 @@ export const GRAMMAR_SENTENCE_LISTS: Record<string, string[]> = {
     'Das [ist] Paco.',
     'Und [das] ist Frau Wachter.',
   ],
-  photo_grammar_concept_sentences: [
-    'Heute [bin] ich müde.',
-    'Sie [ist] meine Lehrerin.',
-    'Wir [sind] in Berlin.',
-  ],
 };
+
+export type PhotoGrammarSentence = {
+  sentence: string;
+  hint?: string;
+};
+
+export const PHOTO_GRAMMAR_CONCEPT_SENTENCES: PhotoGrammarSentence[] = [
+  { sentence: 'Heute [bin] ich müde.', hint: 'sein' },
+  { sentence: '[Der] Mann gibt [dem] Kind das Buch.', hint: 'der / der' },
+  { sentence: 'Der Hund läuft schnell durch den [Park].' },
+];
 
 interface DictionaryLookup {
   normalizedWord: string;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
@@ -44,7 +44,9 @@ import io.github.mucsi96.learnlanguage.model.SourceDueCardCountResponse;
 import io.github.mucsi96.learnlanguage.model.SourceRequest;
 import io.github.mucsi96.learnlanguage.model.SourceResponse;
 import io.github.mucsi96.learnlanguage.model.SourceType;
+import io.github.mucsi96.learnlanguage.model.PhotoGrammarSentencesResponse;
 import io.github.mucsi96.learnlanguage.model.SentenceListResponse;
+import io.github.mucsi96.learnlanguage.model.SentenceWithHint;
 import io.github.mucsi96.learnlanguage.model.WordListResponse;
 import io.github.mucsi96.learnlanguage.repository.DocumentRepository;
 import io.github.mucsi96.learnlanguage.repository.ExtractionRegionRepository;
@@ -555,7 +557,7 @@ public class SourceController {
 
   @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
   @PostMapping("/source/{sourceId}/pending-photo/consume")
-  public SentenceListResponse consumePendingPhoto(
+  public PhotoGrammarSentencesResponse consumePendingPhoto(
       @PathVariable String sourceId,
       @RequestBody PendingPhotoConsumeRequest request,
       @AuthenticationPrincipal Jwt jwt) {
@@ -573,7 +575,7 @@ public class SourceController {
     final PendingPhoto photo = pendingPhotoService.getActive(userId, source)
         .orElseThrow(() -> new ResourceNotFoundException("No pending photo for this source"));
 
-    final List<String> sentences = photoGrammarConceptService.generateConceptCards(
+    final List<SentenceWithHint> sentences = photoGrammarConceptService.generateConceptCards(
         photo.getImageData(),
         photo.getContentType(),
         request.getModel(),
@@ -582,7 +584,7 @@ public class SourceController {
 
     pendingPhotoService.delete(photo);
 
-    return SentenceListResponse.builder().sentences(sentences).build();
+    return PhotoGrammarSentencesResponse.builder().sentences(sentences).build();
   }
 
   @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardData.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardData.java
@@ -39,4 +39,7 @@ public class CardData implements Serializable {
 
     @JsonInclude(Include.NON_NULL)
     private String grammarTopic;
+
+    @JsonInclude(Include.NON_NULL)
+    private String hint;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/PhotoGrammarSentencesResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/PhotoGrammarSentencesResponse.java
@@ -1,0 +1,12 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PhotoGrammarSentencesResponse {
+    private List<SentenceWithHint> sentences;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/SentenceWithHint.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/SentenceWithHint.java
@@ -1,0 +1,20 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SentenceWithHint {
+    private String sentence;
+
+    @JsonInclude(Include.NON_NULL)
+    private String hint;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/PhotoGrammarConceptService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/PhotoGrammarConceptService.java
@@ -10,6 +10,7 @@ import org.springframework.util.MimeTypeUtils;
 import io.github.mucsi96.learnlanguage.model.ChatModel;
 import io.github.mucsi96.learnlanguage.model.LanguageLevel;
 import io.github.mucsi96.learnlanguage.model.OperationType;
+import io.github.mucsi96.learnlanguage.model.SentenceWithHint;
 import lombok.RequiredArgsConstructor;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -17,7 +18,10 @@ import tools.jackson.databind.json.JsonMapper;
 @RequiredArgsConstructor
 public class PhotoGrammarConceptService {
 
-  record ConceptSentences(List<String> sentences) {
+  record ConceptSentence(String sentence, String hint) {
+  }
+
+  record ConceptSentences(List<ConceptSentence> sentences) {
   }
 
   private final JsonMapper jsonMapper;
@@ -33,22 +37,27 @@ public class PhotoGrammarConceptService {
 
         Rules:
         - !IMPORTANT! Do NOT copy the printed exercise sentences from the photo verbatim. Produce fresh, original sentences that exercise the same concepts.
-        - Each sentence must have EXACTLY ONE blank, marked by wrapping the target word or form in square brackets. Example: "Ich gehe jeden [Tag] in die Schule."
+        - Each sentence has ONE OR MORE blanks, depending on what the exercise teaches. Wrap each target word or form in square brackets. Example single blank: "Ich gehe jeden [Tag] in die Schule." Example multiple blanks: "[Der] Mann gibt [dem] Kind das Buch." Use multiple blanks only when the underlying exercise naturally requires it (e.g. article + adjective ending together, two-way preposition + article, paired conjugation patterns).
         - Each sentence must be a complete standalone German sentence with proper capitalisation and punctuation.
         - Sentences must be appropriate for %s level learners.
         - Skip any handwritten text on the photo.
+        - After producing each sentence, judge whether ANY blank is ambiguous - i.e. multiple valid German words or forms could plausibly fit the blank purely from the surrounding context (without seeing the textbook lesson).
+        - If at least one blank is ambiguous, include a "hint" field. The hint is a single German string covering ALL blanks in the sentence. When more than one blank needs disambiguation, separate the per-blank hints with " / " in the same order the blanks appear. Examples: verb conjugation blank -> infinitive (e.g. "gehen"); noun gender/case blank -> nominative with article (e.g. "der Tag"); adjective ending blank -> base adjective; combined article + verb blanks -> "der / gehen".
+        - The "hint" MUST always be in German. Never English, Hungarian or Swiss German.
+        - If no blank is ambiguous, OMIT the "hint" field entirely. Do not emit it as null or an empty string.
         - !IMPORTANT! Respond ONLY with JSON in the form {"sentences": [...]} matching the example below.
         """.formatted(cardCount, languageLevel.name(), languageLevel.name());
 
     final ConceptSentences example = new ConceptSentences(List.of(
-        "Ich gehe jeden [Tag] in die Schule.",
-        "Der Hund läuft schnell durch den [Park]."));
+        new ConceptSentence("Heute [bin] ich müde.", "sein"),
+        new ConceptSentence("[Der] Mann gibt [dem] Kind das Buch.", "der / der"),
+        new ConceptSentence("Der Hund läuft schnell durch den [Park].", null)));
 
     final String exampleJson = jsonMapper.writeValueAsString(example);
     return basePrompt + "\nExample JSON response shape:\n" + exampleJson;
   }
 
-  public List<String> generateConceptCards(
+  public List<SentenceWithHint> generateConceptCards(
       byte[] imageData,
       String contentType,
       ChatModel model,
@@ -71,6 +80,19 @@ public class PhotoGrammarConceptService {
                 .build()),
         ConceptSentences.class);
 
-    return result.sentences;
+    return result.sentences().stream()
+        .map(item -> SentenceWithHint.builder()
+            .sentence(item.sentence())
+            .hint(normalizeHint(item.hint()))
+            .build())
+        .toList();
+  }
+
+  private String normalizeHint(String hint) {
+    if (hint == null) {
+      return null;
+    }
+    final String trimmed = hint.trim();
+    return trimmed.isEmpty() ? null : trimmed;
   }
 }

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -793,6 +793,81 @@ test('grammar card editing saves gaps to database', async ({ page }) => {
   });
 });
 
+test('grammar card editing displays existing hint and saves edits to database', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  const image1 = uploadMockImage(yellowImage);
+  await createCard({
+    cardId: 'grammar-hint-edit-card',
+    sourceId: 'grammar-a1',
+    sourcePageNumber: 7,
+    data: {
+      hint: 'sein',
+      examples: [
+        {
+          de: 'Heute [bin] ich müde.',
+          en: 'Today I am tired.',
+          isSelected: true,
+          images: [{ id: image1, isFavorite: true }],
+        },
+      ],
+    },
+    readiness: 'IN_REVIEW',
+  });
+
+  await page.goto('/in-review-cards');
+
+  const hintInput = page.getByLabel('Hint in German', { exact: true });
+  await expect(hintInput).toHaveValue('sein');
+
+  await hintInput.fill('sein / der');
+  await page.getByRole('button', { name: 'Save card' }).click();
+
+  await withDbConnection(async (client) => {
+    const result = await client.query(
+      "SELECT data FROM learn_language.cards WHERE id = 'grammar-hint-edit-card'"
+    );
+    expect(result.rows.length).toBe(1);
+    expect(result.rows[0].data.hint).toBe('sein / der');
+  });
+});
+
+test('grammar card editing allows adding a hint to a card without one', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  const image1 = uploadMockImage(yellowImage);
+  await createCard({
+    cardId: 'grammar-no-hint-edit-card',
+    sourceId: 'grammar-a1',
+    sourcePageNumber: 8,
+    data: {
+      examples: [
+        {
+          de: 'Der Hund läuft durch den [Park].',
+          en: 'The dog runs through the park.',
+          isSelected: true,
+          images: [{ id: image1, isFavorite: true }],
+        },
+      ],
+    },
+    readiness: 'IN_REVIEW',
+  });
+
+  await page.goto('/in-review-cards');
+
+  const hintInput = page.getByLabel('Hint in German', { exact: true });
+  await expect(hintInput).toHaveValue('');
+
+  await hintInput.fill('der Park');
+  await page.getByRole('button', { name: 'Save card' }).click();
+
+  await withDbConnection(async (client) => {
+    const result = await client.query(
+      "SELECT data FROM learn_language.cards WHERE id = 'grammar-no-hint-edit-card'"
+    );
+    expect(result.rows.length).toBe(1);
+    expect(result.rows[0].data.hint).toBe('der Park');
+  });
+});
+
 test('remove flag button is visible for flagged card', async ({ page }) => {
   await createCard({
     cardId: 'flagged-card-visible',

--- a/test/tests/photo-grammar.spec.ts
+++ b/test/tests/photo-grammar.spec.ts
@@ -106,12 +106,21 @@ test('pending photo banner consumes photo and creates grammar cards', async ({ p
 
   expect(cards.length).toBe(3);
 
-  const sentences = cards
-    .map((row) => row.data.examples?.[0]?.de as string)
-    .sort();
-  expect(sentences).toEqual(
-    ['Heute [bin] ich müde.', 'Sie [ist] meine Lehrerin.', 'Wir [sind] in Berlin.'].sort()
+  const cardsBySentence = new Map<string, (typeof cards)[number]>(
+    cards.map((card) => [card.data.examples?.[0]?.de as string, card])
   );
+
+  expect([...cardsBySentence.keys()].sort()).toEqual(
+    [
+      'Heute [bin] ich müde.',
+      '[Der] Mann gibt [dem] Kind das Buch.',
+      'Der Hund läuft schnell durch den [Park].',
+    ].sort()
+  );
+
+  expect(cardsBySentence.get('Heute [bin] ich müde.')?.data.hint).toBe('sein');
+  expect(cardsBySentence.get('[Der] Mann gibt [dem] Kind das Buch.')?.data.hint).toBe('der / der');
+  expect(cardsBySentence.get('Der Hund läuft schnell durch den [Park].')?.data.hint).toBeUndefined();
 
   for (const card of cards) {
     expect(card.data.grammarTopic).toBe('Sein conjugation');

--- a/test/tests/study-page.spec.ts
+++ b/test/tests/study-page.spec.ts
@@ -1252,6 +1252,68 @@ test('grammar card study shows sentence with gaps on front, full sentence on rev
   await expect(flashcard.locator('.gap-word.highlighted')).toHaveText('jeden');
 });
 
+test('grammar card study shows German hint on front when present', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await setupDefaultImageModelSettings();
+  const image1 = uploadMockImage(yellowImage);
+  await createCard({
+    cardId: 'grammar-hint-card',
+    sourceId: 'grammar-a1',
+    sourcePageNumber: 5,
+    data: {
+      hint: 'sein',
+      examples: [
+        {
+          de: 'Heute [bin] ich müde.',
+          en: 'Today I am tired.',
+          isSelected: true,
+          images: [{ id: image1, isFavorite: true }],
+        },
+      ],
+      audio: [{ id: 'hint-audio', text: 'Heute bin ich müde.', language: 'de' }],
+    },
+  });
+
+  await page.goto('/sources/grammar-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
+
+  const flashcard = page.getByRole('article', { name: 'Flashcard' });
+  await expect(flashcard.getByLabel('Hint')).toHaveText('sein');
+
+  await flashcard.getByText('Heute').click();
+
+  await expect(flashcard.getByLabel('Hint')).toHaveText('sein');
+});
+
+test('grammar card study omits hint element when card has no hint', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await setupDefaultImageModelSettings();
+  const image1 = uploadMockImage(yellowImage);
+  await createCard({
+    cardId: 'grammar-no-hint-card',
+    sourceId: 'grammar-a1',
+    sourcePageNumber: 6,
+    data: {
+      examples: [
+        {
+          de: 'Der Hund läuft durch den [Park].',
+          en: 'The dog runs through the park.',
+          isSelected: true,
+          images: [{ id: image1, isFavorite: true }],
+        },
+      ],
+      audio: [{ id: 'no-hint-audio', text: 'Der Hund läuft durch den Park.', language: 'de' }],
+    },
+  });
+
+  await page.goto('/sources/grammar-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
+
+  const flashcard = page.getByRole('article', { name: 'Flashcard' });
+  await expect(flashcard.locator('.gap-word.masked')).toHaveText('Park');
+  await expect(flashcard.getByLabel('Hint')).toHaveCount(0);
+});
+
 test('grammar card grading functionality', async ({ page }) => {
   await setupDefaultChatModelSettings();
   await setupDefaultImageModelSettings();


### PR DESCRIPTION
The AI in PhotoGrammarConceptService now assesses whether each
generated sentence has an ambiguous blank and emits a German hint
when disambiguation helps. Sentences may have multiple blanks; in
that case the hint is a single "/"-separated string.

The new optional hint field flows from the AI response through the
pending-photo consume pipeline into CardData, is shown on the front
of grammar study cards, and is editable in the grammar card editor.