### PR TITLE
Add Twingate connection step to deployment pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -219,6 +219,11 @@ jobs:
         with:
           kubelogin-version: 'v0.2.7'
 
+      - name: Connect to Twingate
+        uses: twingate/github-action@v1
+        with:
+          service-key: ${{ secrets.TWINGATE_SERVICE_KEY }}
+
       - name: Deploy to Kubernetes
         env:
           AZURE_KEYVAULT_NAME: ${{ secrets.AZURE_KEYVAULT_NAME }}


### PR DESCRIPTION
## Summary
Added a Twingate connection step to the GitHub Actions deployment pipeline to enable secure network access during Kubernetes deployments.

## Changes
- Added a new workflow step that authenticates to Twingate using the official GitHub Action before the Kubernetes deployment step
- Configured the step to use the `TWINGATE_SERVICE_KEY` secret for authentication
- Positioned the Twingate connection immediately after kubelogin setup and before the Kubernetes deployment to ensure network access is established for the deployment process

## Implementation Details
- Uses `twingate/github-action@v1` for the connection
- Service key is passed securely via GitHub secrets
- This enables the deployment job to access Kubernetes clusters through Twingate's secure network access layer

https://claude.ai/code/session_016gncwcvnDVxJ3uoZph5q9k