### PR TITLE
Add language toggle for image generation prompts

### DIFF
--- a/client/src/app/cardTypes/speech-card-type.strategy.ts
+++ b/client/src/app/cardTypes/speech-card-type.strategy.ts
@@ -17,6 +17,7 @@ import { LANGUAGE_CODES } from '../shared/types/audio-generation.types';
 import { nonNullable } from '../utils/type-guards';
 import { ENVIRONMENT_CONFIG } from '../environment/environment.config';
 import { generateExampleImages } from '../utils/image-generation.util';
+import { ImageModelSettingsService } from '../image-model-settings/image-model-settings.service';
 import { RateLimitTokenService } from '../rate-limit-token.service';
 
 interface SentenceIdResponse {
@@ -37,6 +38,7 @@ export class SpeechCardType implements CardTypeStrategy {
   private readonly http = inject(HttpClient);
   private readonly multiModelService = inject(MultiModelService);
   private readonly environmentConfig = inject(ENVIRONMENT_CONFIG);
+  private readonly imageModelSettingsService = inject(ImageModelSettingsService);
   private readonly rateLimitTokenService = inject(RateLimitTokenService);
 
   async extractItems(request: ExtractionRequest): Promise<ExtractedItem[]> {
@@ -144,8 +146,10 @@ export class SpeechCardType implements CardTypeStrategy {
 
       progressCallback(60, 'Generating images...');
 
-      const imageInputs = englishResult.response.translation
-        ? [{ exampleIndex: 0, englishTranslation: englishResult.response.translation }]
+      const useEnglish = this.imageModelSettingsService.useEnglishForImageGeneration();
+      const imageInput = useEnglish ? englishResult.response.translation : sentence;
+      const imageInputs = imageInput
+        ? [{ exampleIndex: 0, input: imageInput }]
         : [];
 
       const imagesMap = await generateExampleImages(

--- a/client/src/app/cardTypes/vocabulary-card-type.strategy.ts
+++ b/client/src/app/cardTypes/vocabulary-card-type.strategy.ts
@@ -20,6 +20,7 @@ import { getWordTypeInfo } from '../shared/word-type-translations';
 import { getGenderInfo } from '../shared/gender-translations';
 import { ENVIRONMENT_CONFIG } from '../environment/environment.config';
 import { generateExampleImages } from '../utils/image-generation.util';
+import { ImageModelSettingsService } from '../image-model-settings/image-model-settings.service';
 import { RateLimitTokenService } from '../rate-limit-token.service';
 
 interface WordTypeResponse {
@@ -50,6 +51,7 @@ export class VocabularyCardType implements CardTypeStrategy {
   private readonly http = inject(HttpClient);
   private readonly multiModelService = inject(MultiModelService);
   private readonly environmentConfig = inject(ENVIRONMENT_CONFIG);
+  private readonly imageModelSettingsService = inject(ImageModelSettingsService);
   private readonly rateLimitTokenService = inject(RateLimitTokenService);
 
   async extractItems(request: ExtractionRequest): Promise<ExtractedItem[]> {
@@ -227,10 +229,13 @@ export class VocabularyCardType implements CardTypeStrategy {
 
       progressCallback(70, 'Generating images...');
 
+      const useEnglish = this.imageModelSettingsService.useEnglishForImageGeneration();
       const imageInputs = germanExamples
-        .map((_, exampleIndex) => {
-          const englishTranslation = exampleTranslations['en']?.[exampleIndex];
-          return englishTranslation ? { exampleIndex, englishTranslation } : null;
+        .map((germanExample, exampleIndex) => {
+          const input = useEnglish
+            ? exampleTranslations['en']?.[exampleIndex]
+            : germanExample;
+          return input ? { exampleIndex, input } : null;
         })
         .filter(nonNullable);
 

--- a/client/src/app/environment/environment.config.ts
+++ b/client/src/app/environment/environment.config.ts
@@ -65,6 +65,7 @@ export interface EnvironmentConfig {
   imageDailyLimit: number;
   audioDailyLimit: number;
   frontAudioDisabled: boolean;
+  useEnglishForImageGeneration: boolean;
   chatModels: ChatModelInfo[];
   imageModels: ImageModel[];
   audioModels: AudioModel[];

--- a/client/src/app/image-model-settings/image-model-settings.component.css
+++ b/client/src/app/image-model-settings/image-model-settings.component.css
@@ -71,3 +71,7 @@ mat-card-header {
 tbody tr:hover {
   background: var(--mat-sys-surface-container-low);
 }
+
+.image-source-toggle {
+  margin-bottom: 16px;
+}

--- a/client/src/app/image-model-settings/image-model-settings.component.html
+++ b/client/src/app/image-model-settings/image-model-settings.component.html
@@ -9,6 +9,15 @@
           <p>No image models available</p>
         </div>
       } @else {
+        <div class="image-source-toggle">
+          <mat-slide-toggle
+            [checked]="useEnglishForImageGeneration()"
+            (change)="toggleUseEnglishForImageGeneration()"
+            aria-label="Use English translation for image generation"
+          >
+            Use English translation for image generation
+          </mat-slide-toggle>
+        </div>
         <div class="models-list">
           <table class="models-table" aria-label="Image model settings">
             <thead>

--- a/client/src/app/image-model-settings/image-model-settings.component.ts
+++ b/client/src/app/image-model-settings/image-model-settings.component.ts
@@ -2,6 +2,7 @@ import { Component, effect, inject, signal, untracked } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { form, FormField, required, min } from '@angular/forms/signals';
 import { ImageModelSettingsService } from './image-model-settings.service';
 
@@ -12,6 +13,7 @@ import { ImageModelSettingsService } from './image-model-settings.service';
     MatCardModule,
     MatFormFieldModule,
     MatInputModule,
+    MatSlideToggleModule,
     FormField,
   ],
   templateUrl: './image-model-settings.component.html',
@@ -21,6 +23,7 @@ export class ImageModelSettingsComponent {
   private readonly service = inject(ImageModelSettingsService);
 
   readonly imageModels = this.service.imageModels;
+  readonly useEnglishForImageGeneration = this.service.useEnglishForImageGeneration;
 
   readonly rateLimitModel = signal({
     rateLimitPerMinute: this.service.imageRateLimitPerMinute(),
@@ -67,5 +70,11 @@ export class ImageModelSettingsComponent {
     if (!isNaN(value) && value >= 0) {
       this.service.updateImageCount(modelId, value);
     }
+  }
+
+  toggleUseEnglishForImageGeneration(): void {
+    this.service.updateUseEnglishForImageGeneration(
+      !this.useEnglishForImageGeneration()
+    );
   }
 }

--- a/client/src/app/image-model-settings/image-model-settings.service.ts
+++ b/client/src/app/image-model-settings/image-model-settings.service.ts
@@ -21,6 +21,9 @@ export class ImageModelSettingsService {
   readonly imageRateLimitPerMinute = signal(this.environmentConfig.imageRateLimitPerMinute);
   readonly imageMaxConcurrentRequests = signal(this.environmentConfig.imageMaxConcurrentRequests);
   readonly imageDailyLimit = signal(this.environmentConfig.imageDailyLimit);
+  readonly useEnglishForImageGeneration = signal(
+    this.environmentConfig.useEnglishForImageGeneration
+  );
 
   updateImageCount(modelId: string, imageCount: number): void {
     this.imageModels.update((models) =>
@@ -60,6 +63,15 @@ export class ImageModelSettingsService {
     fetchJson(this.http, '/api/rate-limit-settings', {
       method: 'PUT',
       body: { type: 'image', dailyLimit: value },
+    });
+  }
+
+  updateUseEnglishForImageGeneration(useEnglish: boolean): void {
+    this.useEnglishForImageGeneration.set(useEnglish);
+
+    fetchJson(this.http, '/api/image-model-settings/use-english', {
+      method: 'PUT',
+      body: { useEnglish },
     });
   }
 }

--- a/client/src/app/image-model-settings/image-model-settings.service.ts
+++ b/client/src/app/image-model-settings/image-model-settings.service.ts
@@ -69,7 +69,7 @@ export class ImageModelSettingsService {
   updateUseEnglishForImageGeneration(useEnglish: boolean): void {
     this.useEnglishForImageGeneration.set(useEnglish);
 
-    fetchJson(this.http, '/api/image-model-settings/use-english', {
+    fetchJson(this.http, '/api/image-settings/use-english', {
       method: 'PUT',
       body: { useEnglish },
     });

--- a/client/src/app/parser/edit-card/edit-speech-card/edit-speech-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-speech-card/edit-speech-card.component.ts
@@ -22,6 +22,7 @@ import {
 } from '../../../shared/image-grid/image-grid.component';
 import { ImageResourceService } from '../../../shared/image-resource.service';
 import { ImageContextDialogComponent } from '../../../shared/image-context-dialog/image-context-dialog.component';
+import { ImageModelSettingsService } from '../../../image-model-settings/image-model-settings.service';
 import { DailyUsageService } from '../../../daily-usage.service';
 import { dialogResult } from '../../../utils/dialog-result';
 
@@ -50,6 +51,7 @@ export class EditSpeechCardComponent {
   markAsReviewedAvailable = output<boolean>();
 
   private readonly imageResourceService = inject(ImageResourceService);
+  private readonly imageModelSettingsService = inject(ImageModelSettingsService);
   private readonly dialog = inject(MatDialog);
   readonly dailyUsageService = inject(DailyUsageService);
 
@@ -105,11 +107,13 @@ export class EditSpeechCardComponent {
   }
 
   async addImage(context?: string) {
-    const englishTranslation = this.formModel().englishTranslation;
-    if (!englishTranslation) return;
+    const { sentence, englishTranslation } = this.formModel();
+    const useEnglish = this.imageModelSettingsService.useEnglishForImageGeneration();
+    const input = useEnglish ? englishTranslation : sentence;
+    if (!input) return;
 
     const { placeholders, done } =
-      this.imageResourceService.generateImages(englishTranslation, context);
+      this.imageResourceService.generateImages(input, context);
 
     this.images.update((imgs) => [...imgs, ...placeholders]);
 

--- a/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.ts
@@ -28,6 +28,7 @@ import {
 } from '../../../shared/image-grid/image-grid.component';
 import { ImageResourceService } from '../../../shared/image-resource.service';
 import { ImageContextDialogComponent } from '../../../shared/image-context-dialog/image-context-dialog.component';
+import { ImageModelSettingsService } from '../../../image-model-settings/image-model-settings.service';
 import { DailyUsageService } from '../../../daily-usage.service';
 import { dialogResult } from '../../../utils/dialog-result';
 
@@ -58,6 +59,7 @@ export class EditVocabularyCardComponent {
   markAsReviewedAvailable = output<boolean>();
 
   private readonly imageResourceService = inject(ImageResourceService);
+  private readonly imageModelSettingsService = inject(ImageModelSettingsService);
   private readonly dialog = inject(MatDialog);
   readonly dailyUsageService = inject(DailyUsageService);
   readonly wordTypeOptions = WORD_TYPE_TRANSLATIONS;
@@ -159,11 +161,14 @@ export class EditVocabularyCardComponent {
   }
 
   async addImage(exampleIdx: number, context?: string) {
-    const englishTranslation = this.examplesTranslations()?.['en'][exampleIdx]();
-    if (!englishTranslation) return;
+    const useEnglish = this.imageModelSettingsService.useEnglishForImageGeneration();
+    const input = useEnglish
+      ? this.examplesTranslations()?.['en'][exampleIdx]()
+      : this.examples()?.[exampleIdx]();
+    if (!input) return;
 
     const { placeholders, done } =
-      this.imageResourceService.generateImages(englishTranslation, context);
+      this.imageResourceService.generateImages(input, context);
 
     this.exampleImages.update((images) => {
       images[exampleIdx] = [...images[exampleIdx], ...placeholders];

--- a/client/src/app/shared/image-resource.service.ts
+++ b/client/src/app/shared/image-resource.service.ts
@@ -32,7 +32,7 @@ export class ImageResourceService {
   }
 
   generateImages(
-    englishTranslation: string,
+    input: string,
     context?: string
   ): {
     placeholders: GridImageResource[];
@@ -62,7 +62,7 @@ export class ImageResourceService {
                 `/api/image`,
                 {
                   body: {
-                    input: englishTranslation,
+                    input,
                     model: model.id,
                     ...(context ? { context } : {}),
                   } satisfies ImageSourceRequest,

--- a/client/src/app/utils/image-generation.util.ts
+++ b/client/src/app/utils/image-generation.util.ts
@@ -6,7 +6,7 @@ import { ToolPool } from './tool-pool';
 
 export type ImageGenerationInput = {
   exampleIndex: number;
-  englishTranslation: string;
+  input: string;
 };
 
 export type ImagesByIndex = Map<number, ExampleImage[]>;
@@ -45,7 +45,7 @@ export const generateExampleImages = async (
           '/api/image',
           {
             body: {
-              input: input.englishTranslation,
+              input: input.input,
               model: model.id,
             } satisfies ImageSourceRequest,
             method: 'POST',

--- a/mock_google_ai_server/src/imageGeneration.ts
+++ b/mock_google_ai_server/src/imageGeneration.ts
@@ -14,12 +14,12 @@ type ImageModelConfig = {
 
 const IMAGE_MODELS: ImageModelConfig[] = [
   {
-    pattern: "We are departing at twelve o'clock.",
+    pattern: 'Wir fahren um zwölf Uhr ab.',
     firstImage: IMAGES.yellow,
     secondImage: IMAGES.blue,
   },
   {
-    pattern: 'When does the train leave?',
+    pattern: 'Wann fährt der Zug ab?',
     firstImage: IMAGES.red,
     secondImage: IMAGES.green,
   },

--- a/mock_openai_server/src/imageGeneration.ts
+++ b/mock_openai_server/src/imageGeneration.ts
@@ -16,12 +16,12 @@ type PromptConfig = {
 
 const PROMPT_CONFIGS: PromptConfig[] = [
   {
-    pattern: "We are departing at twelve o'clock.",
+    pattern: 'Wir fahren um zwölf Uhr ab.',
     firstImage: IMAGES.yellow,
     secondImage: IMAGES.blue,
   },
   {
-    pattern: 'When does the train leave?',
+    pattern: 'Wann fährt der Zug ab?',
     firstImage: IMAGES.red,
     secondImage: IMAGES.green,
   },

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/EnvironmentController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/EnvironmentController.java
@@ -21,6 +21,7 @@ import io.github.mucsi96.learnlanguage.service.AudioSettingService;
 import io.github.mucsi96.learnlanguage.service.ChatModelSettingService;
 import io.github.mucsi96.learnlanguage.service.ElevenLabsAudioService;
 import io.github.mucsi96.learnlanguage.service.ImageModelSettingService;
+import io.github.mucsi96.learnlanguage.service.ImageSettingService;
 import io.github.mucsi96.learnlanguage.service.RateLimitSettingService;
 import lombok.RequiredArgsConstructor;
 
@@ -31,6 +32,7 @@ public class EnvironmentController {
   private final ElevenLabsAudioService elevenLabsAudioService;
   private final ChatModelSettingService chatModelSettingService;
   private final ImageModelSettingService imageModelSettingService;
+  private final ImageSettingService imageSettingService;
   private final RateLimitSettingService rateLimitSettingService;
   private final AudioSettingService audioSettingService;
 
@@ -93,6 +95,7 @@ public class EnvironmentController {
         rateLimitSettingService.getImageDailyLimit(),
         rateLimitSettingService.getAudioDailyLimit(),
         audioSettingService.isFrontAudioDisabled(),
+        imageSettingService.isUseEnglishForImageGeneration(),
         Arrays.stream(ChatModel.values())
             .map(model -> new ChatModelInfo(model.getModelName(), model.getProvider().getCode()))
             .toList(),
@@ -140,6 +143,7 @@ public class EnvironmentController {
       int imageDailyLimit,
       int audioDailyLimit,
       boolean frontAudioDisabled,
+      boolean useEnglishForImageGeneration,
       List<ChatModelInfo> chatModels,
       List<ImageModelResponse> imageModels,
       List<AudioModelResponse> audioModels,

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ImageModelSettingController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ImageModelSettingController.java
@@ -42,7 +42,7 @@ public class ImageModelSettingController {
     @PutMapping("/use-english")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
-    public void updateUseEnglishForImageGeneration(@RequestBody UseEnglishForImageGenerationRequest request) {
+    public void updateUseEnglishForImageGeneration(@Valid @RequestBody UseEnglishForImageGenerationRequest request) {
         imageSettingService.setUseEnglishForImageGeneration(request.isUseEnglish());
     }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ImageModelSettingController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ImageModelSettingController.java
@@ -2,16 +2,20 @@ package io.github.mucsi96.learnlanguage.controller;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.github.mucsi96.learnlanguage.model.ImageModelResponse;
 import io.github.mucsi96.learnlanguage.model.ImageModelSettingRequest;
+import io.github.mucsi96.learnlanguage.model.UseEnglishForImageGenerationRequest;
 import io.github.mucsi96.learnlanguage.service.ImageModelSettingService;
+import io.github.mucsi96.learnlanguage.service.ImageSettingService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -21,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 public class ImageModelSettingController {
 
     private final ImageModelSettingService imageModelSettingService;
+    private final ImageSettingService imageSettingService;
 
     @GetMapping
     @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
@@ -32,5 +37,12 @@ public class ImageModelSettingController {
     @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
     public ImageModelResponse updateSetting(@Valid @RequestBody ImageModelSettingRequest request) {
         return imageModelSettingService.updateSetting(request);
+    }
+
+    @PutMapping("/use-english")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
+    public void updateUseEnglishForImageGeneration(@RequestBody UseEnglishForImageGenerationRequest request) {
+        imageSettingService.setUseEnglishForImageGeneration(request.isUseEnglish());
     }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ImageModelSettingController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ImageModelSettingController.java
@@ -2,20 +2,16 @@ package io.github.mucsi96.learnlanguage.controller;
 
 import java.util.List;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.github.mucsi96.learnlanguage.model.ImageModelResponse;
 import io.github.mucsi96.learnlanguage.model.ImageModelSettingRequest;
-import io.github.mucsi96.learnlanguage.model.UseEnglishForImageGenerationRequest;
 import io.github.mucsi96.learnlanguage.service.ImageModelSettingService;
-import io.github.mucsi96.learnlanguage.service.ImageSettingService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -25,7 +21,6 @@ import lombok.RequiredArgsConstructor;
 public class ImageModelSettingController {
 
     private final ImageModelSettingService imageModelSettingService;
-    private final ImageSettingService imageSettingService;
 
     @GetMapping
     @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
@@ -37,12 +32,5 @@ public class ImageModelSettingController {
     @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
     public ImageModelResponse updateSetting(@Valid @RequestBody ImageModelSettingRequest request) {
         return imageModelSettingService.updateSetting(request);
-    }
-
-    @PutMapping("/use-english")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
-    public void updateUseEnglishForImageGeneration(@Valid @RequestBody UseEnglishForImageGenerationRequest request) {
-        imageSettingService.setUseEnglishForImageGeneration(request.isUseEnglish());
     }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ImageSettingController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ImageSettingController.java
@@ -1,0 +1,30 @@
+package io.github.mucsi96.learnlanguage.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.github.mucsi96.learnlanguage.model.UseEnglishForImageGenerationRequest;
+import io.github.mucsi96.learnlanguage.service.ImageSettingService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/image-settings")
+@RequiredArgsConstructor
+public class ImageSettingController {
+
+    private final ImageSettingService imageSettingService;
+
+    @PutMapping("/use-english")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
+    public void updateUseEnglishForImageGeneration(
+            @Valid @RequestBody UseEnglishForImageGenerationRequest request) {
+        imageSettingService.setUseEnglishForImageGeneration(request.isUseEnglish());
+    }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/entity/ImageSetting.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/entity/ImageSetting.java
@@ -15,16 +15,16 @@ import lombok.Setter;
 @Table(name = "image_settings", schema = "learn_language")
 @Getter
 @Setter
-@EqualsAndHashCode(of = "key")
+@EqualsAndHashCode(of = "id")
 @Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 public class ImageSetting {
 
     @Id
-    @Column(name = "key", nullable = false)
-    private String key;
+    @Column(name = "id", nullable = false)
+    private Integer id;
 
-    @Column(name = "value", nullable = false)
-    private Integer value;
+    @Column(name = "use_english_for_image_generation", nullable = false)
+    private Boolean useEnglishForImageGeneration;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/entity/ImageSetting.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/entity/ImageSetting.java
@@ -1,0 +1,30 @@
+package io.github.mucsi96.learnlanguage.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "image_settings", schema = "learn_language")
+@Getter
+@Setter
+@EqualsAndHashCode(of = "key")
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageSetting {
+
+    @Id
+    @Column(name = "key", nullable = false)
+    private String key;
+
+    @Column(name = "value", nullable = false)
+    private Integer value;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/entity/ImageSetting.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/entity/ImageSetting.java
@@ -26,5 +26,5 @@ public class ImageSetting {
     private Integer id;
 
     @Column(name = "use_english_for_image_generation", nullable = false)
-    private Boolean useEnglishForImageGeneration;
+    private boolean useEnglishForImageGeneration;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/UseEnglishForImageGenerationRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/UseEnglishForImageGenerationRequest.java
@@ -1,0 +1,14 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UseEnglishForImageGenerationRequest {
+    private boolean useEnglish;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/ImageSettingRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/ImageSettingRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ImageSettingRepository extends JpaRepository<ImageSetting, String> {
+public interface ImageSettingRepository extends JpaRepository<ImageSetting, Integer> {
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/ImageSettingRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/ImageSettingRepository.java
@@ -1,0 +1,9 @@
+package io.github.mucsi96.learnlanguage.repository;
+
+import io.github.mucsi96.learnlanguage.entity.ImageSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ImageSettingRepository extends JpaRepository<ImageSetting, String> {
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageSettingService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageSettingService.java
@@ -17,7 +17,7 @@ public class ImageSettingService {
 
     public boolean isUseEnglishForImageGeneration() {
         return imageSettingRepository.findById(SINGLETON_ID)
-                .map(ImageSetting::getUseEnglishForImageGeneration)
+                .map(ImageSetting::isUseEnglishForImageGeneration)
                 .orElse(false);
     }
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageSettingService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageSettingService.java
@@ -1,0 +1,31 @@
+package io.github.mucsi96.learnlanguage.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.github.mucsi96.learnlanguage.entity.ImageSetting;
+import io.github.mucsi96.learnlanguage.repository.ImageSettingRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ImageSettingService {
+
+    private static final String USE_ENGLISH_KEY = "use-english-for-image-generation";
+
+    private final ImageSettingRepository imageSettingRepository;
+
+    public boolean isUseEnglishForImageGeneration() {
+        return imageSettingRepository.findById(USE_ENGLISH_KEY)
+                .map(ImageSetting::getValue)
+                .map(value -> value != 0)
+                .orElse(false);
+    }
+
+    @Transactional
+    public void setUseEnglishForImageGeneration(boolean useEnglish) {
+        imageSettingRepository.save(
+                ImageSetting.builder().key(USE_ENGLISH_KEY).value(useEnglish ? 1 : 0).build()
+        );
+    }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageSettingService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageSettingService.java
@@ -11,21 +11,23 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ImageSettingService {
 
-    private static final String USE_ENGLISH_KEY = "use-english-for-image-generation";
+    private static final int SINGLETON_ID = 1;
 
     private final ImageSettingRepository imageSettingRepository;
 
     public boolean isUseEnglishForImageGeneration() {
-        return imageSettingRepository.findById(USE_ENGLISH_KEY)
-                .map(ImageSetting::getValue)
-                .map(value -> value != 0)
+        return imageSettingRepository.findById(SINGLETON_ID)
+                .map(ImageSetting::getUseEnglishForImageGeneration)
                 .orElse(false);
     }
 
     @Transactional
     public void setUseEnglishForImageGeneration(boolean useEnglish) {
         imageSettingRepository.save(
-                ImageSetting.builder().key(USE_ENGLISH_KEY).value(useEnglish ? 1 : 0).build()
+                ImageSetting.builder()
+                        .id(SINGLETON_ID)
+                        .useEnglishForImageGeneration(useEnglish)
+                        .build()
         );
     }
 }

--- a/server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -846,24 +846,6 @@ databaseChangeLog:
                     unique: true
                     uniqueConstraintName: grammar_topics_name_unique
   - changeSet:
-      id: 27-create-image-settings-table
-      author: mucsi96
-      changes:
-        - createTable:
-            tableName: image_settings
-            columns:
-              - column:
-                  name: key
-                  type: varchar(255)
-                  constraints:
-                    primaryKey: true
-                    primaryKeyName: image_settings_pkey
-              - column:
-                  name: value
-                  type: int
-                  constraints:
-                    nullable: false
-  - changeSet:
       id: 26-create-pending-photos-table
       author: mucsi96
       changes:
@@ -919,3 +901,22 @@ databaseChangeLog:
             columns:
               - column:
                   name: expires_at
+  - changeSet:
+      id: 27-create-image-settings-table
+      author: mucsi96
+      changes:
+        - createTable:
+            tableName: image_settings
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  constraints:
+                    primaryKey: true
+                    primaryKeyName: image_settings_pkey
+              - column:
+                  name: use_english_for_image_generation
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false

--- a/server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -846,6 +846,24 @@ databaseChangeLog:
                     unique: true
                     uniqueConstraintName: grammar_topics_name_unique
   - changeSet:
+      id: 27-create-image-settings-table
+      author: mucsi96
+      changes:
+        - createTable:
+            tableName: image_settings
+            columns:
+              - column:
+                  name: key
+                  type: varchar(255)
+                  constraints:
+                    primaryKey: true
+                    primaryKeyName: image_settings_pkey
+              - column:
+                  name: value
+                  type: int
+                  constraints:
+                    nullable: false
+  - changeSet:
       id: 26-create-pending-photos-table
       author: mucsi96
       changes:

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../fixtures';
 import {
   createCard,
+  createImageSetting,
   downloadImage,
   getCardFromDb,
   getImageColor,
@@ -405,6 +406,87 @@ test('add image with context dialog', async ({ page }) => {
   await page.getByRole('button', { name: 'Generate' }).click();
   await expect(page.getByRole('dialog', { name: 'Image generation context' })).toBeHidden();
   await expect(page.getByRole('img')).toHaveCount(5);
+});
+
+test('image generation sends German example by default', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await setupDefaultImageModelSettings();
+  const image1 = uploadMockImage(blueImage);
+  await createCard({
+    cardId: 'abfahren-elindulni',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'abfahren',
+      type: 'VERB',
+      forms: ['fährt ab', 'fuhr ab', 'abgefahren'],
+      translation: {
+        en: 'to leave',
+        hu: 'elindulni, elhagyni',
+        ch: 'abfahra, verlah',
+      },
+      examples: [
+        {
+          de: 'Wann fährt der Zug ab?',
+          hu: 'Mikor indul a vonat?',
+          en: 'When does the train leave?',
+          ch: 'Wänn fahrt dr',
+          images: [{ id: image1 }],
+          isSelected: true,
+        },
+      ],
+    },
+  });
+  await navigateToCardEditing(page);
+
+  const requestPromise = page.waitForRequest(
+    (req) => req.url().includes('/api/image') && req.method() === 'POST'
+  );
+  await page.getByRole('button', { name: 'Add example image' }).first().click();
+  const request = await requestPromise;
+
+  expect(request.postDataJSON().input).toBe('Wann fährt der Zug ab?');
+});
+
+test('image generation sends English translation when setting is enabled', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await setupDefaultImageModelSettings();
+  await createImageSetting({ useEnglishForImageGeneration: true });
+  const image1 = uploadMockImage(blueImage);
+  await createCard({
+    cardId: 'abfahren-elindulni',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'abfahren',
+      type: 'VERB',
+      forms: ['fährt ab', 'fuhr ab', 'abgefahren'],
+      translation: {
+        en: 'to leave',
+        hu: 'elindulni, elhagyni',
+        ch: 'abfahra, verlah',
+      },
+      examples: [
+        {
+          de: 'Wann fährt der Zug ab?',
+          hu: 'Mikor indul a vonat?',
+          en: 'When does the train leave?',
+          ch: 'Wänn fahrt dr',
+          images: [{ id: image1 }],
+          isSelected: true,
+        },
+      ],
+    },
+  });
+  await navigateToCardEditing(page);
+
+  const requestPromise = page.waitForRequest(
+    (req) => req.url().includes('/api/image') && req.method() === 'POST'
+  );
+  await page.getByRole('button', { name: 'Add example image' }).first().click();
+  const request = await requestPromise;
+
+  expect(request.postDataJSON().input).toBe('When does the train leave?');
 });
 
 test('word type editing', async ({ page }) => {

--- a/test/tests/image-model-settings.spec.ts
+++ b/test/tests/image-model-settings.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '../fixtures';
-import { createImageModelSetting, getImageModelSettings } from '../utils';
+import {
+  createImageModelSetting,
+  createImageSetting,
+  getImageModelSettings,
+  getImageSettings,
+} from '../utils';
 
 test('navigates to image model settings from settings page', async ({ page }) => {
   await page.goto('/settings');
@@ -55,4 +60,53 @@ test('settings page shows image models link in navigation', async ({ page }) => 
   await page.goto('/settings');
   await expect(page.getByRole('navigation', { name: 'Settings navigation' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Image Models' })).toBeVisible();
+});
+
+test('image generation language toggle defaults to German', async ({ page }) => {
+  await createImageModelSetting({ modelName: 'gemini-3-pro-image-preview', imageCount: 1 });
+  await page.goto('/settings/image-models');
+
+  const toggle = page.getByRole('switch', {
+    name: 'Use English translation for image generation',
+  });
+  await expect(toggle).toBeVisible();
+  await expect(toggle).not.toBeChecked();
+});
+
+test('image generation language toggle reflects stored setting', async ({ page }) => {
+  await createImageModelSetting({ modelName: 'gemini-3-pro-image-preview', imageCount: 1 });
+  await createImageSetting({ key: 'use-english-for-image-generation', value: 1 });
+
+  await page.goto('/settings/image-models');
+
+  const toggle = page.getByRole('switch', {
+    name: 'Use English translation for image generation',
+  });
+  await expect(toggle).toBeChecked();
+});
+
+test('toggling image generation language persists the setting', async ({ page }) => {
+  await createImageModelSetting({ modelName: 'gemini-3-pro-image-preview', imageCount: 1 });
+  await page.goto('/settings/image-models');
+
+  const toggle = page.getByRole('switch', {
+    name: 'Use English translation for image generation',
+  });
+  await toggle.click();
+
+  await expect(async () => {
+    const settings = await getImageSettings();
+    const setting = settings.find((s) => s.key === 'use-english-for-image-generation');
+    expect(setting).toBeDefined();
+    expect(setting!.value).toBe(1);
+  }).toPass();
+
+  await toggle.click();
+
+  await expect(async () => {
+    const settings = await getImageSettings();
+    const setting = settings.find((s) => s.key === 'use-english-for-image-generation');
+    expect(setting).toBeDefined();
+    expect(setting!.value).toBe(0);
+  }).toPass();
 });

--- a/test/tests/image-model-settings.spec.ts
+++ b/test/tests/image-model-settings.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from '../fixtures';
 import {
   createImageModelSetting,
-  createImageSetting,
   getImageModelSettings,
   getImageSettings,
+  setUseEnglishForImageGeneration,
 } from '../utils';
 
 test('navigates to image model settings from settings page', async ({ page }) => {
@@ -75,7 +75,7 @@ test('image generation language toggle defaults to German', async ({ page }) => 
 
 test('image generation language toggle reflects stored setting', async ({ page }) => {
   await createImageModelSetting({ modelName: 'gemini-3-pro-image-preview', imageCount: 1 });
-  await createImageSetting({ key: 'use-english-for-image-generation', value: 1 });
+  await setUseEnglishForImageGeneration(true);
 
   await page.goto('/settings/image-models');
 
@@ -96,17 +96,15 @@ test('toggling image generation language persists the setting', async ({ page })
 
   await expect(async () => {
     const settings = await getImageSettings();
-    const setting = settings.find((s) => s.key === 'use-english-for-image-generation');
-    expect(setting).toBeDefined();
-    expect(setting!.value).toBe(1);
+    expect(settings).toHaveLength(1);
+    expect(settings[0].useEnglishForImageGeneration).toBe(true);
   }).toPass();
 
   await toggle.click();
 
   await expect(async () => {
     const settings = await getImageSettings();
-    const setting = settings.find((s) => s.key === 'use-english-for-image-generation');
-    expect(setting).toBeDefined();
-    expect(setting!.value).toBe(0);
+    expect(settings).toHaveLength(1);
+    expect(settings[0].useEnglishForImageGeneration).toBe(false);
   }).toPass();
 });

--- a/test/tests/image-model-settings.spec.ts
+++ b/test/tests/image-model-settings.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from '../fixtures';
 import {
   createImageModelSetting,
+  createImageSetting,
   getImageModelSettings,
   getImageSettings,
-  setUseEnglishForImageGeneration,
 } from '../utils';
 
 test('navigates to image model settings from settings page', async ({ page }) => {
@@ -75,7 +75,7 @@ test('image generation language toggle defaults to German', async ({ page }) => 
 
 test('image generation language toggle reflects stored setting', async ({ page }) => {
   await createImageModelSetting({ modelName: 'gemini-3-pro-image-preview', imageCount: 1 });
-  await setUseEnglishForImageGeneration(true);
+  await createImageSetting({ useEnglishForImageGeneration: true });
 
   await page.goto('/settings/image-models');
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -942,6 +942,36 @@ export async function createAudioSetting(params: {
   });
 }
 
+export async function createImageSetting(params: {
+  key: string;
+  value: number;
+}): Promise<void> {
+  const { key, value } = params;
+
+  await withDbConnection(async (client) => {
+    await client.query(
+      `INSERT INTO learn_language.image_settings (key, value)
+       VALUES ($1, $2)
+       ON CONFLICT (key) DO UPDATE SET value = $2`,
+      [key, value]
+    );
+  });
+}
+
+export async function getImageSettings(): Promise<
+  Array<{
+    key: string;
+    value: number;
+  }>
+> {
+  return await withDbConnection(async (client) => {
+    const result = await client.query(
+      `SELECT key, value FROM learn_language.image_settings ORDER BY key`
+    );
+    return result.rows;
+  });
+}
+
 export async function setupTestRateLimits(audioLimit: number = 100, imageLimit: number = 100): Promise<void> {
   await createRateLimitSetting({ key: 'audio-per-minute', value: audioLimit });
   await createRateLimitSetting({ key: 'image-per-minute', value: imageLimit });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -942,31 +942,27 @@ export async function createAudioSetting(params: {
   });
 }
 
-export async function createImageSetting(params: {
-  key: string;
-  value: number;
-}): Promise<void> {
-  const { key, value } = params;
-
+export async function setUseEnglishForImageGeneration(useEnglish: boolean): Promise<void> {
   await withDbConnection(async (client) => {
     await client.query(
-      `INSERT INTO learn_language.image_settings (key, value)
-       VALUES ($1, $2)
-       ON CONFLICT (key) DO UPDATE SET value = $2`,
-      [key, value]
+      `INSERT INTO learn_language.image_settings (id, use_english_for_image_generation)
+       VALUES (1, $1)
+       ON CONFLICT (id) DO UPDATE SET use_english_for_image_generation = $1`,
+      [useEnglish]
     );
   });
 }
 
 export async function getImageSettings(): Promise<
   Array<{
-    key: string;
-    value: number;
+    id: number;
+    useEnglishForImageGeneration: boolean;
   }>
 > {
   return await withDbConnection(async (client) => {
     const result = await client.query(
-      `SELECT key, value FROM learn_language.image_settings ORDER BY key`
+      `SELECT id, use_english_for_image_generation as "useEnglishForImageGeneration"
+       FROM learn_language.image_settings ORDER BY id`
     );
     return result.rows;
   });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -942,13 +942,17 @@ export async function createAudioSetting(params: {
   });
 }
 
-export async function setUseEnglishForImageGeneration(useEnglish: boolean): Promise<void> {
+export async function createImageSetting(params: {
+  useEnglishForImageGeneration: boolean;
+}): Promise<void> {
+  const { useEnglishForImageGeneration } = params;
+
   await withDbConnection(async (client) => {
     await client.query(
       `INSERT INTO learn_language.image_settings (id, use_english_for_image_generation)
        VALUES (1, $1)
        ON CONFLICT (id) DO UPDATE SET use_english_for_image_generation = $1`,
-      [useEnglish]
+      [useEnglishForImageGeneration]
     );
   });
 }


### PR DESCRIPTION
## Summary
Add a user-configurable toggle to allow image generation to use either the original language or English translations for prompts. This gives users flexibility in controlling what language is used when generating images for vocabulary and speech cards.

## Key Changes

**Backend:**
- Created new `ImageSetting` entity and `ImageSettingRepository` to persist image-related settings
- Added `ImageSettingService` to manage the `use-english-for-image-generation` setting
- Added `UseEnglishForImageGenerationRequest` model for API requests
- Extended `ImageModelSettingController` with new `/use-english` PUT endpoint to update the setting
- Added database migration to create `image_settings` table
- Updated `EnvironmentController` to expose the setting in environment configuration

**Frontend:**
- Added `useEnglishForImageGeneration` signal to `ImageModelSettingsService` with update method
- Created toggle UI in `ImageModelSettingsComponent` using Material slide toggle
- Updated `EditVocabularyCardComponent` to use the toggle setting when generating images (uses English translation when enabled, original language when disabled)
- Updated `EditSpeechCardComponent` similarly to respect the language preference
- Updated `ImageResourceService` to accept generic input parameter instead of hardcoded English translation
- Added styling for the toggle control

**Tests:**
- Added three new test cases covering:
  - Default toggle state (unchecked/German)
  - Toggle reflecting stored setting
  - Toggle persistence when toggled on/off
- Added test utilities `createImageSetting()` and `getImageSettings()` for database operations

## Implementation Details
- The setting defaults to German (toggle unchecked) when not explicitly set
- The toggle is displayed at the top of the image model settings page
- Changes persist immediately to the database via the API
- Both vocabulary and speech card editors respect the user's language preference when generating images

https://claude.ai/code/session_011Uy3oMkYoC4BVvgsFESiSL