### PR TITLE
Fix grammar card layout and audio text formatting

### DIFF
--- a/client/src/app/cardTypes/grammar-card-type.strategy.ts
+++ b/client/src/app/cardTypes/grammar-card-type.strategy.ts
@@ -16,6 +16,7 @@ import {
 } from '../parser/types';
 import { LANGUAGE_CODES } from '../shared/types/audio-generation.types';
 import { nonNullable } from '../utils/type-guards';
+import { createGrammarGapRegex } from '../shared/constants/grammar.constants';
 
 interface SentenceIdResponse {
   id: string;
@@ -168,7 +169,10 @@ export class GrammarCardType implements CardTypeStrategy {
     const example = card.data.examples?.[0];
     return [
       example?.de
-        ? { text: example.de, language: LANGUAGE_CODES.GERMAN }
+        ? {
+            text: example.de.replace(createGrammarGapRegex(), '$1'),
+            language: LANGUAGE_CODES.GERMAN,
+          }
         : null,
     ].filter(nonNullable);
   }

--- a/client/src/app/study/learn-grammar-card/learn-grammar-card.component.css
+++ b/client/src/app/study/learn-grammar-card/learn-grammar-card.component.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   position: relative;
+  aspect-ratio: 4 / 3;
 }
 
 .content-section {
@@ -14,11 +15,12 @@
 }
 
 .sentence-section {
-  margin-top: 1.5rem;
+  flex: 1;
   text-align: center;
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   gap: 0.5rem;
 }
 
@@ -71,16 +73,15 @@
 }
 
 @media (min-width: 768px) {
+  :host {
+    aspect-ratio: 20 / 11;
+  }
+
   .content-section {
     overflow-y: auto;
     overflow-x: hidden;
     padding: 1.5rem;
     gap: 1.5rem;
-  }
-
-  .sentence-section {
-    margin-top: 5rem;
-    gap: 1rem;
   }
 
   .sentence-text {

--- a/client/src/app/study/learn-grammar-card/learn-grammar-card.component.html
+++ b/client/src/app/study/learn-grammar-card/learn-grammar-card.component.html
@@ -5,15 +5,16 @@
     }
   </div>
 
+  @if (hint()) {
+    <p class="hint-text" aria-label="Hint">{{ hint() }}</p>
+  }
+
   <div class="sentence-section">
     <p class="sentence-text">@for (part of sentenceParts(); track $index) {<span
         [class.gap-word]="part.isGap"
         [class.masked]="part.isGap && !isRevealed()"
         [class.highlighted]="part.isGap && isRevealed()"
       >{{ part.text }}</span>}</p>
-    @if (hint()) {
-      <p class="hint-text" aria-label="Hint">{{ hint() }}</p>
-    }
     @if (isRevealed() && hungarianTranslation()) {
       <p class="translation-text" aria-label="Hungarian translation">{{ hungarianTranslation() }}</p>
     }

--- a/test/tests/bulk-audio-creation.spec.ts
+++ b/test/tests/bulk-audio-creation.spec.ts
@@ -424,6 +424,49 @@ test('bulk audio creation creates audio in database', async ({ page }) => {
   });
 });
 
