### PR TITLE
Add optional context parameter for image generation

### DIFF
--- a/client/src/app/parser/edit-card/edit-speech-card/edit-speech-card.component.html
+++ b/client/src/app/parser/edit-card/edit-speech-card/edit-speech-card.component.html
@@ -39,6 +39,15 @@
   >
     <mat-icon>add_photo_alternate</mat-icon>
   </button>
+  <button
+    mat-icon-button
+    (click)="addImageWithContext()"
+    aria-label="Add image with context"
+    [disabled]="areImagesLoading() || dailyUsageService.isImageLimitReached()"
+    [matTooltip]="dailyUsageService.imageLimitTooltip() || 'Add image with context'"
+  >
+    <mat-icon>edit_note</mat-icon>
+  </button>
 </div>
 @let imgs = images();
 @if (imgs && imgs.length) {

--- a/client/src/app/parser/edit-card/edit-speech-card/edit-speech-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-speech-card/edit-speech-card.component.ts
@@ -15,7 +15,6 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDialog } from '@angular/material/dialog';
-import { firstValueFrom } from 'rxjs';
 import { Card, CardData } from '../../types';
 import {
   ImageGridComponent,
@@ -24,6 +23,7 @@ import {
 import { ImageResourceService } from '../../../shared/image-resource.service';
 import { ImageContextDialogComponent } from '../../../shared/image-context-dialog/image-context-dialog.component';
 import { DailyUsageService } from '../../../daily-usage.service';
+import { dialogResult } from '../../../utils/dialog-result';
 
 @Component({
   selector: 'app-edit-speech-card',
@@ -104,20 +104,7 @@ export class EditSpeechCardComponent {
     });
   }
 
-  async addImage() {
-    await this.generateImages();
-  }
-
-  async addImageWithContext() {
-    const dialogRef = this.dialog.open(ImageContextDialogComponent, {
-      width: '400px',
-    });
-    const context = await firstValueFrom(dialogRef.afterClosed());
-    if (context === undefined) return;
-    await this.generateImages(context);
-  }
-
-  private async generateImages(context?: string) {
+  async addImage(context?: string) {
     const englishTranslation = this.formModel().englishTranslation;
     if (!englishTranslation) return;
 
@@ -134,6 +121,15 @@ export class EditSpeechCardComponent {
       this.cardUpdate.emit(cardData);
     }
     this.saveRequested.emit();
+  }
+
+  async addImageWithContext() {
+    const dialogRef = this.dialog.open(ImageContextDialogComponent, {
+      width: '400px',
+    });
+    const context = await dialogResult(dialogRef);
+    if (context === undefined) return;
+    await this.addImage(context);
   }
 
   areImagesLoading() {

--- a/client/src/app/parser/edit-card/edit-speech-card/edit-speech-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-speech-card/edit-speech-card.component.ts
@@ -14,12 +14,15 @@ import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatDialog } from '@angular/material/dialog';
+import { firstValueFrom } from 'rxjs';
 import { Card, CardData } from '../../types';
 import {
   ImageGridComponent,
   GridImageResource,
 } from '../../../shared/image-grid/image-grid.component';
 import { ImageResourceService } from '../../../shared/image-resource.service';
+import { ImageContextDialogComponent } from '../../../shared/image-context-dialog/image-context-dialog.component';
 import { DailyUsageService } from '../../../daily-usage.service';
 
 @Component({
@@ -47,6 +50,7 @@ export class EditSpeechCardComponent {
   markAsReviewedAvailable = output<boolean>();
 
   private readonly imageResourceService = inject(ImageResourceService);
+  private readonly dialog = inject(MatDialog);
   readonly dailyUsageService = inject(DailyUsageService);
 
   readonly formModel = linkedSignal(() => ({
@@ -101,11 +105,24 @@ export class EditSpeechCardComponent {
   }
 
   async addImage() {
+    await this.generateImages();
+  }
+
+  async addImageWithContext() {
+    const dialogRef = this.dialog.open(ImageContextDialogComponent, {
+      width: '400px',
+    });
+    const context = await firstValueFrom(dialogRef.afterClosed());
+    if (context === undefined) return;
+    await this.generateImages(context);
+  }
+
+  private async generateImages(context?: string) {
     const englishTranslation = this.formModel().englishTranslation;
     if (!englishTranslation) return;
 
     const { placeholders, done } =
-      this.imageResourceService.generateImages(englishTranslation);
+      this.imageResourceService.generateImages(englishTranslation, context);
 
     this.images.update((imgs) => [...imgs, ...placeholders]);
 

--- a/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.html
+++ b/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.html
@@ -88,6 +88,15 @@
       >
         <mat-icon>add_photo_alternate</mat-icon>
       </button>
+      <button
+        mat-icon-button
+        (click)="addImageWithContext($index)"
+        aria-label="Add example image with context"
+        [disabled]="areImagesLoading($index) || dailyUsageService.isImageLimitReached()"
+        [matTooltip]="dailyUsageService.imageLimitTooltip() || 'Add image with context'"
+      >
+        <mat-icon>edit_note</mat-icon>
+      </button>
     </div>
     <div class="example-fields">
       <mat-form-field class="field">

--- a/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.html
+++ b/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.html
@@ -91,7 +91,7 @@
       <button
         mat-icon-button
         (click)="addImageWithContext($index)"
-        aria-label="Add example image with context"
+        aria-label="Add image with context"
         [disabled]="areImagesLoading($index) || dailyUsageService.isImageLimitReached()"
         [matTooltip]="dailyUsageService.imageLimitTooltip() || 'Add image with context'"
       >

--- a/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.ts
@@ -18,7 +18,6 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDialog } from '@angular/material/dialog';
-import { firstValueFrom } from 'rxjs';
 import { WORD_TYPE_TRANSLATIONS } from '../../../shared/word-type-translations';
 import { GENDER_TRANSLATIONS } from '../../../shared/gender-translations';
 import { Card, CardData } from '../../types';
@@ -30,6 +29,7 @@ import {
 import { ImageResourceService } from '../../../shared/image-resource.service';
 import { ImageContextDialogComponent } from '../../../shared/image-context-dialog/image-context-dialog.component';
 import { DailyUsageService } from '../../../daily-usage.service';
+import { dialogResult } from '../../../utils/dialog-result';
 
 @Component({
   selector: 'app-edit-vocabulary-card',
@@ -158,20 +158,7 @@ export class EditVocabularyCardComponent {
     });
   }
 
-  async addImage(exampleIdx: number) {
-    await this.generateImagesForExample(exampleIdx);
-  }
-
-  async addImageWithContext(exampleIdx: number) {
-    const dialogRef = this.dialog.open(ImageContextDialogComponent, {
-      width: '400px',
-    });
-    const context = await firstValueFrom(dialogRef.afterClosed());
-    if (context === undefined) return;
-    await this.generateImagesForExample(exampleIdx, context);
-  }
-
-  private async generateImagesForExample(exampleIdx: number, context?: string) {
+  async addImage(exampleIdx: number, context?: string) {
     const englishTranslation = this.examplesTranslations()?.['en'][exampleIdx]();
     if (!englishTranslation) return;
 
@@ -191,6 +178,15 @@ export class EditVocabularyCardComponent {
       this.cardUpdate.emit(cardData);
     }
     this.saveRequested.emit();
+  }
+
+  async addImageWithContext(exampleIdx: number) {
+    const dialogRef = this.dialog.open(ImageContextDialogComponent, {
+      width: '400px',
+    });
+    const context = await dialogResult(dialogRef);
+    if (context === undefined) return;
+    await this.addImage(exampleIdx, context);
   }
 
   areImagesLoading(exampleIdx: number) {

--- a/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.ts
@@ -17,6 +17,8 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatDialog } from '@angular/material/dialog';
+import { firstValueFrom } from 'rxjs';
 import { WORD_TYPE_TRANSLATIONS } from '../../../shared/word-type-translations';
 import { GENDER_TRANSLATIONS } from '../../../shared/gender-translations';
 import { Card, CardData } from '../../types';
@@ -26,6 +28,7 @@ import {
   GridImageResource,
 } from '../../../shared/image-grid/image-grid.component';
 import { ImageResourceService } from '../../../shared/image-resource.service';
+import { ImageContextDialogComponent } from '../../../shared/image-context-dialog/image-context-dialog.component';
 import { DailyUsageService } from '../../../daily-usage.service';
 
 @Component({
@@ -55,6 +58,7 @@ export class EditVocabularyCardComponent {
   markAsReviewedAvailable = output<boolean>();
 
   private readonly imageResourceService = inject(ImageResourceService);
+  private readonly dialog = inject(MatDialog);
   readonly dailyUsageService = inject(DailyUsageService);
   readonly wordTypeOptions = WORD_TYPE_TRANSLATIONS;
   readonly genderOptions = GENDER_TRANSLATIONS;
@@ -155,11 +159,24 @@ export class EditVocabularyCardComponent {
   }
 
   async addImage(exampleIdx: number) {
+    await this.generateImagesForExample(exampleIdx);
+  }
+
+  async addImageWithContext(exampleIdx: number) {
+    const dialogRef = this.dialog.open(ImageContextDialogComponent, {
+      width: '400px',
+    });
+    const context = await firstValueFrom(dialogRef.afterClosed());
+    if (context === undefined) return;
+    await this.generateImagesForExample(exampleIdx, context);
+  }
+
+  private async generateImagesForExample(exampleIdx: number, context?: string) {
     const englishTranslation = this.examplesTranslations()?.['en'][exampleIdx]();
     if (!englishTranslation) return;
 
     const { placeholders, done } =
-      this.imageResourceService.generateImages(englishTranslation);
+      this.imageResourceService.generateImages(englishTranslation, context);
 
     this.exampleImages.update((images) => {
       images[exampleIdx] = [...images[exampleIdx], ...placeholders];

--- a/client/src/app/shared/image-context-dialog/image-context-dialog.component.html
+++ b/client/src/app/shared/image-context-dialog/image-context-dialog.component.html
@@ -1,0 +1,16 @@
+<h2 mat-dialog-title>Image generation context</h2>
+<mat-dialog-content>
+  <mat-form-field class="context-field">
+    <mat-label>Additional context</mat-label>
+    <textarea
+      matInput
+      [(ngModel)]="context"
+      aria-label="Image generation context"
+      rows="4"
+    ></textarea>
+  </mat-form-field>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button (click)="onCancel()">Cancel</button>
+  <button mat-button (click)="onGenerate()">Generate</button>
+</mat-dialog-actions>

--- a/client/src/app/shared/image-context-dialog/image-context-dialog.component.html
+++ b/client/src/app/shared/image-context-dialog/image-context-dialog.component.html
@@ -12,5 +12,5 @@
 </mat-dialog-content>
 <mat-dialog-actions align="end">
   <button mat-button (click)="onCancel()">Cancel</button>
-  <button mat-button (click)="onGenerate()">Generate</button>
+  <button mat-button (click)="onGenerate()" [disabled]="!canGenerate()">Generate</button>
 </mat-dialog-actions>

--- a/client/src/app/shared/image-context-dialog/image-context-dialog.component.ts
+++ b/client/src/app/shared/image-context-dialog/image-context-dialog.component.ts
@@ -1,0 +1,40 @@
+import { Component, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MatDialogActions,
+  MatDialogContent,
+  MatDialogRef,
+  MatDialogTitle,
+} from '@angular/material/dialog';
+import { MatFormFieldModule, MatLabel } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+
+@Component({
+  selector: 'app-image-context-dialog',
+  templateUrl: './image-context-dialog.component.html',
+  imports: [
+    FormsModule,
+    MatButtonModule,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogTitle,
+    MatFormFieldModule,
+    MatLabel,
+    MatInputModule,
+  ],
+})
+export class ImageContextDialogComponent {
+  readonly context = signal('');
+
+  constructor(private readonly dialogRef: MatDialogRef<ImageContextDialogComponent, string | undefined>) {}
+
+  onCancel(): void {
+    this.dialogRef.close(undefined);
+  }
+
+  onGenerate(): void {
+    const value = this.context().trim();
+    this.dialogRef.close(value === '' ? undefined : value);
+  }
+}

--- a/client/src/app/shared/image-context-dialog/image-context-dialog.component.ts
+++ b/client/src/app/shared/image-context-dialog/image-context-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, signal } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import {
@@ -7,7 +7,7 @@ import {
   MatDialogRef,
   MatDialogTitle,
 } from '@angular/material/dialog';
-import { MatFormFieldModule, MatLabel } from '@angular/material/form-field';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 
 @Component({
@@ -20,21 +20,23 @@ import { MatInputModule } from '@angular/material/input';
     MatDialogActions,
     MatDialogTitle,
     MatFormFieldModule,
-    MatLabel,
     MatInputModule,
   ],
 })
 export class ImageContextDialogComponent {
-  readonly context = signal('');
+  private readonly dialogRef =
+    inject<MatDialogRef<ImageContextDialogComponent, string>>(MatDialogRef);
 
-  constructor(private readonly dialogRef: MatDialogRef<ImageContextDialogComponent, string | undefined>) {}
+  readonly context = signal('');
+  readonly canGenerate = computed(() => this.context().trim().length > 0);
 
   onCancel(): void {
-    this.dialogRef.close(undefined);
+    this.dialogRef.close();
   }
 
   onGenerate(): void {
     const value = this.context().trim();
-    this.dialogRef.close(value === '' ? undefined : value);
+    if (value === '') return;
+    this.dialogRef.close(value);
   }
 }

--- a/client/src/app/shared/image-resource.service.ts
+++ b/client/src/app/shared/image-resource.service.ts
@@ -31,7 +31,10 @@ export class ImageResourceService {
     });
   }
 
-  generateImages(englishTranslation: string): {
+  generateImages(
+    englishTranslation: string,
+    context?: string
+  ): {
     placeholders: GridImageResource[];
     done: Promise<void>;
   } {
@@ -61,6 +64,7 @@ export class ImageResourceService {
                   body: {
                     input: englishTranslation,
                     model: model.id,
+                    ...(context ? { context } : {}),
                   } satisfies ImageSourceRequest,
                   method: 'POST',
                 }

--- a/client/src/app/shared/types/image-generation.types.ts
+++ b/client/src/app/shared/types/image-generation.types.ts
@@ -1,6 +1,7 @@
 export interface ImageSourceRequest {
   input: string;
   model: string;
+  context?: string;
 }
 
 export interface ImageResponse {

--- a/client/src/app/utils/dialog-result.ts
+++ b/client/src/app/utils/dialog-result.ts
@@ -1,0 +1,11 @@
+import { MatDialogRef } from '@angular/material/dialog';
+
+export const dialogResult = <R>(
+  dialogRef: MatDialogRef<unknown, R>
+): Promise<R | undefined> =>
+  new Promise<R | undefined>((resolve) => {
+    const subscription = dialogRef.afterClosed().subscribe((value) => {
+      subscription.unsubscribe();
+      resolve(value);
+    });
+  });

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ImageController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ImageController.java
@@ -53,7 +53,8 @@ public class ImageController {
       }
     }
     final String displayName = imageSource.getModel().getDisplayName();
-    final byte[] data = imageService.generateImage(imageSource.getInput(), imageSource.getModel());
+    final byte[] data = imageService.generateImage(
+        imageSource.getInput(), imageSource.getContext(), imageSource.getModel());
     final String uuid = UUID.randomUUID().toString();
     final String filePath = "images/%s.webp".formatted(uuid);
     try {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageSourceRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageSourceRequest.java
@@ -1,6 +1,7 @@
 package io.github.mucsi96.learnlanguage.model;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,5 +18,6 @@ public class ImageSourceRequest {
   @NotNull
   private ImageGenerationModel model;
 
+  @Size(max = 500)
   private String context;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageSourceRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageSourceRequest.java
@@ -16,4 +16,6 @@ public class ImageSourceRequest {
 
   @NotNull
   private ImageGenerationModel model;
+
+  private String context;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/GoogleImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/GoogleImageService.java
@@ -19,7 +19,7 @@ public class GoogleImageService {
   private final Client googleAiClient;
   private final ModelUsageLoggingService usageLoggingService;
 
-  public byte[] generateImage(String prompt) {
+  public byte[] generateImage(String input, String context) {
     final long startTime = System.currentTimeMillis();
     try {
       final GenerateContentConfig config = GenerateContentConfig.builder()
@@ -30,8 +30,7 @@ public class GoogleImageService {
               .build())
           .build();
 
-      final String fullPrompt = "Create a photorealistic image for the following context: " + prompt
-          + ". Avoid using text.";
+      final String fullPrompt = ImagePromptBuilder.build(input, context);
 
       final byte[] image = googleAiClient.models.generateContent(MODEL_NAME, fullPrompt, config)
           .candidates().orElseThrow(() -> new RuntimeException("No candidates in Gemini response")).stream()

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImagePromptBuilder.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImagePromptBuilder.java
@@ -1,0 +1,14 @@
+package io.github.mucsi96.learnlanguage.service;
+
+final class ImagePromptBuilder {
+  private ImagePromptBuilder() {
+  }
+
+  static String build(String input, String context) {
+    final String contextSegment = context == null || context.isBlank()
+        ? ""
+        : " Additional context: " + context + ".";
+    return "Create a photorealistic image for the following context: " + input + "."
+        + contextSegment + " Avoid using text.";
+  }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
@@ -13,10 +13,10 @@ public class ImageService {
   private final OpenAIImageService openAIImageService;
   private final GoogleImageService googleImageService;
 
-  public byte[] generateImage(String input, ImageGenerationModel model) {
+  public byte[] generateImage(String input, String context, ImageGenerationModel model) {
     return switch (model) {
-      case GPT_IMAGE_1_5 -> openAIImageService.generateImage(input);
-      case GEMINI_3_PRO_IMAGE_PREVIEW -> googleImageService.generateImage(input);
+      case GPT_IMAGE_1_5 -> openAIImageService.generateImage(input, context);
+      case GEMINI_3_PRO_IMAGE_PREVIEW -> googleImageService.generateImage(input, context);
     };
   }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/OpenAIImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/OpenAIImageService.java
@@ -20,11 +20,11 @@ public class OpenAIImageService {
     private final OpenAIClient openAIClient;
     private final ModelUsageLoggingService usageLoggingService;
 
-    public byte[] generateImage(String prompt) {
+    public byte[] generateImage(String input, String context) {
         final long startTime = System.currentTimeMillis();
         try {
             final ImageGenerateParams imageGenerateParams = ImageGenerateParams.builder()
-                .prompt("Create a photorealistic image for the following context: " + prompt + ". Avoid using text.")
+                .prompt(ImagePromptBuilder.build(input, context))
                 .model(MODEL_NAME)
                 .size(ImageGenerateParams.Size._1024X1024)
                 .quality(ImageGenerateParams.Quality.HIGH)

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -355,6 +355,58 @@ test('favorite toggle on newly generated image', async ({ page }) => {
   });
 });
 
+test('add image with context dialog', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await setupDefaultImageModelSettings();
+  const image1 = uploadMockImage(blueImage);
+  await createCard({
+    cardId: 'abfahren-elindulni',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'abfahren',
+      type: 'VERB',
+      forms: ['fährt ab', 'fuhr ab', 'abgefahren'],
+      translation: {
+        en: 'to leave',
+        hu: 'elindulni, elhagyni',
+        ch: 'abfahra, verlah',
+      },
+      examples: [
+        {
+          de: 'Wir fahren um zwölf Uhr ab.',
+          hu: 'Tizenkét órakor indulunk.',
+          en: "We leave at twelve o'clock.",
+          ch: 'Mir fahred am zwöufi ab.',
+          images: [{ id: image1 }],
+          isSelected: true,
+        },
+      ],
+    },
+  });
+  await navigateToCardEditing(page);
+  await expect(page.getByRole('img')).toHaveCount(1);
+
+  // Open dialog and cancel -> no images added
+  await page.getByRole('button', { name: 'Add image with context' }).first().click();
+  await expect(page.getByRole('dialog', { name: 'Image generation context' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Generate' })).toBeDisabled();
+  await page.getByRole('button', { name: 'Cancel' }).click();
+  await expect(page.getByRole('dialog', { name: 'Image generation context' })).toBeHidden();
+  await expect(page.getByRole('img')).toHaveCount(1);
+
+  // Open dialog, enter context, generate -> 4 images added (1 OpenAI + 3 Gemini)
+  await page.getByRole('button', { name: 'Add image with context' }).first().click();
+  await expect(page.getByRole('button', { name: 'Generate' })).toBeDisabled();
+  await page
+    .getByRole('textbox', { name: 'Image generation context' })
+    .fill('A vintage steam train at sunset');
+  await expect(page.getByRole('button', { name: 'Generate' })).toBeEnabled();
+  await page.getByRole('button', { name: 'Generate' }).click();
+  await expect(page.getByRole('dialog', { name: 'Image generation context' })).toBeHidden();
+  await expect(page.getByRole('img')).toHaveCount(5);
+});
+
 test('word type editing', async ({ page }) => {
   await setupDefaultChatModelSettings();
   const image1 = uploadMockImage(yellowImage);


### PR DESCRIPTION
## Summary
This PR adds support for providing additional context when generating images, allowing users to refine image generation results with custom prompts.

## Key Changes
- **New Dialog Component**: Created `ImageContextDialogComponent` to collect optional context from users before image generation
- **Updated Image Generation Flow**: 
  - Modified `EditSpeechCardComponent` and `EditVocabularyCardComponent` to support both standard image generation (`addImage`) and context-aware generation (`addImageWithContext`)
  - Added new UI buttons with `edit_note` icon to trigger context-based image generation
- **Backend Prompt Building**: 
  - Introduced `ImagePromptBuilder` utility class to construct consistent image prompts with optional context
  - Updated `ImageService`, `OpenAIImageService`, and `GoogleImageService` to accept and use context parameter
- **API Updates**:
  - Extended `ImageSourceRequest` model to include optional `context` field
  - Updated `ImageController` to pass context through the generation pipeline
  - Updated TypeScript types to reflect the new optional context parameter

## Implementation Details
- Context is optional and only included in the prompt if provided and non-empty
- The dialog uses a textarea for multi-line context input with a 400px width
- Context is appended to the base prompt as "Additional context: {context}." when present
- Both OpenAI and Google image generation services now support context through the unified `ImagePromptBuilder`

https://claude.ai/code/session_01DjvrJHHbSSuEvrbvcos43j