### PR TITLE
Add settings page to cleanup all daily study sessions

### DIFF
--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -77,6 +77,12 @@ export const routes: Routes = [
           import('./api-tokens/api-tokens.component').then((m) => m.ApiTokensComponent),
         title: 'API Tokens',
       },
+      {
+        path: 'daily-sessions',
+        loadComponent: () =>
+          import('./daily-sessions/daily-sessions.component').then((m) => m.DailySessionsComponent),
+        title: 'Daily Sessions',
+      },
     ],
   },
   {

--- a/client/src/app/daily-sessions/daily-sessions.component.css
+++ b/client/src/app/daily-sessions/daily-sessions.component.css
@@ -5,7 +5,5 @@
 }
 
 .cleanup-button {
-  background-color: var(--mat-sys-error);
-  color: var(--mat-sys-on-error);
   margin-top: 16px;
 }

--- a/client/src/app/daily-sessions/daily-sessions.component.css
+++ b/client/src/app/daily-sessions/daily-sessions.component.css
@@ -1,0 +1,11 @@
+.daily-sessions-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.cleanup-button {
+  background-color: var(--mat-sys-error);
+  color: var(--mat-sys-on-error);
+  margin-top: 16px;
+}

--- a/client/src/app/daily-sessions/daily-sessions.component.html
+++ b/client/src/app/daily-sessions/daily-sessions.component.html
@@ -1,7 +1,7 @@
 <div class="daily-sessions-container">
   <mat-card>
     <mat-card-header>
-      <mat-card-title><h2>Daily Sessions</h2></mat-card-title>
+      <h2 mat-card-title>Daily Sessions</h2>
     </mat-card-header>
     <mat-card-content>
       <p>

--- a/client/src/app/daily-sessions/daily-sessions.component.html
+++ b/client/src/app/daily-sessions/daily-sessions.component.html
@@ -1,0 +1,24 @@
+<div class="daily-sessions-container">
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title><h2>Daily Sessions</h2></mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <p>
+        Remove every stored daily study session. Useful when you want to start
+        the day over from scratch.
+      </p>
+      <button
+        mat-flat-button
+        color="warn"
+        class="cleanup-button"
+        (click)="cleanupDailySessions()"
+        [disabled]="isDeleting()"
+        aria-label="Cleanup daily sessions"
+      >
+        <mat-icon>delete_forever</mat-icon>
+        Cleanup Daily Sessions
+      </button>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/client/src/app/daily-sessions/daily-sessions.component.ts
+++ b/client/src/app/daily-sessions/daily-sessions.component.ts
@@ -3,7 +3,6 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { firstValueFrom } from 'rxjs';
 import { StudySessionService } from '../study-session.service';
 import { ConfirmDialogComponent } from '../parser/edit-card/confirm-dialog/confirm-dialog.component';
 
@@ -32,7 +31,9 @@ export class DailySessionsComponent {
       },
     });
 
-    const confirmed = await firstValueFrom(dialogRef.afterClosed());
+    const confirmed = await new Promise<boolean>((resolve) => {
+      dialogRef.afterClosed().subscribe((result) => resolve(!!result));
+    });
     if (!confirmed) {
       return;
     }

--- a/client/src/app/daily-sessions/daily-sessions.component.ts
+++ b/client/src/app/daily-sessions/daily-sessions.component.ts
@@ -1,0 +1,47 @@
+import { Component, inject, signal } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { firstValueFrom } from 'rxjs';
+import { StudySessionService } from '../study-session.service';
+import { ConfirmDialogComponent } from '../parser/edit-card/confirm-dialog/confirm-dialog.component';
+
+@Component({
+  selector: 'app-daily-sessions',
+  standalone: true,
+  imports: [
+    MatButtonModule,
+    MatCardModule,
+    MatIconModule,
+    MatDialogModule,
+  ],
+  templateUrl: './daily-sessions.component.html',
+  styleUrl: './daily-sessions.component.css',
+})
+export class DailySessionsComponent {
+  private readonly studySessionService = inject(StudySessionService);
+  private readonly dialog = inject(MatDialog);
+
+  readonly isDeleting = signal(false);
+
+  async cleanupDailySessions(): Promise<void> {
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+      data: {
+        message: 'Delete all daily study sessions? This cannot be undone.',
+      },
+    });
+
+    const confirmed = await firstValueFrom(dialogRef.afterClosed());
+    if (!confirmed) {
+      return;
+    }
+
+    this.isDeleting.set(true);
+    try {
+      await this.studySessionService.deleteAllSessions();
+    } finally {
+      this.isDeleting.set(false);
+    }
+  }
+}

--- a/client/src/app/settings/settings.component.html
+++ b/client/src/app/settings/settings.component.html
@@ -29,6 +29,10 @@
         <mat-icon matListItemIcon>vpn_key</mat-icon>
         <span matListItemTitle>API Tokens</span>
       </a>
