### PR TITLE
Fix audio transcription file handling in OpenAI API call

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/TranscriptionService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/TranscriptionService.java
@@ -1,8 +1,12 @@
 package io.github.mucsi96.learnlanguage.service;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
 import org.springframework.stereotype.Service;
 
 import com.openai.client.OpenAIClient;
+import com.openai.core.MultipartField;
 import com.openai.models.audio.transcriptions.TranscriptionCreateParams;
 
 import io.github.mucsi96.learnlanguage.model.OperationType;
@@ -23,7 +27,10 @@ public class TranscriptionService {
         final long startTime = System.currentTimeMillis();
         try {
             final TranscriptionCreateParams params = TranscriptionCreateParams.builder()
-                .file(audio)
+                .file(MultipartField.<InputStream>builder()
+                    .value(new ByteArrayInputStream(audio))
+                    .filename(fileName)
+                    .build())
                 .model(MODEL_NAME)
                 .language("hu")
                 .build();


### PR DESCRIPTION
## Summary
Updated the transcription service to properly format audio file uploads for the OpenAI API by using `MultipartField` with an `InputStream` instead of passing raw bytes.

## Key Changes
- Wrapped audio byte array in `ByteArrayInputStream` to provide stream-based access
- Used `MultipartField` builder to properly construct the file parameter with both the input stream and filename
- Added necessary imports for `ByteArrayInputStream`, `InputStream`, and `MultipartField`

## Implementation Details
The OpenAI client library expects file uploads to be formatted as multipart fields with both the file content and metadata (filename). The previous implementation passed raw bytes directly, which didn't properly handle the multipart encoding. The updated code now:
1. Converts the byte array to an `InputStream` using `ByteArrayInputStream`
2. Builds a `MultipartField` with the stream value and original filename
3. Passes this properly formatted field to the transcription API

This ensures the audio file is correctly transmitted to the OpenAI transcription endpoint.

https://claude.ai/code/session_01QVv22VRaA7fvyTDyoDDXT3