### PR TITLE
Configure HikariCP connection pool and disable OpenInView

### DIFF
--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -18,7 +18,6 @@ spring:
       connection-init-sql: CREATE SCHEMA IF NOT EXISTS learn_language
       maximum-pool-size: 20
       minimum-idle: 5
-      connection-timeout: 30000
       leak-detection-threshold: 30000
   jpa:
     open-in-view: false

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -16,7 +16,12 @@ spring:
     driver-class-name: org.postgresql.Driver
     hikari:
       connection-init-sql: CREATE SCHEMA IF NOT EXISTS learn_language
+      maximum-pool-size: 20
+      minimum-idle: 5
+      connection-timeout: 30000
+      leak-detection-threshold: 30000
   jpa:
+    open-in-view: false
     properties:
       hibernate:
         show-sql: true


### PR DESCRIPTION
## Summary
Optimized database connection pool configuration and improved JPA session management by disabling OpenInView pattern.

## Key Changes
- **HikariCP Pool Configuration**: Added connection pool settings to improve database connection management:
  - Set maximum pool size to 20 connections
  - Set minimum idle connections to 5
  - Enabled leak detection with 30-second threshold
- **JPA Configuration**: Disabled `open-in-view` to prevent lazy loading outside of transaction boundaries and improve application performance

## Implementation Details
These changes enhance database connection reliability and prevent common issues with lazy-loaded entities being accessed outside of active transactions. The HikariCP settings provide better resource management and help identify connection leaks during development.

https://claude.ai/code/session_01R4VqY9V91xWG6GvKkssNjH