### PR TITLE
Switch grammar card translations from English to Hungarian

### DIFF
--- a/client/src/app/cardTypes/grammar-card-type.strategy.ts
+++ b/client/src/app/cardTypes/grammar-card-type.strategy.ts
@@ -110,14 +110,14 @@ export class GrammarCardType implements CardTypeStrategy {
     onToolsRequested();
 
     try {
-      progressCallback(30, 'Translating to English...');
-      const englishResult =
+      progressCallback(30, 'Translating to Hungarian...');
+      const hungarianResult =
         await this.multiModelService.callWithModel<SentenceTranslationResponse>(
           'translation',
           (model: string, headers?: Record<string, string>) =>
             fetchJson<SentenceTranslationResponse>(
               this.http,
-              `/api/translate-sentence/en?model=${model}`,
+              `/api/translate-sentence/hu?model=${model}`,
               {
                 body: { sentence },
                 method: 'POST',
@@ -132,11 +132,11 @@ export class GrammarCardType implements CardTypeStrategy {
         examples: [
           {
             de: sentence,
-            en: englishResult.response.translation,
+            hu: hungarianResult.response.translation,
             isSelected: true,
           },
         ],
-        translationModel: englishResult.model,
+        translationModel: hungarianResult.model,
         extractionModel: cardData.extractionModel,
         ...(cardData.grammarTopic ? { grammarTopic: cardData.grammarTopic } : {}),
         ...(cardData.hint ? { hint: cardData.hint } : {}),

--- a/client/src/app/parser/edit-card/edit-grammar-card/edit-grammar-card.component.html
+++ b/client/src/app/parser/edit-card/edit-grammar-card/edit-grammar-card.component.html
@@ -10,11 +10,11 @@
     ></textarea>
   </mat-form-field>
   <mat-form-field class="field">
-    <mat-label>English Translation</mat-label>
+    <mat-label>Hungarian Translation</mat-label>
     <textarea
       matInput
-      [formField]="grammarForm.englishTranslation"
-      aria-label="English translation"
+      [formField]="grammarForm.hungarianTranslation"
+      aria-label="Hungarian translation"
       rows="3"
     ></textarea>
   </mat-form-field>

--- a/client/src/app/parser/edit-card/edit-grammar-card/edit-grammar-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-grammar-card/edit-grammar-card.component.ts
@@ -46,7 +46,7 @@ export class EditGrammarCardComponent {
 
   readonly formModel = linkedSignal(() => ({
     sentence: this.card()?.data.examples?.[0]?.de ?? '',
-    englishTranslation: this.card()?.data.examples?.[0]?.en ?? '',
+    hungarianTranslation: this.card()?.data.examples?.[0]?.hu ?? '',
     hint: this.card()?.data.hint ?? '',
   }));
   readonly grammarForm = form(this.formModel);
@@ -144,7 +144,7 @@ export class EditGrammarCardComponent {
     const sourceId = this.selectedSourceId();
     const pageNumber = this.selectedPageNumber();
     const cardId = this.selectedCardId();
-    const { sentence, englishTranslation, hint } = this.formModel();
+    const { sentence, hungarianTranslation, hint } = this.formModel();
 
     if (!cardId || !sentence || !sourceId || !pageNumber) {
       return;
@@ -156,7 +156,7 @@ export class EditGrammarCardComponent {
       examples: [
         {
           de: sentence,
-          en: englishTranslation,
+          hu: hungarianTranslation,
           isSelected: true,
         },
       ],

--- a/client/src/app/study/learn-grammar-card/learn-grammar-card.component.css
+++ b/client/src/app/study/learn-grammar-card/learn-grammar-card.component.css
@@ -50,6 +50,13 @@
   text-align: center;
 }
 
+.translation-text {
+  font-size: 1.25rem;
+  margin: 0;
+  color: var(--mat-sys-on-surface-variant);
+  text-align: center;
+}
+
 .gap-word.masked {
   background: rgba(255, 255, 255, 0.1);
   color: transparent;

--- a/client/src/app/study/learn-grammar-card/learn-grammar-card.component.html
+++ b/client/src/app/study/learn-grammar-card/learn-grammar-card.component.html
@@ -14,5 +14,8 @@
     @if (hint()) {
       <p class="hint-text" aria-label="Hint">{{ hint() }}</p>
     }
+    @if (isRevealed() && hungarianTranslation()) {
+      <p class="translation-text" aria-label="Hungarian translation">{{ hungarianTranslation() }}</p>
+    }
   </div>
 </div>

--- a/client/src/app/study/learn-grammar-card/learn-grammar-card.component.ts
+++ b/client/src/app/study/learn-grammar-card/learn-grammar-card.component.ts
@@ -37,6 +37,8 @@ export class LearnGrammarCardComponent {
 
   readonly sentence = computed(() => this.selectedExample()?.de ?? '');
 
+  readonly hungarianTranslation = computed(() => this.selectedExample()?.hu);
+
   readonly hint = computed(() => this.card()?.value()?.data.hint);
 
   readonly audioSentence = computed(() => {

--- a/mock_anthropic_server/src/data.ts
+++ b/mock_anthropic_server/src/data.ts
@@ -248,11 +248,11 @@ export const SENTENCE_TRANSLATIONS: Record<string, Record<string, string>> = {
   hungarian: {
     'Hören Sie.': 'Hallgasson.',
     'Wie heißt das Lied?': 'Hogy hívják a dalt?',
+    'Das [ist] Paco.': 'Ez Paco.',
+    'Und [das] ist Frau Wachter.': 'És ez Wachter asszony.',
   },
   english: {
     'Hören Sie.': 'Listen.',
     'Wie heißt das Lied?': 'What is the name of the song?',
-    'Das [ist] Paco.': 'This is Paco.',
-    'Und [das] ist Frau Wachter.': 'And this is Frau Wachter.',
   },
 };

--- a/mock_google_ai_server/src/data.ts
+++ b/mock_google_ai_server/src/data.ts
@@ -327,14 +327,14 @@ export const SENTENCE_TRANSLATIONS: Record<string, Record<string, string>> = {
   hungarian: {
     'Hören Sie.': 'Hallgasson.',
     'Wie heißt das Lied?': 'Hogy hívják a dalt?',
+    'Das [ist] Paco.': 'Ez Paco.',
+    'Und [das] ist Frau Wachter.': 'És ez Wachter asszony.',
+    'Heute [bin] ich müde.': 'Ma fáradt vagyok.',
+    '[Der] Mann gibt [dem] Kind das Buch.': 'A férfi a gyereknek adja a könyvet.',
+    'Der Hund läuft schnell durch den [Park].': 'A kutya gyorsan átfut a parkon.',
   },
   english: {
     'Hören Sie.': 'Listen.',
     'Wie heißt das Lied?': 'What is the name of the song?',
-    'Das [ist] Paco.': 'This is Paco.',
-    'Und [das] ist Frau Wachter.': 'And this is Frau Wachter.',
-    'Heute [bin] ich müde.': 'Today I am tired.',
-    '[Der] Mann gibt [dem] Kind das Buch.': 'The man gives the child the book.',
-    'Der Hund läuft schnell durch den [Park].': 'The dog runs quickly through the park.',
   },
 };

--- a/mock_openai_server/src/data.ts
+++ b/mock_openai_server/src/data.ts
@@ -255,11 +255,11 @@ export const SENTENCE_TRANSLATIONS: Record<string, Record<string, string>> = {
   hungarian: {
     'Hören Sie.': 'Hallgasson.',
     'Wie heißt das Lied?': 'Hogy hívják a dalt?',
+    'Das [ist] Paco.': 'Ez Paco.',
+    'Und [das] ist Frau Wachter.': 'És ez Wachter asszony.',
   },
   english: {
     'Hören Sie.': 'Listen.',
     'Wie heißt das Lied?': 'What is the name of the song?',
-    'Das [ist] Paco.': 'This is Paco.',
-    'Und [das] ist Frau Wachter.': 'And this is Frau Wachter.',
   },
 };

--- a/server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -755,11 +755,12 @@ databaseChangeLog:
                   rs.review_score,
                   cs.correct_streak,
                   CASE WHEN c.readiness IN ('READY', 'REVIEWED', 'KNOWN') AND (
-                      (c.data->'translation'->>'en' IS NULL OR TRIM(c.data->'translation'->>'en') = '') OR
-                      (c.data->'translation'->>'hu' IS NULL OR TRIM(c.data->'translation'->>'hu') = '') OR
-                      (c.data->'translation'->>'ch' IS NULL OR TRIM(c.data->'translation'->>'ch') = '') OR
+                      (s.card_type <> 'GRAMMAR' AND (c.data->'translation'->>'en' IS NULL OR TRIM(c.data->'translation'->>'en') = '')) OR
+                      (s.card_type <> 'GRAMMAR' AND (c.data->'translation'->>'hu' IS NULL OR TRIM(c.data->'translation'->>'hu') = '')) OR
+                      (s.card_type <> 'GRAMMAR' AND (c.data->'translation'->>'ch' IS NULL OR TRIM(c.data->'translation'->>'ch') = '')) OR
                       (s.card_type = 'VOCABULARY' AND c.data->>'type' = 'NOUN' AND (c.data->>'gender' IS NULL OR TRIM(c.data->>'gender') = '')) OR
-                      (s.card_type = 'VOCABULARY' AND (c.data->>'type' IS NULL OR TRIM(c.data->>'type') = ''))
+                      (s.card_type = 'VOCABULARY' AND (c.data->>'type' IS NULL OR TRIM(c.data->>'type') = '')) OR
+                      (s.card_type = 'GRAMMAR' AND (c.data->'examples'->0->>'hu' IS NULL OR TRIM(c.data->'examples'->0->>'hu') = ''))
                   ) THEN true ELSE false END AS is_unhealthy,
                   CASE WHEN c.readiness = 'READY'
                       AND c.state = 'REVIEW'

--- a/test/tests/bulk-card-creation.spec.ts
+++ b/test/tests/bulk-card-creation.spec.ts
@@ -859,7 +859,7 @@ test('bulk grammar card creation extracts sentences with gaps', async ({ page })
     expect(card1?.state).toBe('NEW');
     expect(card1?.readiness).toBe('IN_REVIEW');
     expect(card1?.data.examples[0].hu).toBe('Ez Paco.');
-    expect(card1?.data.examples[0].en).toBeUndefined();
+    expect(card1?.data.examples[0].en).toBeNull();
     expect(card1?.data.examples[0].de).toContain('[ist]');
     expect(card1?.data.grammarTopic).toBe('Verbs');
 
@@ -870,7 +870,7 @@ test('bulk grammar card creation extracts sentences with gaps', async ({ page })
     expect(card2).toBeDefined();
     expect(card2?.data.examples[0].de).toContain('[das]');
     expect(card2?.data.examples[0].hu).toBe('És ez Wachter asszony.');
-    expect(card2?.data.examples[0].en).toBeUndefined();
+    expect(card2?.data.examples[0].en).toBeNull();
     expect(card2?.data.grammarTopic).toBe('Verbs');
     expect(card2?.data.translationModel).toBe('gemini-3.1-pro-preview');
     expect(card2?.data.extractionModel).toBe('gemini-3.1-pro-preview');

--- a/test/tests/bulk-card-creation.spec.ts
+++ b/test/tests/bulk-card-creation.spec.ts
@@ -858,7 +858,8 @@ test('bulk grammar card creation extracts sentences with gaps', async ({ page })
     expect(card1?.source_page_number).toBe(1);
     expect(card1?.state).toBe('NEW');
     expect(card1?.readiness).toBe('IN_REVIEW');
-    expect(card1?.data.examples[0].en).toBe('This is Paco.');
+    expect(card1?.data.examples[0].hu).toBe('Ez Paco.');
+    expect(card1?.data.examples[0].en).toBeUndefined();
     expect(card1?.data.examples[0].de).toContain('[ist]');
     expect(card1?.data.grammarTopic).toBe('Verbs');
 
@@ -868,6 +869,8 @@ test('bulk grammar card creation extracts sentences with gaps', async ({ page })
     const card2 = result.rows.find((row) => row.data.examples?.[0]?.de === 'Und [das] ist Frau Wachter.');
     expect(card2).toBeDefined();
     expect(card2?.data.examples[0].de).toContain('[das]');
+    expect(card2?.data.examples[0].hu).toBe('És ez Wachter asszony.');
+    expect(card2?.data.examples[0].en).toBeUndefined();
     expect(card2?.data.grammarTopic).toBe('Verbs');
     expect(card2?.data.translationModel).toBe('gemini-3.1-pro-preview');
     expect(card2?.data.extractionModel).toBe('gemini-3.1-pro-preview');

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -665,7 +665,6 @@ test('speech card editing updates sentence in database', async ({ page }) => {
 
 test('grammar card editing shows complete sentence and gaps', async ({ page }) => {
   await setupDefaultChatModelSettings();
-  const image1 = uploadMockImage(yellowImage);
   await createCard({
     cardId: 'grammar-edit-card',
     sourceId: 'grammar-a1',
@@ -674,9 +673,8 @@ test('grammar card editing shows complete sentence and gaps', async ({ page }) =
       examples: [
         {
           de: 'Der Hund [läuft] schnell.',
-          en: 'The dog runs fast.',
+          hu: 'A kutya gyorsan fut.',
           isSelected: true,
-          images: [{ id: image1, isFavorite: true }],
         },
       ],
     },
@@ -686,13 +684,12 @@ test('grammar card editing shows complete sentence and gaps', async ({ page }) =
   await page.goto('/in-review-cards');
 
   await expect(page.getByLabel('German sentence', { exact: true })).toHaveValue('Der Hund [läuft] schnell.');
-  await expect(page.getByLabel('English translation', { exact: true })).toHaveValue('The dog runs fast.');
+  await expect(page.getByLabel('Hungarian translation', { exact: true })).toHaveValue('A kutya gyorsan fut.');
   await expect(page.locator('.sentence-preview')).toContainText('Der Hund _____ schnell.');
 });
 
 test('grammar card editing allows adding gaps from selection', async ({ page }) => {
   await setupDefaultChatModelSettings();
-  const image1 = uploadMockImage(yellowImage);
   await createCard({
     cardId: 'grammar-add-gap-card',
     sourceId: 'grammar-a1',
@@ -701,9 +698,8 @@ test('grammar card editing allows adding gaps from selection', async ({ page }) 
       examples: [
         {
           de: 'Sie trinkt Kaffee.',
-          en: 'She drinks coffee.',
+          hu: 'Ő kávét iszik.',
           isSelected: true,
-          images: [{ id: image1, isFavorite: true }],
         },
       ],
     },
@@ -725,7 +721,6 @@ test('grammar card editing allows adding gaps from selection', async ({ page }) 
 
 test('grammar card editing allows removing gaps', async ({ page }) => {
   await setupDefaultChatModelSettings();
-  const image1 = uploadMockImage(yellowImage);
   await createCard({
     cardId: 'grammar-remove-gap-card',
     sourceId: 'grammar-a1',
@@ -734,9 +729,8 @@ test('grammar card editing allows removing gaps', async ({ page }) => {
       examples: [
         {
           de: 'Wir [gehen] ins Kino.',
-          en: 'We go to the cinema.',
+          hu: 'Moziba megyünk.',
           isSelected: true,
-          images: [{ id: image1, isFavorite: true }],
         },
       ],
     },
@@ -754,7 +748,6 @@ test('grammar card editing allows removing gaps', async ({ page }) => {
 
 test('grammar card editing saves gaps to database', async ({ page }) => {
   await setupDefaultChatModelSettings();
-  const image1 = uploadMockImage(yellowImage);
   await createCard({
     cardId: 'grammar-save-card',
     sourceId: 'grammar-a1',
@@ -763,9 +756,8 @@ test('grammar card editing saves gaps to database', async ({ page }) => {
       examples: [
         {
           de: 'Das Kind spielt im Garten.',
-          en: 'The child plays in the garden.',
+          hu: 'A gyerek a kertben játszik.',
           isSelected: true,
-          images: [{ id: image1, isFavorite: true }],
         },
       ],
     },
@@ -781,7 +773,7 @@ test('grammar card editing saves gaps to database', async ({ page }) => {
   });
 
   await page.getByRole('button', { name: 'Add Gap from Selection' }).click();
-  await page.getByLabel('English translation', { exact: true }).fill('The child is playing in the garden.');
+  await page.getByLabel('Hungarian translation', { exact: true }).fill('A gyerek éppen a kertben játszik.');
   await page.getByRole('button', { name: 'Save card' }).click();
 
   await withDbConnection(async (client) => {
@@ -789,13 +781,12 @@ test('grammar card editing saves gaps to database', async ({ page }) => {
     expect(result.rows.length).toBe(1);
     const cardData = result.rows[0].data;
     expect(cardData.examples[0].de).toBe('Das Kind [spielt] im Garten.');
-    expect(cardData.examples[0].en).toBe('The child is playing in the garden.');
+    expect(cardData.examples[0].hu).toBe('A gyerek éppen a kertben játszik.');
   });
 });
 
 test('grammar card editing displays existing hint and saves edits to database', async ({ page }) => {
   await setupDefaultChatModelSettings();
-  const image1 = uploadMockImage(yellowImage);
   await createCard({
     cardId: 'grammar-hint-edit-card',
     sourceId: 'grammar-a1',
@@ -805,9 +796,8 @@ test('grammar card editing displays existing hint and saves edits to database', 
       examples: [
         {
           de: 'Heute [bin] ich müde.',
-          en: 'Today I am tired.',
+          hu: 'Ma fáradt vagyok.',
           isSelected: true,
-          images: [{ id: image1, isFavorite: true }],
         },
       ],
     },
@@ -833,7 +823,6 @@ test('grammar card editing displays existing hint and saves edits to database', 
 
 test('grammar card editing allows adding a hint to a card without one', async ({ page }) => {
   await setupDefaultChatModelSettings();
-  const image1 = uploadMockImage(yellowImage);
   await createCard({
     cardId: 'grammar-no-hint-edit-card',
     sourceId: 'grammar-a1',
@@ -842,9 +831,8 @@ test('grammar card editing allows adding a hint to a card without one', async ({
       examples: [
         {
           de: 'Der Hund läuft durch den [Park].',
-          en: 'The dog runs through the park.',
+          hu: 'A kutya átfut a parkon.',
           isSelected: true,
-          images: [{ id: image1, isFavorite: true }],
         },
       ],
     },

--- a/test/tests/study-page.spec.ts
+++ b/test/tests/study-page.spec.ts
@@ -1220,8 +1220,6 @@ test('speech card grading functionality', async ({ page }) => {
 
 test('grammar card study shows sentence with gaps on front, full sentence on reveal', async ({ page }) => {
   await setupDefaultChatModelSettings();
-  await setupDefaultImageModelSettings();
-  const image1 = uploadMockImage(yellowImage);
   await createCard({
     cardId: 'grammar-test-card',
     sourceId: 'grammar-a1',
@@ -1230,9 +1228,8 @@ test('grammar card study shows sentence with gaps on front, full sentence on rev
       examples: [
         {
           de: 'Ich gehe [jeden] Tag in die Schule.',
-          en: 'I go to school every day.',
+          hu: 'Minden nap iskolába megyek.',
           isSelected: true,
-          images: [{ id: image1, isFavorite: true }],
         },
       ],
       audio: [{ id: 'test-audio', text: 'Ich gehe jeden Tag in die Schule.', language: 'de' }],
@@ -1245,17 +1242,17 @@ test('grammar card study shows sentence with gaps on front, full sentence on rev
   const flashcard = page.getByRole('article', { name: 'Flashcard' });
   await expect(flashcard.locator('.gap-word.masked')).toBeVisible();
   await expect(flashcard.locator('.gap-word.masked')).toHaveText('jeden');
+  await expect(flashcard.getByLabel('Hungarian translation')).toHaveCount(0);
 
   await flashcard.getByText('Ich gehe').click();
 
   await expect(flashcard.locator('.gap-word.highlighted')).toBeVisible();
   await expect(flashcard.locator('.gap-word.highlighted')).toHaveText('jeden');
+  await expect(flashcard.getByLabel('Hungarian translation')).toHaveText('Minden nap iskolába megyek.');
 });
 
 test('grammar card study shows German hint on front when present', async ({ page }) => {
   await setupDefaultChatModelSettings();
-  await setupDefaultImageModelSettings();
-  const image1 = uploadMockImage(yellowImage);
   await createCard({
     cardId: 'grammar-hint-card',
     sourceId: 'grammar-a1',
@@ -1265,9 +1262,8 @@ test('grammar card study shows German hint on front when present', async ({ page
       examples: [
         {
           de: 'Heute [bin] ich müde.',
-          en: 'Today I am tired.',
+          hu: 'Ma fáradt vagyok.',
           isSelected: true,
-          images: [{ id: image1, isFavorite: true }],
         },
       ],
       audio: [{ id: 'hint-audio', text: 'Heute bin ich müde.', language: 'de' }],
@@ -1287,8 +1283,6 @@ test('grammar card study shows German hint on front when present', async ({ page
 
 test('grammar card study omits hint element when card has no hint', async ({ page }) => {
   await setupDefaultChatModelSettings();
-  await setupDefaultImageModelSettings();
-  const image1 = uploadMockImage(yellowImage);
   await createCard({
     cardId: 'grammar-no-hint-card',
     sourceId: 'grammar-a1',
@@ -1297,9 +1291,8 @@ test('grammar card study omits hint element when card has no hint', async ({ pag
       examples: [
         {
           de: 'Der Hund läuft durch den [Park].',
-          en: 'The dog runs through the park.',
+          hu: 'A kutya átfut a parkon.',
           isSelected: true,
-          images: [{ id: image1, isFavorite: true }],
         },
       ],
       audio: [{ id: 'no-hint-audio', text: 'Der Hund läuft durch den Park.', language: 'de' }],
@@ -1316,8 +1309,6 @@ test('grammar card study omits hint element when card has no hint', async ({ pag
 
 test('grammar card grading functionality', async ({ page }) => {
   await setupDefaultChatModelSettings();
-  await setupDefaultImageModelSettings();
-  const image1 = uploadMockImage(greenImage);
   await createCard({
     cardId: 'grammar-grade-card',
     sourceId: 'grammar-a1',
@@ -1326,9 +1317,8 @@ test('grammar card grading functionality', async ({ page }) => {
       examples: [
         {
           de: 'Er [trinkt] jeden Morgen Kaffee.',
-          en: 'He drinks coffee every morning.',
+          hu: 'Minden reggel kávét iszik.',
           isSelected: true,
-          images: [{ id: image1, isFavorite: true }],
         },
       ],
     },

--- a/test/tests/unhealthy-cards.spec.ts
+++ b/test/tests/unhealthy-cards.spec.ts
@@ -149,3 +149,53 @@ test('unhealthy filter does not show healthy cards', async ({ page }) => {
     expect(rows).toHaveLength(0);
   }).toPass();
 });
+
+test('unhealthy filter shows grammar cards missing hungarian translation', async ({ page }) => {
+  await createCard({
+    cardId: 'grammar-missing-hu',
+    sourceId: 'grammar-a1',
+    sourcePageNumber: 1,
+    data: {
+      examples: [
+        {
+          de: 'Das [ist] ein Test.',
+          isSelected: true,
+        },
+      ],
+    },
+  });
+
+  await page.goto('/sources/grammar-a1/cards?filter=unhealthy');
+
+  const grid = page.getByRole('grid');
+  await expect(async () => {
+    const rows = await getGridData(grid);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]['ID']).toBe('grammar-missing-hu');
+  }).toPass();
+});
+
+test('unhealthy filter does not show grammar cards with hungarian translation', async ({ page }) => {
+  await createCard({
+    cardId: 'grammar-healthy',
+    sourceId: 'grammar-a1',
+    sourcePageNumber: 1,
+    data: {
+      examples: [
+        {
+          de: 'Das [ist] ein Test.',
+          hu: 'Ez egy teszt.',
+          isSelected: true,
+        },
+      ],
+    },
+  });
+
+  await page.goto('/sources/grammar-a1/cards?filter=unhealthy');
+
+  const grid = page.getByRole('grid');
+  await expect(async () => {
+    const rows = await getGridData(grid);
+    expect(rows).toHaveLength(0);
+  }).toPass();
+});


### PR DESCRIPTION
## Summary
This change updates the grammar card type to use Hungarian translations instead of English translations. This affects card creation, editing, study, and the health check logic for grammar cards.

## Key Changes

- **Translation Language**: Grammar cards now translate German sentences to Hungarian (`hu`) instead of English (`en`)
  - Updated API endpoint from `/api/translate-sentence/en` to `/api/translate-sentence/hu`
  - Changed progress message from "Translating to English..." to "Translating to Hungarian..."
  - Updated form field labels and aria-labels in edit component

- **Card Display**: Grammar cards now show Hungarian translation on reveal during study
  - Added `hungarianTranslation` computed property to study component
  - Added translation text display in study template with proper styling
  - Translation only appears when card is revealed

- **Card Editing**: Updated edit form to use Hungarian translation field
  - Changed form field from `englishTranslation` to `hungarianTranslation`
  - Updated template labels and accessibility attributes

- **Health Check Logic**: Updated unhealthy card detection for grammar cards
  - Grammar cards are now considered unhealthy if missing Hungarian translation in first example
  - Excluded grammar cards from English/Chinese translation health checks
  - Added specific check: `(s.card_type = 'GRAMMAR' AND (c.data->'examples'->0->>'hu' IS NULL OR TRIM(c.data->'examples'->0->>'hu') = ''))`

- **Mock Data**: Updated translation mock servers to provide Hungarian translations
  - Moved grammar sentence translations from English to Hungarian in all mock servers (Google AI, Anthropic, OpenAI)

- **Tests**: Updated all grammar card tests to use Hungarian translations
  - Removed image references from grammar card test data
  - Changed expected translation values from English to Hungarian
  - Added new tests for unhealthy filter detecting missing Hungarian translations
  - Updated study page tests to verify Hungarian translation display on reveal

https://claude.ai/code/session_019Hp3ywCYJ6ToKLMHs9ccfz