+test('bulk audio creation strips grammar gap markers from audio text', async ({ page }) => {
+  await setupVoiceConfigurations();
+  await createCard({
+    cardId: 'grammar-audio-strip',
+    sourceId: 'grammar-a1',
+    sourcePageNumber: 3,
+    data: {
+      examples: [
+        {
+          de: 'Ich gehe [jeden] Tag in die Schule.',
+          hu: 'Minden nap iskolába megyek.',
+          isSelected: true,
+        },
+      ],
+    },
+    readiness: 'REVIEWED',
+  });
+
+  await page.goto('/in-review-cards');
+
+  await page.getByRole('button', { name: 'Generate audio for cards' }).click();
+
+  await expect(page.getByText('Audio generated successfully for 1 card!')).toBeVisible();
+
+  await withDbConnection(async (client) => {
+    const result = await client.query("SELECT data FROM learn_language.cards WHERE id = 'grammar-audio-strip'");
+
+    expect(result.rows.length).toBe(1);
+    const cardData = result.rows[0].data;
+    const audioList = cardData.audio;
+    expect(Array.isArray(audioList)).toBeTruthy();
+
+    const strippedAudio = audioList.find(
+      (audio: any) => audio.text === 'Ich gehe jeden Tag in die Schule.'
+    );
+    expect(strippedAudio).toBeDefined();
+    assertAudioExists(strippedAudio.id);
+
+    const bracketedAudio = audioList.find((audio: any) => audio.text?.includes('['));
+    expect(bracketedAudio).toBeUndefined();
+  });
+});
+
 test('bulk audio creation updates card readiness to ready', async ({ page }) => {
   await setupVoiceConfigurations();
   await createCard({

--- a/test/tests/study-page.spec.ts
+++ b/test/tests/study-page.spec.ts
@@ -1340,6 +1340,66 @@ test('grammar card grading functionality', async ({ page }) => {
   await expect(page.getByText('All caught up!')).toBeVisible();
 });
 
+test('grammar card without image keeps the same size as image cards', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await createCard({
+    cardId: 'grammar-size-card',
+    sourceId: 'grammar-a1',
+    sourcePageNumber: 8,
+    data: {
+      examples: [
+        {
+          de: 'Ich [lese] ein Buch.',
+          hu: 'Könyvet olvasok.',
+          isSelected: true,
+        },
+      ],
+      audio: [{ id: 'size-audio', text: 'Ich lese ein Buch.', language: 'de' }],
+    },
+  });
+
+  await page.goto('/sources/grammar-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
+
+  const flashcard = page.getByRole('article', { name: 'Flashcard' });
+  await expect(flashcard.locator('.gap-word.masked')).toBeVisible();
+
+  const box = await flashcard.boundingBox();
+  const ratio = box!.height / box!.width;
+  expect(ratio).toBeGreaterThan(0.5);
+  expect(ratio).toBeLessThan(0.6);
+});
+
+test('grammar card shows hint above the sentence', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await createCard({
+    cardId: 'grammar-hint-order-card',
+    sourceId: 'grammar-a1',
+    sourcePageNumber: 7,
+    data: {
+      hint: 'Perfekt',
+      examples: [
+        {
+          de: 'Ich [habe] gegessen.',
+          hu: 'Ettem.',
+          isSelected: true,
+        },
+      ],
+      audio: [{ id: 'hint-order-audio', text: 'Ich habe gegessen.', language: 'de' }],
+    },
+  });
+
+  await page.goto('/sources/grammar-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
+
+  const flashcard = page.getByRole('article', { name: 'Flashcard' });
+  await expect(flashcard.getByLabel('Hint')).toBeVisible();
+
+  const hintBox = await flashcard.getByLabel('Hint').boundingBox();
+  const sentenceBox = await flashcard.locator('.gap-word.masked').boundingBox();
+  expect(hintBox!.y).toBeLessThan(sentenceBox!.y);
+});
+
 test('Enter key reveals and unreveals card', async ({ page }) => {
   await createCard({
     cardId: 'keyboard-reveal-test',


### PR DESCRIPTION
## Summary
This PR fixes the visual layout of grammar cards to maintain consistent sizing regardless of whether an image is present, and ensures audio generation strips grammar gap markers from the text.

## Key Changes

- **Grammar card aspect ratio**: Added fixed aspect ratios (4:3 on mobile, 20:11 on desktop) to the grammar card component to ensure consistent card sizing
- **Hint positioning**: Moved hint text to display above the sentence instead of below it for better visual hierarchy
- **Sentence centering**: Updated sentence section to use flexbox centering (`flex: 1` and `justify-content: center`) for proper vertical alignment
- **Audio text formatting**: Modified grammar card audio generation to strip gap markers (brackets) from example text before creating audio, so audio files contain clean, readable text
- **CSS refinements**: Removed fixed margins from sentence section in favor of flexible layout that adapts to content

## Implementation Details

- The grammar gap regex (`createGrammarGapRegex()`) is used to extract text from bracketed gaps (e.g., `[jeden]` → `jeden`) when generating audio
- The aspect ratio approach ensures grammar cards without images maintain the same visual footprint as those with images
- Hint is now positioned in the content section above the sentence section for better semantic ordering

https://claude.ai/code/session_017cAdtZ7TVQb3CiWiwN5k5g