### PR TITLE
Strip grammar gap brackets from audio text in GrammarCardTypeStrategy

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/cardtype/GrammarCardTypeStrategy.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/cardtype/GrammarCardTypeStrategy.java
@@ -6,10 +6,13 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 @Component
 public class GrammarCardTypeStrategy implements CardTypeStrategy {
+
+    private static final Pattern GRAMMAR_GAP_PATTERN = Pattern.compile("\\[([^\\]]+)\\]");
 
     @Override
     public String getPrimaryText(CardData cardData) {
@@ -27,8 +30,13 @@ public class GrammarCardTypeStrategy implements CardTypeStrategy {
         return Stream.of(
                 example.map(ExampleData::getDe)
                         .filter(this::hasText)
+                        .map(this::stripGapBrackets)
                         .map(de -> new AudioTextItem(de, "de", false))
         ).flatMap(Optional::stream).toList();
+    }
+
+    private String stripGapBrackets(String sentence) {
+        return GRAMMAR_GAP_PATTERN.matcher(sentence).replaceAll("$1");
     }
 
     private Optional<ExampleData> getFirstExample(CardData cardData) {


### PR DESCRIPTION
## Summary
Updated the `GrammarCardTypeStrategy` to remove bracket notation from grammar gap markers before generating audio text. This ensures that audio files are generated for the actual words without the surrounding brackets used for marking gaps in the UI.

## Changes
- Added a regex pattern to match grammar gap brackets: `[word]`
- Introduced `stripGapBrackets()` method that removes the brackets while preserving the inner text
- Updated `getRequiredAudioTexts()` to strip gap brackets from German example text before creating audio items

## Implementation Details
- Uses a compiled `Pattern` for efficient regex matching: `\[([^\]]+)\]`
- The `replaceAll("$1")` operation extracts just the captured group (text inside brackets)
- This ensures audio generation uses clean text without formatting markers

https://claude.ai/code/session_01BTtdttkmHRQcgTjvAedaNh