### PR TITLE
Add edit functionality for grammar topics

### DIFF
--- a/client/src/app/grammar-topics/edit-grammar-topic-dialog/edit-grammar-topic-dialog.component.css
+++ b/client/src/app/grammar-topics/edit-grammar-topic-dialog/edit-grammar-topic-dialog.component.css
@@ -1,0 +1,4 @@
+.topic-name-field {
+  width: 100%;
+  min-width: 320px;
+}

--- a/client/src/app/grammar-topics/edit-grammar-topic-dialog/edit-grammar-topic-dialog.component.html
+++ b/client/src/app/grammar-topics/edit-grammar-topic-dialog/edit-grammar-topic-dialog.component.html
@@ -6,7 +6,6 @@
     <input
       matInput
       [formField]="topicForm.name"
-      aria-label="Topic name"
       (keydown.enter)="save()"
     />
   </mat-form-field>

--- a/client/src/app/grammar-topics/edit-grammar-topic-dialog/edit-grammar-topic-dialog.component.html
+++ b/client/src/app/grammar-topics/edit-grammar-topic-dialog/edit-grammar-topic-dialog.component.html
@@ -1,0 +1,25 @@
+<h2 mat-dialog-title>Edit Grammar Topic</h2>
+
+<mat-dialog-content>
+  <mat-form-field appearance="outline" class="topic-name-field">
+    <mat-label>Topic name</mat-label>
+    <input
+      matInput
+      [formField]="topicForm.name"
+      aria-label="Topic name"
+      (keydown.enter)="save()"
+    />
+  </mat-form-field>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()">Cancel</button>
+  <button
+    mat-flat-button
+    color="primary"
+    (click)="save()"
+    [disabled]="!isValid()"
+  >
+    Save
+  </button>
+</mat-dialog-actions>

