### PR TITLE
Add OpenAI Java client OkHttp dependency

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -142,6 +142,11 @@
       <groupId>org.springframework.ai</groupId>
       <artifactId>spring-ai-starter-model-google-genai</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.github.victools</groupId>
+      <artifactId>jsonschema-module-jackson</artifactId>
+      <version>5.0.0</version>
+    </dependency>
   </dependencies>
   <dependencyManagement>
     <dependencies>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -122,6 +122,11 @@
       <artifactId>spring-ai-starter-model-openai</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.openai</groupId>
+      <artifactId>openai-java-client-okhttp</artifactId>
+      <version>4.38.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.ai</groupId>
       <artifactId>spring-ai-starter-model-elevenlabs</artifactId>
     </dependency>


### PR DESCRIPTION
## Summary
Added the OpenAI Java client OkHttp dependency to the project's Maven configuration.

## Changes
- Added `com.openai:openai-java-client-okhttp` (version 4.38.0) as a project dependency

## Details
This dependency provides an OkHttp-based HTTP client implementation for interacting with OpenAI's APIs. It complements the existing Spring AI OpenAI starter dependency and enables direct OpenAI client functionality with OkHttp as the underlying HTTP transport.

https://claude.ai/code/session_019ThtmouNcSP4jbT8AYiHEX