### PR TITLE
Enhance photo grammar hints for ambiguous inflected forms

### DIFF
--- a/mock_google_ai_server/src/data.ts
+++ b/mock_google_ai_server/src/data.ts
@@ -332,6 +332,7 @@ export const SENTENCE_TRANSLATIONS: Record<string, Record<string, string>> = {
     'Und [das] ist Frau Wachter.': 'És ez Wachter asszony.',
     'Heute [bin] ich müde.': 'Ma fáradt vagyok.',
     '[Der] Mann gibt [dem] Kind das Buch.': 'A férfi a gyereknek adja a könyvet.',
+    'Im Sommer [machte] sie oft Sport im Park.': 'Nyáron gyakran sportolt a parkban.',
     'Der Hund läuft schnell durch den [Park].': 'A kutya gyorsan átfut a parkon.',
   },
   english: {

--- a/mock_google_ai_server/src/data.ts
+++ b/mock_google_ai_server/src/data.ts
@@ -270,6 +270,7 @@ export type PhotoGrammarSentence = {
 export const PHOTO_GRAMMAR_CONCEPT_SENTENCES: PhotoGrammarSentence[] = [
   { sentence: 'Heute [bin] ich müde.', hint: 'sein' },
   { sentence: '[Der] Mann gibt [dem] Kind das Buch.', hint: 'der / der' },
+  { sentence: 'Im Sommer [machte] sie oft Sport im Park.', hint: 'machen (3. Person Singular)' },
   { sentence: 'Der Hund läuft schnell durch den [Park].' },
 ];
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/PhotoGrammarConceptService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/PhotoGrammarConceptService.java
@@ -42,7 +42,9 @@ public class PhotoGrammarConceptService {
         - Sentences must be appropriate for %s level learners.
         - Skip any handwritten text on the photo.
         - After producing each sentence, judge whether ANY blank is ambiguous - i.e. multiple valid German words or forms could plausibly fit the blank purely from the surrounding context (without seeing the textbook lesson).
+        - Also judge a second kind of ambiguity: even after the base hint (e.g. the infinitive) is known, the required INFLECTED form may still be ambiguous because a grammatical feature (person, number, gender, case or tense) is not uniquely fixed by the sentence. The most common trigger is an ambiguous subject pronoun: "sie" can be 3rd person singular ("she") or 3rd person plural ("they"), and "Sie" is the formal "you" - so several conjugations fit the same blank (e.g. "machte" vs. "machten"). Treat such a blank as ambiguous.
         - If at least one blank is ambiguous, include a "hint" field. The hint is a single German string covering ALL blanks in the sentence. When more than one blank needs disambiguation, separate the per-blank hints with " / " in the same order the blanks appear. Examples: verb conjugation blank -> infinitive (e.g. "gehen"); noun gender/case blank -> nominative with article (e.g. "der Tag"); adjective ending blank -> base adjective; combined article + verb blanks -> "der / gehen".
+        - When the inflected form stays ambiguous after the base hint (e.g. the ambiguous subject "sie"/"Sie" above), ENHANCE the hint so it pins down the exact form: append the distinguishing grammatical feature in German, in parentheses, after the base hint. Example: verb conjugation with an ambiguous subject -> "machen (3. Person Singular)".
         - The "hint" MUST always be in German. Never English, Hungarian or Swiss German.
         - If no blank is ambiguous, OMIT the "hint" field entirely. Do not emit it as null or an empty string.
         - !IMPORTANT! Respond ONLY with JSON in the form {"sentences": [...]} matching the example below.
@@ -51,6 +53,7 @@ public class PhotoGrammarConceptService {
     final ConceptSentences example = new ConceptSentences(List.of(
         new ConceptSentence("Heute [bin] ich müde.", "sein"),
         new ConceptSentence("[Der] Mann gibt [dem] Kind das Buch.", "der / der"),
+        new ConceptSentence("Im Sommer [machte] sie oft Sport im Park.", "machen (3. Person Singular)"),
         new ConceptSentence("Der Hund läuft schnell durch den [Park].", null)));
 
     final String exampleJson = jsonMapper.writeValueAsString(example);

--- a/test/tests/photo-grammar.spec.ts
+++ b/test/tests/photo-grammar.spec.ts
@@ -104,7 +104,7 @@ test('pending photo banner consumes photo and creates grammar cards', async ({ p
     return result.rows;
   });
 
-  expect(cards.length).toBe(3);
+  expect(cards.length).toBe(4);
 
   const cardsBySentence = new Map<string, (typeof cards)[number]>(
     cards.map((card) => [card.data.examples?.[0]?.de as string, card])
@@ -114,12 +114,14 @@ test('pending photo banner consumes photo and creates grammar cards', async ({ p
     [
       'Heute [bin] ich müde.',
       '[Der] Mann gibt [dem] Kind das Buch.',
+      'Im Sommer [machte] sie oft Sport im Park.',
       'Der Hund läuft schnell durch den [Park].',
     ].sort()
   );
 
   expect(cardsBySentence.get('Heute [bin] ich müde.')?.data.hint).toBe('sein');
   expect(cardsBySentence.get('[Der] Mann gibt [dem] Kind das Buch.')?.data.hint).toBe('der / der');
+  expect(cardsBySentence.get('Im Sommer [machte] sie oft Sport im Park.')?.data.hint).toBe('machen (3. Person Singular)');
   expect(cardsBySentence.get('Der Hund läuft schnell durch den [Park].')?.data.hint).toBeUndefined();
 
   for (const card of cards) {


### PR DESCRIPTION
## Summary
Enhanced the photo grammar concept generation to better handle ambiguity in inflected verb forms. When a blank's required inflected form is ambiguous due to grammatical features (like ambiguous subject pronouns), the hint now includes the specific grammatical feature in parentheses to disambiguate.

## Changes
- **PhotoGrammarConceptService**: Updated system prompt to detect and handle a second type of ambiguity—when the inflected form is ambiguous even after knowing the base hint. Added guidance to enhance hints with grammatical features in parentheses (e.g., "machen (3. Person Singular)") to pin down the exact required form.
- **Test expectations**: Updated test to expect 4 grammar cards instead of 3, and added assertions for the new example sentence with enhanced hint format.
- **Mock data**: Added the new example sentence to the mock Google AI server data to match the updated system prompt example.

## Implementation Details
The enhancement specifically addresses cases where ambiguous subject pronouns (e.g., "sie" = 3rd person singular or plural, "Sie" = formal you) result in multiple valid conjugations fitting the same blank. The hint now clarifies which specific grammatical form is required by appending the distinguishing feature in German within parentheses.

https://claude.ai/code/session_01ACiiTJs8mYBZXbigcKUcUS