--- a/client/src/app/grammar-topics/edit-grammar-topic-dialog/edit-grammar-topic-dialog.component.ts
+++ b/client/src/app/grammar-topics/edit-grammar-topic-dialog/edit-grammar-topic-dialog.component.ts
@@ -1,0 +1,54 @@
+import { Component, inject, signal, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { form, FormField } from '@angular/forms/signals';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogRef,
+  MatDialogModule,
+} from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { GrammarTopic } from '../grammar-topics.service';
+
+interface DialogData {
+  topic: GrammarTopic;
+}
+
+@Component({
+  selector: 'app-edit-grammar-topic-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormField,
+    MatDialogModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+  ],
+  templateUrl: './edit-grammar-topic-dialog.component.html',
+  styleUrl: './edit-grammar-topic-dialog.component.css',
+})
+export class EditGrammarTopicDialogComponent {
+  private readonly dialogRef = inject(
+    MatDialogRef<EditGrammarTopicDialogComponent>
+  );
+  private readonly data = inject<DialogData>(MAT_DIALOG_DATA);
+
+  readonly formModel = signal({ name: this.data.topic.name });
+  readonly topicForm = form(this.formModel);
+
+  readonly isValid = computed(() => {
+    const name = this.formModel().name.trim();
+    return name.length > 0 && name !== this.data.topic.name;
+  });
+
+  save(): void {
+    if (!this.isValid()) return;
+    this.dialogRef.close({ name: this.formModel().name.trim() });
+  }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/client/src/app/grammar-topics/edit-grammar-topic-dialog/edit-grammar-topic-dialog.component.ts
+++ b/client/src/app/grammar-topics/edit-grammar-topic-dialog/edit-grammar-topic-dialog.component.ts
@@ -40,7 +40,7 @@ export class EditGrammarTopicDialogComponent {
 
   readonly isValid = computed(() => {
     const name = this.formModel().name.trim();
-    return name.length > 0 && name !== this.data.topic.name;
+    return name.length > 0 && name !== this.data.topic.name.trim();
   });
 
   save(): void {

--- a/client/src/app/grammar-topics/edit-grammar-topic-dialog/edit-grammar-topic-dialog.component.ts
+++ b/client/src/app/grammar-topics/edit-grammar-topic-dialog/edit-grammar-topic-dialog.component.ts
@@ -1,5 +1,4 @@
 import { Component, inject, signal, computed } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { form, FormField } from '@angular/forms/signals';
 import {
   MAT_DIALOG_DATA,
@@ -19,7 +18,6 @@ interface DialogData {
   selector: 'app-edit-grammar-topic-dialog',
   standalone: true,
   imports: [
-    CommonModule,
     FormField,
     MatDialogModule,
     MatButtonModule,

--- a/client/src/app/grammar-topics/grammar-topics.component.html
+++ b/client/src/app/grammar-topics/grammar-topics.component.html
@@ -61,6 +61,14 @@
             <div matListItemMeta class="topic-actions">
               <button
                 mat-icon-button
+                (click)="editTopic(topic)"
+                matTooltip="Edit topic"
+                [attr.aria-label]="'Edit ' + topic.name"
+              >
+                <mat-icon>edit</mat-icon>
+              </button>
+              <button
+                mat-icon-button
                 (click)="deleteTopic(topic)"
                 matTooltip="Delete topic"
                 [attr.aria-label]="'Delete ' + topic.name"

--- a/client/src/app/grammar-topics/grammar-topics.component.html
+++ b/client/src/app/grammar-topics/grammar-topics.component.html
@@ -62,6 +62,7 @@
               <button
                 mat-icon-button
                 (click)="editTopic(topic)"
+                [disabled]="editingTopicId() === topic.id"
                 matTooltip="Edit topic"
                 [attr.aria-label]="'Edit ' + topic.name"
               >

--- a/client/src/app/grammar-topics/grammar-topics.component.ts
+++ b/client/src/app/grammar-topics/grammar-topics.component.ts
@@ -43,6 +43,7 @@ export class GrammarTopicsComponent {
   readonly formModel = signal({ name: '' });
   readonly topicForm = form(this.formModel);
   readonly isAdding = signal(false);
+  readonly editingTopicId = signal<number | null>(null);
 
   readonly topicsList = computed(() => this.topics.value() ?? []);
 
@@ -62,13 +63,20 @@ export class GrammarTopicsComponent {
   }
 
   async editTopic(topic: GrammarTopic): Promise<void> {
+    if (this.editingTopicId() !== null) return;
+
     const dialogRef = this.dialog.open(EditGrammarTopicDialogComponent, {
       data: { topic },
     });
 
     const result = await firstValueFrom(dialogRef.afterClosed());
-    if (result?.name) {
+    if (!result?.name) return;
+
+    this.editingTopicId.set(topic.id);
+    try {
       await this.service.updateTopic(topic.id, { name: result.name });
+    } finally {
+      this.editingTopicId.set(null);
     }
   }
 

--- a/client/src/app/grammar-topics/grammar-topics.component.ts
+++ b/client/src/app/grammar-topics/grammar-topics.component.ts
@@ -9,6 +9,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatListModule } from '@angular/material/list';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { firstValueFrom } from 'rxjs';
 import {
   GrammarTopicsService,
@@ -38,6 +39,7 @@ import { EditGrammarTopicDialogComponent } from './edit-grammar-topic-dialog/edi
 export class GrammarTopicsComponent {
   private readonly service = inject(GrammarTopicsService);
   private readonly dialog = inject(MatDialog);
+  private readonly snackBar = inject(MatSnackBar);
 
   readonly topics = this.service.topics;
   readonly formModel = signal({ name: '' });
@@ -75,6 +77,10 @@ export class GrammarTopicsComponent {
     this.editingTopicId.set(topic.id);
     try {
       await this.service.updateTopic(topic.id, { name: result.name });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to update topic';
+      this.snackBar.open(message, 'Dismiss', { duration: 5000 });
     } finally {
       this.editingTopicId.set(null);
     }

--- a/client/src/app/grammar-topics/grammar-topics.component.ts
+++ b/client/src/app/grammar-topics/grammar-topics.component.ts
@@ -15,6 +15,7 @@ import {
   GrammarTopic,
 } from './grammar-topics.service';
 import { ConfirmDialogComponent } from '../parser/edit-card/confirm-dialog/confirm-dialog.component';
+import { EditGrammarTopicDialogComponent } from './edit-grammar-topic-dialog/edit-grammar-topic-dialog.component';
 
 @Component({
   selector: 'app-grammar-topics',
@@ -57,6 +58,17 @@ export class GrammarTopicsComponent {
       this.formModel.set({ name: '' });
     } finally {
       this.isAdding.set(false);
+    }
+  }
+
+  async editTopic(topic: GrammarTopic): Promise<void> {
+    const dialogRef = this.dialog.open(EditGrammarTopicDialogComponent, {
+      data: { topic },
+    });
+
+    const result = await firstValueFrom(dialogRef.afterClosed());
+    if (result?.name) {
+      await this.service.updateTopic(topic.id, { name: result.name });
     }
   }
 

--- a/test/tests/grammar-topics.spec.ts
+++ b/test/tests/grammar-topics.spec.ts
@@ -36,6 +36,27 @@ test('can add multiple grammar topics', async ({ page }) => {
   expect(topics.length).toBe(2);
 });
 
+test('can edit a grammar topic', async ({ page }) => {
+  await createGrammarTopic({ name: 'Akkusativ' });
+
+  await page.goto('/settings/grammar-topics');
+
+  await expect(page.getByText('Akkusativ')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Edit Akkusativ' }).click();
+
+  const dialog = page.getByRole('dialog', { name: 'Edit Grammar Topic' });
+  await dialog.getByRole('textbox', { name: 'Topic name' }).fill('Dativ');
+  await dialog.getByRole('button', { name: 'Save' }).click();
+
+  await expect(page.getByText('Dativ')).toBeVisible();
+  await expect(page.getByText('Akkusativ')).not.toBeVisible();
+
+  const topics = await getGrammarTopics();
+  expect(topics.length).toBe(1);
+  expect(topics[0].name).toBe('Dativ');
+});
+
 test('can delete a grammar topic', async ({ page }) => {
   await createGrammarTopic({ name: 'Akkusativ' });
 


### PR DESCRIPTION
## Summary
This PR adds the ability to edit grammar topics through a new dialog component. Users can now update the name of existing grammar topics from the grammar topics settings page.

## Key Changes
- **New Dialog Component**: Created `EditGrammarTopicDialogComponent` with reactive form handling using Angular signals
  - Validates that the topic name is non-empty and different from the original name
  - Supports saving via button click or Enter key
  - Provides cancel functionality
  
- **Updated Grammar Topics Component**: 
  - Added `editTopic()` method to open the edit dialog and handle the update
  - Added edit button to the topic list UI with appropriate accessibility labels
  
- **Test Coverage**: Added e2e test verifying the complete edit workflow (open dialog, change name, save, verify update)

## Implementation Details
- Uses Angular's new signals-based form API (`form()` and `FormField`)
- Computed property `isValid()` ensures the save button is only enabled when the name has changed and is non-empty
- Dialog closes with the new name data on save, or without data on cancel
- Edit button positioned before the delete button in the action menu

https://claude.ai/code/session_01EoZaYa72gX6m2z5M3zAXFR