+      <a mat-list-item routerLink="daily-sessions" routerLinkActive="active">
+        <mat-icon matListItemIcon>event_busy</mat-icon>
+        <span matListItemTitle>Daily Sessions</span>
+      </a>
     </mat-nav-list>
   </nav>
   <main class="settings-content">

--- a/client/src/app/study-session.service.ts
+++ b/client/src/app/study-session.service.ts
@@ -122,4 +122,11 @@ export class StudySessionService {
     this.hasSession.set(false);
     this.hasExistingSession.set(false);
   }
+
+  async deleteAllSessions(): Promise<void> {
+    await fetchJson(this.http, '/api/study-sessions', { method: 'DELETE' });
+    this.clearSession();
+    this.dueCardsService.refetchDueCounts();
+    this.sourcesService.refetchSources();
+  }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/StudySessionController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/StudySessionController.java
@@ -8,6 +8,7 @@ import java.time.ZoneId;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -100,6 +101,13 @@ public class StudySessionController {
             @RequestBody AddCardsToSessionRequest request,
             @RequestHeader("X-Timezone") String timezone) {
         studySessionService.addCardsToSessions(request.getCardIds(), startOfDayUtc(parseTimezone(timezone)));
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/study-sessions")
+    @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
+    public ResponseEntity<Void> deleteAllSessions() {
+        studySessionService.deleteAllSessions();
         return ResponseEntity.noContent().build();
     }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/StudySessionService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/StudySessionService.java
@@ -233,6 +233,11 @@ public class StudySessionService {
     }
 
     @Transactional
+    public void deleteAllSessions() {
+        studySessionRepository.deleteAllInBatch();
+    }
+
+    @Transactional
     public void addCardsToSessions(List<String> cardIds, LocalDateTime startOfDay) {
         final List<Card> cards = cardRepository.findByIdInOrderByIdAsc(cardIds).stream()
                 .filter(Card::isReady)

--- a/test/tests/daily-sessions.spec.ts
+++ b/test/tests/daily-sessions.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '../fixtures';
+import {
+  createCard,
+  createStudySession,
+  getStudySessionCardsBySource,
+} from '../utils';
+
+test('navigates to daily sessions settings from settings page', async ({ page }) => {
+  await page.goto('/settings');
+  await expect(page.getByRole('link', { name: 'Daily Sessions' })).toBeVisible();
+  await page.getByRole('link', { name: 'Daily Sessions' }).click();
+  await expect(page.getByRole('heading', { name: 'Daily Sessions' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Cleanup daily sessions' })).toBeVisible();
+});
+
+test('cleanup daily sessions button removes all study sessions', async ({ page }) => {
+  await createCard({
+    cardId: 'haus-haz',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 5,
+    data: {
+      word: 'Haus',
+      type: 'NOUN',
+      translation: { en: 'house', hu: 'ház', ch: 'Huus' },
+    },
+  });
+  await createStudySession({
+    sourceId: 'goethe-a1',
+    cardIds: ['haus-haz'],
+  });
+
+  expect((await getStudySessionCardsBySource('goethe-a1')).length).toBe(1);
+
+  await page.goto('/settings/daily-sessions');
+  await page.getByRole('button', { name: 'Cleanup daily sessions' }).click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText('Delete all daily study sessions?')).toBeVisible();
+  await dialog.getByRole('button', { name: 'Yes' }).click();
+
+  await expect(page.getByRole('dialog')).not.toBeVisible();
+
+  expect(await getStudySessionCardsBySource('goethe-a1')).toEqual([]);
+});
+
+test('cancelling the confirmation dialog keeps sessions intact', async ({ page }) => {
+  await createCard({
+    cardId: 'baum-fa',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 5,
+    data: {
+      word: 'Baum',
+      type: 'NOUN',
+      translation: { en: 'tree', hu: 'fa', ch: 'Baum' },
+    },
+  });
+  await createStudySession({
+    sourceId: 'goethe-a1',
+    cardIds: ['baum-fa'],
+  });
+
+  await page.goto('/settings/daily-sessions');
+  await page.getByRole('button', { name: 'Cleanup daily sessions' }).click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole('button', { name: 'No' }).click();
+
+  await expect(page.getByRole('dialog')).not.toBeVisible();
+
+  expect((await getStudySessionCardsBySource('goethe-a1')).length).toBe(1);
+});


### PR DESCRIPTION
Adds a Daily Sessions settings page with a red Cleanup button that wipes
every stored study session via a confirmation dialog. The new
DELETE /api/study-sessions endpoint relies on the existing database
ON DELETE CASCADE to remove study_session_cards.

https://claude.ai/code/session_0191jLTWTLLwsmjv1v97Njop