### PR TITLE
Add virtual two-stage image models (GPT Image 2, Imagen 4 Ultra)

### DIFF
--- a/client/src/app/model-usage-logs/model-usage-logs.service.ts
+++ b/client/src/app/model-usage-logs/model-usage-logs.service.ts
@@ -127,7 +127,7 @@ export class ModelUsageLogsService {
   readonly availableModelTypes: ModelType[] = ['CHAT', 'IMAGE', 'AUDIO'];
 
   readonly availableOperationTypes: string[] = [
-    'translation', 'extraction', 'classification', 'image_generation', 'audio_generation',
+    'translation', 'extraction', 'classification', 'image_generation', 'image_description', 'audio_generation',
   ];
 
   async fetchLogs(params: ModelUsageLogFetchParams): Promise<ModelUsageLogTableResponse> {

--- a/mock_google_ai_server/src/chatHandler.ts
+++ b/mock_google_ai_server/src/chatHandler.ts
@@ -329,6 +329,19 @@ export class ChatHandler {
     return null;
   }
 
+  handleImageDescription(request: GeminiRequest): any | null {
+    const systemContent = request.systemInstruction?.parts?.[0]?.text || '';
+    const userContent = getTextContent(request);
+
+    if (!systemContent.includes('detailed visual description') || !userContent) {
+      return null;
+    }
+
+    return createGeminiResponse(
+      `Detailed scene: ${userContent} A train platform with a large clock, no visible text.`
+    );
+  }
+
   handleExplanation(request: GeminiRequest): any | null {
     const systemContent = request.systemInstruction?.parts?.[0]?.text || '';
 
@@ -377,6 +390,9 @@ export class ChatHandler {
 
     const photoGrammarResponse = await this.handlePhotoGrammarConceptExtraction(request);
     if (photoGrammarResponse) return photoGrammarResponse;
+
+    const imageDescriptionResponse = this.handleImageDescription(request);
+    if (imageDescriptionResponse) return imageDescriptionResponse;
 
     const sentenceTranslationResponse = this.handleSentenceTranslation(request);
     if (sentenceTranslationResponse) return sentenceTranslationResponse;

--- a/mock_google_ai_server/src/index.ts
+++ b/mock_google_ai_server/src/index.ts
@@ -60,6 +60,27 @@ app.post(
   }
 );
 
+app.post(
+  '/v1beta/models/imagen-4.0-ultra-generate-001:predict',
+  (req, res) => {
+    try {
+      const prompt = req.body.instances[0].prompt;
+      console.log({ prompt });
+      const images = imageHandler.generateImages(prompt);
+      res.status(200).json({
+        predictions: images.map(imageBytes => ({
+          mimeType: 'image/png',
+          bytesBase64Encoded: imageBytes,
+        })),
+      });
+      console.log({ imageCount: images.length });
+    } catch (error) {
+      console.error('Imagen generation error:', error);
+      res.status(500).json({ error: { message: 'Image generation failed' } });
+    }
+  }
+);
+
 app.post(/\/v1beta\/models\/([^/]+):generateContent/, async (req, res) => {
   try {
     const model = req.params[0];

--- a/mock_openai_server/src/chatHandler.ts
+++ b/mock_openai_server/src/chatHandler.ts
@@ -197,6 +197,23 @@ export class ChatHandler {
     return null;
   }
 
+  handleImageDescription(messages: ChatMessage[]): any | null {
+    const systemMessage = messages[0]?.content;
+    const userMessage = messages[1]?.content;
+
+    if (
+      typeof systemMessage !== 'string' ||
+      !systemMessage.includes('detailed visual description') ||
+      typeof userMessage !== 'string'
+    ) {
+      return null;
+    }
+
+    return createAssistantResponse(
+      `Detailed scene: ${userMessage} A train platform with a large clock, no visible text.`
+    );
+  }
+
   handleSentenceTranslation(messages: ChatMessage[]): any | null {
     const systemMessage = messages[0]?.content;
     const userMessage = messages[1]?.content;
@@ -274,6 +291,9 @@ export class ChatHandler {
 
     const grammarExtractionResponse = await this.handleGrammarExtraction(messages);
     if (grammarExtractionResponse) return grammarExtractionResponse;
+
+    const imageDescriptionResponse = this.handleImageDescription(messages);
+    if (imageDescriptionResponse) return imageDescriptionResponse;
 
     // Try sentence translation
     const sentenceTranslationResponse = this.handleSentenceTranslation(messages);

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/config/ModelPricingConfig.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/config/ModelPricingConfig.java
@@ -41,8 +41,10 @@ public class ModelPricingConfig {
     private static final Map<String, ImageModelPricing> IMAGE_MODEL_PRICING = Map.of(
         // OpenAI image models (1024x1024 high quality)
         "gpt-image-1.5", new ImageModelPricing(new BigDecimal("0.133")),
+        "gpt-image-2", new ImageModelPricing(new BigDecimal("0.211")),
         // Gemini Developer API: 1,290 output tokens per 1024x1024 image at $30/M tokens
-        "gemini-3-pro-image-preview", new ImageModelPricing(new BigDecimal("0.134"))
+        "gemini-3-pro-image-preview", new ImageModelPricing(new BigDecimal("0.134")),
+        "imagen-4.0-ultra-generate-001", new ImageModelPricing(new BigDecimal("0.06"))
     );
 
     private static final Map<String, AudioModelPricing> AUDIO_MODEL_PRICING = Map.of(

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationModel.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationModel.java
@@ -9,11 +9,14 @@ import lombok.RequiredArgsConstructor;
 //          https://ai.google.dev/gemini-api/docs/pricing
 @RequiredArgsConstructor
 public enum ImageGenerationModel {
-    GPT_IMAGE_1_5("gpt-image-1.5", "GPT Image 1.5"),
-    GEMINI_3_PRO_IMAGE_PREVIEW("gemini-3-pro-image-preview", "Gemini 3 Pro");
+    GPT_IMAGE_1_5("gpt-image-1.5", "GPT Image 1.5", null),
+    GEMINI_3_PRO_IMAGE_PREVIEW("gemini-3-pro-image-preview", "Gemini 3 Pro", null),
+    GPT_IMAGE_2("gpt-image-2", "GPT Image 2", ChatModel.GPT_5_2),
+    IMAGEN_4_ULTRA("imagen-4.0-ultra-generate-001", "Imagen 4 Ultra", ChatModel.GEMINI_3_1_PRO_PREVIEW);
 
     private final String modelName;
     private final String displayName;
+    private final ChatModel descriptionModel;
 
     @JsonValue
     public String getModelName() {
@@ -22,6 +25,10 @@ public enum ImageGenerationModel {
 
     public String getDisplayName() {
         return displayName;
+    }
+
+    public ChatModel getDescriptionModel() {
+        return descriptionModel;
     }
 
     @JsonCreator

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationModel.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationModel.java
@@ -1,5 +1,7 @@
 package io.github.mucsi96.learnlanguage.model;
 
+import java.util.Arrays;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -33,11 +35,9 @@ public enum ImageGenerationModel {
 
     @JsonCreator
     public static ImageGenerationModel fromString(String modelName) {
-        for (ImageGenerationModel model : values()) {
-            if (model.modelName.equals(modelName)) {
-                return model;
-            }
-        }
-        throw new IllegalArgumentException("Unknown image generation model: " + modelName);
+        return Arrays.stream(values())
+            .filter(model -> model.modelName.equals(modelName))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Unknown image generation model: " + modelName));
     }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationModel.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationModel.java
@@ -11,14 +11,13 @@ import lombok.RequiredArgsConstructor;
 //          https://ai.google.dev/gemini-api/docs/pricing
 @RequiredArgsConstructor
 public enum ImageGenerationModel {
-    GPT_IMAGE_1_5("gpt-image-1.5", "GPT Image 1.5", null),
-    GEMINI_3_PRO_IMAGE_PREVIEW("gemini-3-pro-image-preview", "Gemini 3 Pro", null),
-    GPT_IMAGE_2("gpt-image-2", "GPT Image 2", ChatModel.GPT_5_2),
-    IMAGEN_4_ULTRA("imagen-4.0-ultra-generate-001", "Imagen 4 Ultra", ChatModel.GEMINI_3_1_PRO_PREVIEW);
+    GPT_IMAGE_1_5("gpt-image-1.5", "GPT Image 1.5"),
+    GEMINI_3_PRO_IMAGE_PREVIEW("gemini-3-pro-image-preview", "Gemini 3 Pro"),
+    GPT_IMAGE_2("gpt-image-2", "GPT Image 2"),
+    IMAGEN_4_ULTRA("imagen-4.0-ultra-generate-001", "Imagen 4 Ultra");
 
     private final String modelName;
     private final String displayName;
-    private final ChatModel descriptionModel;
 
     @JsonValue
     public String getModelName() {
@@ -27,10 +26,6 @@ public enum ImageGenerationModel {
 
     public String getDisplayName() {
         return displayName;
-    }
-
-    public ChatModel getDescriptionModel() {
-        return descriptionModel;
     }
 
     @JsonCreator

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/OperationType.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/OperationType.java
@@ -16,6 +16,7 @@ public enum OperationType {
     CLASSIFICATION("classification", "Classification", true),
     DUPLICATE_DETECTION("duplicate_detection", "Duplicate Detection", true),
     IMAGE_GENERATION("image_generation", "Image Generation", false),
+    IMAGE_DESCRIPTION("image_description", "Image Description", false),
     AUDIO_GENERATION("audio_generation", "Audio Generation", false),
     EXPLANATION("explanation", "Explanation", true),
     TRANSCRIPTION("transcription", "Transcription", false);

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/GoogleImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/GoogleImageService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 
 import com.google.genai.Client;
 import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.GenerateImagesConfig;
 import com.google.genai.types.ImageConfig;
 
 import io.github.mucsi96.learnlanguage.model.OperationType;
@@ -15,11 +16,10 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class GoogleImageService {
 
-  private static final String MODEL_NAME = "gemini-3-pro-image-preview";
   private final Client googleAiClient;
   private final ModelUsageLoggingService usageLoggingService;
 
-  public byte[] generateImage(String input, String context) {
+  public byte[] generateImage(String input, String context, String modelName) {
     final long startTime = System.currentTimeMillis();
     try {
       final GenerateContentConfig config = GenerateContentConfig.builder()
@@ -32,7 +32,7 @@ public class GoogleImageService {
 
       final String fullPrompt = ImagePromptBuilder.build(input, context);
 
-      final byte[] image = googleAiClient.models.generateContent(MODEL_NAME, fullPrompt, config)
+      final byte[] image = googleAiClient.models.generateContent(modelName, fullPrompt, config)
           .candidates().orElseThrow(() -> new RuntimeException("No candidates in Gemini response")).stream()
           .flatMap(candidate -> candidate.content().stream()
               .flatMap(content -> content.parts().stream())
@@ -40,16 +40,44 @@ public class GoogleImageService {
           .flatMap(part -> part.inlineData().stream())
           .flatMap(data -> data.data().stream())
           .findFirst()
-          .orElseThrow(() -> new RuntimeException("No image found in Gemini 3 Pro Image response"));
+          .orElseThrow(() -> new RuntimeException("No image found in " + modelName + " response"));
 
       final long processingTime = System.currentTimeMillis() - startTime;
-      usageLoggingService.logImageUsage(MODEL_NAME, OperationType.IMAGE_GENERATION, 1, processingTime);
+      usageLoggingService.logImageUsage(modelName, OperationType.IMAGE_GENERATION, 1, processingTime);
 
       return image;
 
     } catch (Exception e) {
-      log.error("Failed to generate image with Gemini 3 Pro Image", e);
-      throw new RuntimeException("Failed to generate image with Gemini 3 Pro Image: " + e.getMessage(), e);
+      log.error("Failed to generate image with {}", modelName, e);
+      throw new RuntimeException("Failed to generate image with " + modelName + ": " + e.getMessage(), e);
+    }
+  }
+
+  public byte[] generateImagenImage(String input, String context, String modelName) {
+    final long startTime = System.currentTimeMillis();
+    try {
+      final GenerateImagesConfig config = GenerateImagesConfig.builder()
+          .numberOfImages(1)
+          .aspectRatio("1:1")
+          .build();
+
+      final String fullPrompt = ImagePromptBuilder.build(input, context);
+
+      final byte[] image = googleAiClient.models.generateImages(modelName, fullPrompt, config)
+          .generatedImages().orElseThrow(() -> new RuntimeException("No images in Imagen response")).stream()
+          .flatMap(generatedImage -> generatedImage.image().stream())
+          .flatMap(img -> img.imageBytes().stream())
+          .findFirst()
+          .orElseThrow(() -> new RuntimeException("No image found in " + modelName + " response"));
+
+      final long processingTime = System.currentTimeMillis() - startTime;
+      usageLoggingService.logImageUsage(modelName, OperationType.IMAGE_GENERATION, 1, processingTime);
+
+      return image;
+
+    } catch (Exception e) {
+      log.error("Failed to generate image with {}", modelName, e);
+      throw new RuntimeException("Failed to generate image with " + modelName + ": " + e.getMessage(), e);
     }
   }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/GoogleImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/GoogleImageService.java
@@ -16,12 +16,16 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class GoogleImageService {
 
+  @FunctionalInterface
+  private interface ImageCall {
+    byte[] call() throws Exception;
+  }
+
   private final Client googleAiClient;
   private final ModelUsageLoggingService usageLoggingService;
 
   public byte[] generateGeminiImage(String input, String context, String modelName) {
-    final long startTime = System.currentTimeMillis();
-    try {
+    return generateWithUsageLogging(modelName, () -> {
       final GenerateContentConfig config = GenerateContentConfig.builder()
           .responseModalities("TEXT", "IMAGE")
           .imageConfig(ImageConfig.builder()
@@ -32,7 +36,7 @@ public class GoogleImageService {
 
       final String fullPrompt = ImagePromptBuilder.build(input, context);
 
-      final byte[] image = googleAiClient.models.generateContent(modelName, fullPrompt, config)
+      return googleAiClient.models.generateContent(modelName, fullPrompt, config)
           .candidates().orElseThrow(() -> new RuntimeException("No candidates in Gemini response")).stream()
           .flatMap(candidate -> candidate.content().stream()
               .flatMap(content -> content.parts().stream())
@@ -41,21 +45,11 @@ public class GoogleImageService {
           .flatMap(data -> data.data().stream())
           .findFirst()
           .orElseThrow(() -> new RuntimeException("No image found in " + modelName + " response"));
-
-      final long processingTime = System.currentTimeMillis() - startTime;
-      usageLoggingService.logImageUsage(modelName, OperationType.IMAGE_GENERATION, 1, processingTime);
-
-      return image;
-
-    } catch (Exception e) {
-      log.error("Failed to generate image with {}", modelName, e);
-      throw new RuntimeException("Failed to generate image with " + modelName + ": " + e.getMessage(), e);
-    }
+    });
   }
 
   public byte[] generateImagenImage(String input, String context, String modelName) {
-    final long startTime = System.currentTimeMillis();
-    try {
+    return generateWithUsageLogging(modelName, () -> {
       final GenerateImagesConfig config = GenerateImagesConfig.builder()
           .numberOfImages(1)
           .aspectRatio("1:1")
@@ -63,12 +57,19 @@ public class GoogleImageService {
 
       final String fullPrompt = ImagePromptBuilder.build(input, context);
 
-      final byte[] image = googleAiClient.models.generateImages(modelName, fullPrompt, config)
+      return googleAiClient.models.generateImages(modelName, fullPrompt, config)
           .generatedImages().orElseThrow(() -> new RuntimeException("No images in Imagen response")).stream()
           .flatMap(generatedImage -> generatedImage.image().stream())
           .flatMap(img -> img.imageBytes().stream())
           .findFirst()
           .orElseThrow(() -> new RuntimeException("No image found in " + modelName + " response"));
+    });
+  }
+
+  private byte[] generateWithUsageLogging(String modelName, ImageCall imageCall) {
+    final long startTime = System.currentTimeMillis();
+    try {
+      final byte[] image = imageCall.call();
 
       final long processingTime = System.currentTimeMillis() - startTime;
       usageLoggingService.logImageUsage(modelName, OperationType.IMAGE_GENERATION, 1, processingTime);

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/GoogleImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/GoogleImageService.java
@@ -1,5 +1,7 @@
 package io.github.mucsi96.learnlanguage.service;
 
+import java.util.concurrent.Callable;
+
 import org.springframework.stereotype.Service;
 
 import com.google.genai.Client;
@@ -15,11 +17,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor
 public class GoogleImageService {
-
-  @FunctionalInterface
-  private interface ImageCall {
-    byte[] call() throws Exception;
-  }
 
   private final Client googleAiClient;
   private final ModelUsageLoggingService usageLoggingService;
@@ -66,7 +63,7 @@ public class GoogleImageService {
     });
   }
 
-  private byte[] generateWithUsageLogging(String modelName, ImageCall imageCall) {
+  private byte[] generateWithUsageLogging(String modelName, Callable<byte[]> imageCall) {
     final long startTime = System.currentTimeMillis();
     try {
       final byte[] image = imageCall.call();

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/GoogleImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/GoogleImageService.java
@@ -19,7 +19,7 @@ public class GoogleImageService {
   private final Client googleAiClient;
   private final ModelUsageLoggingService usageLoggingService;
 
-  public byte[] generateImage(String input, String context, String modelName) {
+  public byte[] generateGeminiImage(String input, String context, String modelName) {
     final long startTime = System.currentTimeMillis();
     try {
       final GenerateContentConfig config = GenerateContentConfig.builder()

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
@@ -61,7 +61,7 @@ public class ImageService {
 
     if (modelName == null) {
       throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
-          "No primary model configured for extraction");
+          "Image description requires a primary chat model configured for the extraction operation");
     }
 
     return ChatModel.fromString(modelName);

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
@@ -1,6 +1,10 @@
 package io.github.mucsi96.learnlanguage.service;
 
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import io.github.mucsi96.learnlanguage.model.ChatModel;
 import io.github.mucsi96.learnlanguage.model.ImageGenerationModel;
@@ -25,30 +29,41 @@ public class ImageService {
   private final OpenAIImageService openAIImageService;
   private final GoogleImageService googleImageService;
   private final ChatService chatService;
+  private final ChatModelSettingService chatModelSettingService;
 
   public byte[] generateImage(String input, String context, ImageGenerationModel model) {
     return switch (model) {
       case GPT_IMAGE_1_5 -> openAIImageService.generateImage(input, context, model.getModelName());
       case GEMINI_3_PRO_IMAGE_PREVIEW -> googleImageService.generateGeminiImage(input, context, model.getModelName());
       case GPT_IMAGE_2 ->
-        openAIImageService.generateImage(describeScene(input, context, model.getDescriptionModel()), null,
-            model.getModelName());
+        openAIImageService.generateImage(describeScene(input, context), null, model.getModelName());
       case IMAGEN_4_ULTRA ->
-        googleImageService.generateImagenImage(describeScene(input, context, model.getDescriptionModel()), null,
-            model.getModelName());
+        googleImageService.generateImagenImage(describeScene(input, context), null, model.getModelName());
     };
   }
 
-  private String describeScene(String input, String context, ChatModel descriptionModel) {
+  private String describeScene(String input, String context) {
     final String contextSegment = context == null || context.isBlank()
         ? ""
         : " Additional context: " + context + ".";
     final String description = chatService.callForTextWithLogging(
-        descriptionModel,
+        resolveDescriptionModel(),
         OperationType.IMAGE_DESCRIPTION,
         DESCRIPTION_SYSTEM_PROMPT,
         input + contextSegment);
     log.info("Generated image description for input \"{}\": {}", input, description);
     return description;
+  }
+
+  private ChatModel resolveDescriptionModel() {
+    final Map<OperationType, String> primaryModels = chatModelSettingService.getPrimaryModelByOperation();
+    final String modelName = primaryModels.get(OperationType.EXTRACTION);
+
+    if (modelName == null) {
+      throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
+          "No primary model configured for extraction");
+    }
+
+    return ChatModel.fromString(modelName);
   }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
@@ -2,7 +2,9 @@ package io.github.mucsi96.learnlanguage.service;
 
 import org.springframework.stereotype.Service;
 
+import io.github.mucsi96.learnlanguage.model.ChatModel;
 import io.github.mucsi96.learnlanguage.model.ImageGenerationModel;
+import io.github.mucsi96.learnlanguage.model.OperationType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -10,13 +12,43 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class ImageService {
+
+  private static final String DESCRIPTION_SYSTEM_PROMPT = """
+      You are an expert prompt writer for image generation models. \
+      Given a word or sentence, write a detailed visual description of a single photorealistic scene \
+      that illustrates its meaning. Describe the concrete objects and people that are visible, \
+      their positions and spatial relationships, the setting, lighting and mood. \
+      Use simple, unambiguous language an image model can follow. \
+      The scene must not contain any text, letters, numbers, signs with writing or captions. \
+      Respond with the description only.""";
+
   private final OpenAIImageService openAIImageService;
   private final GoogleImageService googleImageService;
+  private final ChatService chatService;
 
   public byte[] generateImage(String input, String context, ImageGenerationModel model) {
     return switch (model) {
-      case GPT_IMAGE_1_5 -> openAIImageService.generateImage(input, context);
-      case GEMINI_3_PRO_IMAGE_PREVIEW -> googleImageService.generateImage(input, context);
+      case GPT_IMAGE_1_5 -> openAIImageService.generateImage(input, context, model.getModelName());
+      case GEMINI_3_PRO_IMAGE_PREVIEW -> googleImageService.generateImage(input, context, model.getModelName());
+      case GPT_IMAGE_2 ->
+        openAIImageService.generateImage(describeScene(input, context, model.getDescriptionModel()), null,
+            model.getModelName());
+      case IMAGEN_4_ULTRA ->
+        googleImageService.generateImagenImage(describeScene(input, context, model.getDescriptionModel()), null,
+            model.getModelName());
     };
+  }
+
+  private String describeScene(String input, String context, ChatModel descriptionModel) {
+    final String contextSegment = context == null || context.isBlank()
+        ? ""
+        : " Additional context: " + context + ".";
+    final String description = chatService.callForTextWithLogging(
+        descriptionModel,
+        OperationType.IMAGE_DESCRIPTION,
+        DESCRIPTION_SYSTEM_PROMPT,
+        input + contextSegment);
+    log.info("Generated image description for input \"{}\": {}", input, description);
+    return description;
   }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
@@ -29,7 +29,7 @@ public class ImageService {
   public byte[] generateImage(String input, String context, ImageGenerationModel model) {
     return switch (model) {
       case GPT_IMAGE_1_5 -> openAIImageService.generateImage(input, context, model.getModelName());
-      case GEMINI_3_PRO_IMAGE_PREVIEW -> googleImageService.generateImage(input, context, model.getModelName());
+      case GEMINI_3_PRO_IMAGE_PREVIEW -> googleImageService.generateGeminiImage(input, context, model.getModelName());
       case GPT_IMAGE_2 ->
         openAIImageService.generateImage(describeScene(input, context, model.getDescriptionModel()), null,
             model.getModelName());

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/OpenAIImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/OpenAIImageService.java
@@ -16,16 +16,15 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class OpenAIImageService {
 
-    private static final String MODEL_NAME = "gpt-image-1.5";
     private final OpenAIClient openAIClient;
     private final ModelUsageLoggingService usageLoggingService;
 
-    public byte[] generateImage(String input, String context) {
+    public byte[] generateImage(String input, String context, String modelName) {
         final long startTime = System.currentTimeMillis();
         try {
             final ImageGenerateParams imageGenerateParams = ImageGenerateParams.builder()
                 .prompt(ImagePromptBuilder.build(input, context))
-                .model(MODEL_NAME)
+                .model(modelName)
                 .size(ImageGenerateParams.Size._1024X1024)
                 .quality(ImageGenerateParams.Quality.HIGH)
                 .n(1)
@@ -40,7 +39,7 @@ public class OpenAIImageService {
                 .orElseThrow(() -> new RuntimeException("No image data returned from OpenAI API"));
 
             final long processingTime = System.currentTimeMillis() - startTime;
-            usageLoggingService.logImageUsage(MODEL_NAME, OperationType.IMAGE_GENERATION, 1, processingTime);
+            usageLoggingService.logImageUsage(modelName, OperationType.IMAGE_GENERATION, 1, processingTime);
 
             return image;
 

--- a/test/tests/chat-model-settings.spec.ts
+++ b/test/tests/chat-model-settings.spec.ts
@@ -19,6 +19,7 @@ test('displays matrix with all chat models and operation types', async ({ page }
   await expect(page.getByText('Translation')).toBeVisible();
   await expect(page.getByText('Extraction')).toBeVisible();
   await expect(page.getByText('Classification')).toBeVisible();
+  await expect(page.getByText('Image Description')).not.toBeVisible();
 });
 
 test('can set primary model for operation type', async ({ page }) => {

--- a/test/tests/chat-model-settings.spec.ts
+++ b/test/tests/chat-model-settings.spec.ts
@@ -19,7 +19,7 @@ test('displays matrix with all chat models and operation types', async ({ page }
   await expect(page.getByText('Translation')).toBeVisible();
   await expect(page.getByText('Extraction')).toBeVisible();
   await expect(page.getByText('Classification')).toBeVisible();
-  await expect(page.getByText('Image Description')).not.toBeVisible();
+  await expect(page.getByText('Image Description')).not.toBeAttached();
 });
 
 test('can set primary model for operation type', async ({ page }) => {

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -1,11 +1,13 @@
 import { test, expect } from '../fixtures';
 import {
   createCard,
+  createImageModelSetting,
   createImageSetting,
   downloadImage,
   getCardFromDb,
   getImageColor,
   getImageContent,
+  getModelUsageLogs,
   withDbConnection,
   yellowImage,
   redImage,
@@ -354,6 +356,59 @@ test('favorite toggle on newly generated image', async ({ page }) => {
     expect(cardData.examples[0].images[0].isFavorite).toBeUndefined();
     expect(cardData.examples[0].images[1].isFavorite).toBe(true);
   });
+});
+
+test('generates image with virtual two-stage model', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await createImageModelSetting({ modelName: 'imagen-4.0-ultra-generate-001', imageCount: 1 });
+  const image1 = uploadMockImage(blueImage);
+  await createCard({
+    cardId: 'abfahren-elindulni',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'abfahren',
+      type: 'VERB',
+      forms: ['fährt ab', 'fuhr ab', 'abgefahren'],
+      translation: {
+        en: 'to leave',
+        hu: 'elindulni, elhagyni',
+        ch: 'abfahra, verlah',
+      },
+      examples: [
+        {
+          de: 'Wann fährt der Zug ab?',
+          hu: 'Mikor indul a vonat?',
+          en: 'When does the train leave?',
+          ch: 'Wänn fahrt dr Zug ab?',
+          images: [{ id: image1 }],
+        },
+      ],
+    },
+  });
+  await navigateToCardEditing(page);
+
+  await page.getByRole('button', { name: 'Add example image' }).first().click();
+  await expect(page.getByRole('img')).toHaveCount(2);
+
+  await expect(page.getByText('Imagen 4 Ultra')).toHaveCount(1);
+
+  const generatedImageContent = await getImageContent(
+    page.getByRole('img', { name: 'Wann fährt der Zug ab?' }).nth(1)
+  );
+  expect(await getImageColor(page, generatedImageContent)).toBe('red');
+
+  const logs = await getModelUsageLogs();
+  const descriptionLog = logs.find((log) => log.operationType === 'IMAGE_DESCRIPTION');
+  expect(descriptionLog).toBeDefined();
+  expect(descriptionLog!.modelType).toBe('CHAT');
+  expect(descriptionLog!.modelName).toBe('gemini-3.1-pro-preview');
+  expect(descriptionLog!.responseContent).toContain('Wann fährt der Zug ab?');
+
+  const generationLog = logs.find((log) => log.operationType === 'IMAGE_GENERATION');
+  expect(generationLog).toBeDefined();
+  expect(generationLog!.modelType).toBe('IMAGE');
+  expect(generationLog!.modelName).toBe('imagen-4.0-ultra-generate-001');
 });
 
 test('add image with context dialog', async ({ page }) => {

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../fixtures';
 import {
   createCard,
+  createChatModelSetting,
   createImageModelSetting,
   createImageSetting,
   downloadImage,
@@ -409,6 +410,68 @@ test('generates image with virtual two-stage model', async ({ page }) => {
   expect(generationLog).toBeDefined();
   expect(generationLog!.modelType).toBe('IMAGE');
   expect(generationLog!.modelName).toBe('imagen-4.0-ultra-generate-001');
+});
+
+test('generates image with virtual two-stage model using OpenAI models', async ({ page }) => {
+  await Promise.all(
+    ['TRANSLATION', 'EXTRACTION', 'CLASSIFICATION', 'EXPLANATION'].map((operationType) =>
+      createChatModelSetting({
+        modelName: 'gpt-5.2',
+        operationType,
+        isEnabled: true,
+        isPrimary: true,
+      })
+    )
+  );
+  await createImageModelSetting({ modelName: 'gpt-image-2', imageCount: 1 });
+  const image1 = uploadMockImage(blueImage);
+  await createCard({
+    cardId: 'abfahren-elindulni',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'abfahren',
+      type: 'VERB',
+      forms: ['fährt ab', 'fuhr ab', 'abgefahren'],
+      translation: {
+        en: 'to leave',
+        hu: 'elindulni, elhagyni',
+        ch: 'abfahra, verlah',
+      },
+      examples: [
+        {
+          de: 'Wann fährt der Zug ab?',
+          hu: 'Mikor indul a vonat?',
+          en: 'When does the train leave?',
+          ch: 'Wänn fahrt dr Zug ab?',
+          images: [{ id: image1 }],
+        },
+      ],
+    },
+  });
+  await navigateToCardEditing(page);
+
+  await page.getByRole('button', { name: 'Add example image' }).first().click();
+  await expect(page.getByRole('img')).toHaveCount(2);
+
+  await expect(page.getByText('GPT Image 2')).toHaveCount(1);
+
+  const generatedImageContent = await getImageContent(
+    page.getByRole('img', { name: 'Wann fährt der Zug ab?' }).nth(1)
+  );
+  expect(await getImageColor(page, generatedImageContent)).toBe('red');
+
+  const logs = await getModelUsageLogs();
+  const descriptionLog = logs.find((log) => log.operationType === 'IMAGE_DESCRIPTION');
+  expect(descriptionLog).toBeDefined();
+  expect(descriptionLog!.modelType).toBe('CHAT');
+  expect(descriptionLog!.modelName).toBe('gpt-5.2');
+  expect(descriptionLog!.responseContent).toContain('Wann fährt der Zug ab?');
+
+  const generationLog = logs.find((log) => log.operationType === 'IMAGE_GENERATION');
+  expect(generationLog).toBeDefined();
+  expect(generationLog!.modelType).toBe('IMAGE');
+  expect(generationLog!.modelName).toBe('gpt-image-2');
 });
 
 test('add image with context dialog', async ({ page }) => {

--- a/test/tests/image-model-settings.spec.ts
+++ b/test/tests/image-model-settings.spec.ts
@@ -20,25 +20,34 @@ test('displays all image models with default image counts', async ({ page }) => 
 
   await expect(page.getByText('GPT Image 1.5')).toBeVisible();
   await expect(page.getByText('Gemini 3 Pro')).toBeVisible();
+  await expect(page.getByText('GPT Image 2')).toBeVisible();
+  await expect(page.getByText('Imagen 4 Ultra')).toBeVisible();
 
   const gptInput = page.getByRole('spinbutton', { name: 'Image count for GPT Image 1.5' });
   const geminiInput = page.getByRole('spinbutton', { name: 'Image count for Gemini 3 Pro' });
+  const gptImage2Input = page.getByRole('spinbutton', { name: 'Image count for GPT Image 2' });
+  const imagenUltraInput = page.getByRole('spinbutton', { name: 'Image count for Imagen 4 Ultra' });
 
   await expect(gptInput).toHaveValue('0');
   await expect(geminiInput).toHaveValue('0');
+  await expect(gptImage2Input).toHaveValue('0');
+  await expect(imagenUltraInput).toHaveValue('0');
 });
 
 test('displays image counts from database settings', async ({ page }) => {
   await createImageModelSetting({ modelName: 'gpt-image-1.5', imageCount: 2 });
   await createImageModelSetting({ modelName: 'gemini-3-pro-image-preview', imageCount: 5 });
+  await createImageModelSetting({ modelName: 'gpt-image-2', imageCount: 3 });
 
   await page.goto('/settings/image-models');
 
   const gptInput = page.getByRole('spinbutton', { name: 'Image count for GPT Image 1.5' });
   const geminiInput = page.getByRole('spinbutton', { name: 'Image count for Gemini 3 Pro' });
+  const gptImage2Input = page.getByRole('spinbutton', { name: 'Image count for GPT Image 2' });
 
   await expect(gptInput).toHaveValue('2');
   await expect(geminiInput).toHaveValue('5');
+  await expect(gptImage2Input).toHaveValue('3');
 });
 
 test('can update image count for a model', async ({ page }) => {
@@ -53,6 +62,21 @@ test('can update image count for a model', async ({ page }) => {
     const gptSetting = settings.find((s) => s.modelName === 'gpt-image-1.5');
     expect(gptSetting).toBeDefined();
     expect(gptSetting!.imageCount).toBe(4);
+  }).toPass();
+});
+
+test('can update image count for a virtual model', async ({ page }) => {
+  await page.goto('/settings/image-models');
+
+  const imagenUltraInput = page.getByRole('spinbutton', { name: 'Image count for Imagen 4 Ultra' });
+  await imagenUltraInput.fill('2');
+  await imagenUltraInput.dispatchEvent('change');
+
+  await expect(async () => {
+    const settings = await getImageModelSettings();
+    const imagenUltraSetting = settings.find((s) => s.modelName === 'imagen-4.0-ultra-generate-001');
+    expect(imagenUltraSetting).toBeDefined();
+    expect(imagenUltraSetting!.imageCount).toBe(2);
   }).toPass();
 });
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -770,13 +770,15 @@ export async function getModelUsageLogs(): Promise<
     inputTokens: number | null;
     outputTokens: number | null;
     rating: number | null;
+    responseContent: string | null;
   }>
 > {
   return await withDbConnection(async (client) => {
     const result = await client.query(
       `SELECT id, model_name as "modelName", model_type as "modelType",
               operation_type as "operationType", input_tokens as "inputTokens",
-              output_tokens as "outputTokens", rating
+              output_tokens as "outputTokens", rating,
+              response_content as "responseContent"
        FROM learn_language.model_usage_logs
        ORDER BY created_at DESC`
     );


### PR DESCRIPTION
## Summary

Introduces two **virtual image models** that run a two-stage pipeline and are selectable in image model settings alongside the existing plain models:

| Virtual model | Stage 1 (description) | Stage 2 (image) |
|---|---|---|
| GPT Image 2 | Primary chat model of the Extraction operation | `gpt-image-2` (OpenAI Images API) |
| Imagen 4 Ultra | Primary chat model of the Extraction operation | `imagen-4.0-ultra-generate-001` (Imagen generateImages API) |

Stage 1 turns the German sentence (plus optional context) into a detailed visual scene description — visible objects, positions, setting, lighting, no text in the scene — which stage 2 renders. This gives weaker/cheaper image models a much better prompt than the raw sentence.

The stage-1 text model is resolved from the chat model configured as **primary for Extraction** (the card-creation default) — intentionally coupled so the description quality follows the card-creation model choice. If none is configured, image generation for virtual models fails with 503 rather than silently falling back.

## Key changes

- `ImageGenerationModel` gains two new virtual entries
- `ImageService` routes virtual models through a `describeScene` chat call (`ChatService.callForTextWithLogging`) under the new `IMAGE_DESCRIPTION` operation type (non-chat, so it stays out of the data-model settings matrix), resolving the model from the Extraction primary setting
- Stage-1 descriptions are inspectable for prompt/model fine-tuning: persisted in `model_usage_logs.response_content` (filterable as `image_description` on the usage logs page) and logged via `log.info`
- `OpenAIImageService` / `GoogleImageService` take the model name as a parameter; new `generateImagenImage` method for the Imagen predict API
- Pricing entries for both new models ($0.211 / $0.06 per image)
- Mock servers: description-echo chat handlers (OpenAI + Google) and an Imagen `:predict` route
- Frontend picks the new models up automatically (settings UI is data-driven from `/api/environment`)

## Tests

- New e2e test exercising the full two-stage pipeline (image label, mock image color proving the description flowed through, and both usage-log rows including the persisted description)
- Image model settings tests extended for the 4-model list and virtual-model count persistence
- Guard assertion that "Image Description" does not appear in the chat-model settings matrix

https://claude.ai/code/session_0163Lw8mtDpxChf2Vno7jpfZ