### PR TITLE
Implement async image generation with job status polling

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -219,6 +219,11 @@ jobs:
         with:
           kubelogin-version: 'v0.2.7'
 
+      - name: Connect to Twingate
+        uses: twingate/github-action@v1
+        with:
+          service-key: ${{ secrets.TWINGATE_SERVICE_KEY }}
+
       - name: Deploy to Kubernetes
         env:
           AZURE_KEYVAULT_NAME: ${{ secrets.AZURE_KEYVAULT_NAME }}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,32 +8,32 @@
       "name": "admin-client",
       "version": "0.0.0",
       "dependencies": {
-        "@angular/animations": "21.2.15",
-        "@angular/cdk": "21.2.13",
-        "@angular/common": "21.2.15",
-        "@angular/compiler": "21.2.15",
-        "@angular/core": "21.2.15",
-        "@angular/forms": "21.2.15",
-        "@angular/material": "21.2.13",
-        "@angular/platform-browser": "21.2.15",
-        "@angular/platform-browser-dynamic": "21.2.15",
-        "@angular/router": "21.2.15",
+        "@angular/animations": "21.2.16",
+        "@angular/cdk": "21.2.14",
+        "@angular/common": "21.2.16",
+        "@angular/compiler": "21.2.16",
+        "@angular/core": "21.2.16",
+        "@angular/forms": "21.2.16",
+        "@angular/material": "21.2.14",
+        "@angular/platform-browser": "21.2.16",
+        "@angular/platform-browser-dynamic": "21.2.16",
+        "@angular/router": "21.2.16",
         "@grafana/faro-web-sdk": "^2.7.0",
         "@mucsi96/angular-material-theme": "^1.8.0",
         "ag-grid-angular": "^35.0.1",
         "ag-grid-community": "^35.0.1",
-        "oidc-client-ts": "^3.5.0",
+        "oidc-client-ts": "^3.1.0",
         "rxjs": "7.8.2",
         "ts-fsrs": "5.4.1",
         "tslib": "2.8.1",
         "zone.js": "0.16.2"
       },
       "devDependencies": {
-        "@angular-devkit/build-angular": "21.2.13",
-        "@angular-devkit/core": "21.2.13",
-        "@angular/build": "21.2.13",
-        "@angular/cli": "21.2.13",
-        "@angular/compiler-cli": "21.2.15",
+        "@angular-devkit/build-angular": "21.2.14",
+        "@angular-devkit/core": "21.2.14",
+        "@angular/build": "21.2.14",
+        "@angular/cli": "21.2.14",
+        "@angular/compiler-cli": "21.2.16",
         "typescript": "5.9.3"
       }
     },
@@ -261,13 +261,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2102.13",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2102.13.tgz",
-      "integrity": "sha512-fheyi0gPx6b7tT+WQ+ePlzdGqKjPLUK72wg5Z9pkVtQ5+VN/8yB9mlRlmoivngd2FeNG9wMeNynWZGYycnOWVw==",
+      "version": "0.2102.14",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2102.14.tgz",
+      "integrity": "sha512-0+vjVsCkMyJdVjz5XkPW+Bdf/9TI8V2voomx/+o0o+oOaqqiEhptQWFnaIlLr7HasjB0LxXK5P9L0oQ61vxj8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "21.2.13",
+        "@angular-devkit/core": "21.2.14",
         "rxjs": "7.8.2"
       },
       "bin": {
@@ -280,17 +280,17 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "21.2.13",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-21.2.13.tgz",
-      "integrity": "sha512-H+wLj9n4khPIUYlIPCVfOGZzTsTVn/lzkY46DTMHd7gQF35vG+/xWvWCu3Shpf/0c631U7Jc2Mg7G+GBDgxe/g==",
+      "version": "21.2.14",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-21.2.14.tgz",
+      "integrity": "sha512-EgKDd5pYctnsj3yYAZt3vivodH+r61X0ivWbZljcwT7OO4CEDyTR7Vtu4TUSr+tlplz5x2PYsWNr1nqyF0hufw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2102.13",
-        "@angular-devkit/build-webpack": "0.2102.13",
-        "@angular-devkit/core": "21.2.13",
-        "@angular/build": "21.2.13",
+        "@angular-devkit/architect": "0.2102.14",
+        "@angular-devkit/build-webpack": "0.2102.14",
+        "@angular-devkit/core": "21.2.14",
+        "@angular/build": "21.2.14",
         "@babel/core": "7.29.0",
         "@babel/generator": "7.29.1",
         "@babel/helper-annotate-as-pure": "7.27.3",
@@ -301,7 +301,7 @@
         "@babel/preset-env": "7.29.2",
         "@babel/runtime": "7.29.2",
         "@discoveryjs/json-ext": "0.6.3",
-        "@ngtools/webpack": "21.2.13",
+        "@ngtools/webpack": "21.2.14",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.27",
         "babel-loader": "10.0.0",
@@ -356,7 +356,7 @@
         "@angular/platform-browser": "^21.0.0",
         "@angular/platform-server": "^21.0.0",
         "@angular/service-worker": "^21.0.0",
-        "@angular/ssr": "^21.2.13",
+        "@angular/ssr": "^21.2.14",
         "@web/test-runner": "^0.20.0",
         "browser-sync": "^3.0.2",
         "jest": "^30.2.0",
@@ -413,13 +413,13 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.2102.13",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.2102.13.tgz",
-      "integrity": "sha512-xnGq62JImcvPUM5r7Uvj7Y243fepwhbTG3zaIR2JKR+4EwF5pS5moXuVf+xVvxRqQkNcmLGfr7uJogmpw+dUgA==",
+      "version": "0.2102.14",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.2102.14.tgz",
+      "integrity": "sha512-UjZzypzYLYaWMVplu9CYpx0gxKYu9+V3GiOrtlshInuGMZe9uQy7wRgiFUUKClRSMf8CCT1jfCof9gFwqYCRuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2102.13",
+        "@angular-devkit/architect": "0.2102.14",
         "rxjs": "7.8.2"
       },
       "engines": {
@@ -433,9 +433,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "21.2.13",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.13.tgz",
-      "integrity": "sha512-9jLaHcUr6BumIY9nCsBib1q62p259nf++gd2igYJ7mLm1w/0wEacsZ1cC8wCGEe6vx8a+DrD+EVCQ6zivePG2A==",
+      "version": "21.2.14",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.14.tgz",
+      "integrity": "sha512-RSOWXB9bFc2nwRWMxbIT0RbSNFUrwfBo4N5MNxbyQ69Ndc0gVm3h+3ArHv0qotH4d+pJYbm5ttXu8YqR2kc0CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -461,13 +461,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "21.2.13",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.13.tgz",
-      "integrity": "sha512-gifpOcMNiAy49lQmQKhzpxoSfS3qJQSEdJSF5m7RVFkAcmllfcCD76GPN4dhho3wdAnbZ3qr54LtDqrGY4xNjw==",
+      "version": "21.2.14",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.14.tgz",
+      "integrity": "sha512-KMJlQSBEzI4+Cy1Zh72gmGQNN2I1vY+nj9CoRcZPBIi1si+0ZAc49XT85eYl+eQumNTVQviUG7LQqgLDAHml+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "21.2.13",
+        "@angular-devkit/core": "21.2.14",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.21",
         "ora": "9.3.0",
@@ -480,9 +480,9 @@
       }
     },
     "node_modules/@angular/animations": {
-      "version": "21.2.15",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.15.tgz",
-      "integrity": "sha512-Z8AsLTwc++Fcu0fJnclAF9zMfumAd5KXrwtSdyECqLpqd+lEmmsOpeOl6P7loqdDz99KYh/8UF4eJxdMvnsaKw==",
+      "version": "21.2.16",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.16.tgz",
+      "integrity": "sha512-YPhph/OC1A0vkT95XZW6lXMNmi5ly91JeXi+5yeG8CCxfqscVfRNPsYbRWjSueO0cQT2HJ8U1CLteQ5a1OaoHA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -491,18 +491,18 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "21.2.15"
+        "@angular/core": "21.2.16"
       }
     },
     "node_modules/@angular/build": {
-      "version": "21.2.13",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-21.2.13.tgz",
-      "integrity": "sha512-Y9TDAaTQ+E5LScCKA/hPZmns/7Mpu6J2BiPj2cETA1xNjvgRpeb5Mh32KuhZb20NSFLvjpdnLuBTTtbym7hevw==",
+      "version": "21.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-21.2.14.tgz",
+      "integrity": "sha512-l8JB326iIwum2WmbopUUFdiuYsbHchix6MH8o6F6FA7LJr8QLTvipwwbw+Jx31/RE50WkGmzsZ1fBDw/cMbmUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2102.13",
+        "@angular-devkit/architect": "0.2102.14",
         "@babel/core": "7.29.0",
         "@babel/helper-annotate-as-pure": "7.27.3",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -545,7 +545,7 @@
         "@angular/platform-browser": "^21.0.0",
         "@angular/platform-server": "^21.0.0",
         "@angular/service-worker": "^21.0.0",
-        "@angular/ssr": "^21.2.13",
+        "@angular/ssr": "^21.2.14",
         "karma": "^6.4.0",
         "less": "^4.2.0",
         "ng-packagr": "^21.0.0",
@@ -595,9 +595,9 @@
       }
     },
     "node_modules/@angular/cdk": {
-      "version": "21.2.13",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.2.13.tgz",
-      "integrity": "sha512-nQGGJ6Efqi8n0qhT/PllsaIIY+vz+TL7/tpR7F2QKiqzS/9l4m7ea0vvS6fSMGrjEbqbkzTHbjLDsIg6X2hK+w==",
+      "version": "21.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.2.14.tgz",
+      "integrity": "sha512-806REq/CLf37nEhmmd8Q+ILN8z/RVG2vk2n8YZ/4TdHpcBCi5ux4AxLbpMmduLwGPOzPagJ6ggRzE5fnX0rmcQ==",
       "license": "MIT",
       "dependencies": {
         "parse5": "^8.0.0",
@@ -611,19 +611,19 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "21.2.13",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-21.2.13.tgz",
-      "integrity": "sha512-j1kOV/f0og/3xCwG7Y8RyPd6V7uYfX2NuvXbvN1mzgxLLN2mu6CTsvPg5l/9Pu9SJI3KOPRgDxWyuP3k8KuzMg==",
+      "version": "21.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-21.2.14.tgz",
+      "integrity": "sha512-S8jExTjxPJILwpg2lu3DohSASVZ8DLhSNCmOe7z0qF9VskRSjC7SIQv1rq36tsJkenxuA72gjVOHZv+uSRT8HA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2102.13",
-        "@angular-devkit/core": "21.2.13",
-        "@angular-devkit/schematics": "21.2.13",
+        "@angular-devkit/architect": "0.2102.14",
+        "@angular-devkit/core": "21.2.14",
+        "@angular-devkit/schematics": "21.2.14",
         "@inquirer/prompts": "7.10.1",
         "@listr2/prompt-adapter-inquirer": "3.0.5",
         "@modelcontextprotocol/sdk": "1.26.0",
-        "@schematics/angular": "21.2.13",
+        "@schematics/angular": "21.2.14",
         "@yarnpkg/lockfile": "1.1.0",
         "algoliasearch": "5.48.1",
         "ini": "6.0.0",
@@ -646,9 +646,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "21.2.15",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.15.tgz",
-      "integrity": "sha512-PHbICQe4YCXnax2FcmKUpiffs8XPW9A0KlZF35qgJoQyBMBZx5F8c8geCh25jxtq77n3eBTmOa/WIAdSqiitkQ==",
+      "version": "21.2.16",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.16.tgz",
+      "integrity": "sha512-htHNepKzjIjkc5BQ7MKDN0bVDOfQpFr/fGUxa6irC0kFLfWt7idUTdNcxypRvjCCTuBYHkjr74fH4QKu+qvPXg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -657,14 +657,14 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "21.2.15",
+        "@angular/core": "21.2.16",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "21.2.15",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.15.tgz",
-      "integrity": "sha512-nwpNb+NbVUNzR3cck0QXbU/oFK7BpmXOXVnN/w7+P4+TsFUYeTtO1Ojbc15jkqe6mSM0lBvGlcoztVblHQkqcw==",
+      "version": "21.2.16",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.16.tgz",
+      "integrity": "sha512-hVjp93gYgNj5aRbCQUK7L+pOfdqk96lCtmSL2hOL725Pmib9NyNIrA3ISfAQHN+Qo70763WUZahOiqBBOzfAcg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -674,9 +674,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "21.2.15",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-21.2.15.tgz",
-      "integrity": "sha512-/MU7OA9d/e9P5SthR+N6JJObBmzcGsgNQaeQ2YfSUnU0lCRVQweTWwxLFDbfU6UX8MZFWB6pdI57zod8r5kXUw==",
+      "version": "21.2.16",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-21.2.16.tgz",
+      "integrity": "sha512-w2ck3o+uw29AZEGK3HvOsF/ZRiPcfoq2TaDtiNjdH+svhwawt9PfMXrDbbIKF30prWzKLpT3UsCqTz1awv7Ubw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -697,7 +697,7 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "21.2.15",
+        "@angular/compiler": "21.2.16",
         "typescript": ">=5.9 <6.1"
       },
       "peerDependenciesMeta": {
@@ -707,9 +707,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "21.2.15",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.15.tgz",
-      "integrity": "sha512-J5JsUnNtQURdeA7EA3DoCsMBizW3l01gfqM326Al72Ou3woFWmRb5P3LOXpIOzAeMQhO6Z5tW+B1t+4qmoq7uw==",
+      "version": "21.2.16",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.16.tgz",
+      "integrity": "sha512-uufKORlB0jeYdqOvjAfMYgqIqmJentOj8XvTUxsFP5k85xxzXsDarSpP199YQz6jhJJQYNOWIloDkUTQJi5rNA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -718,7 +718,7 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "21.2.15",
+        "@angular/compiler": "21.2.16",
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.15.0 || ~0.16.0"
       },
@@ -732,9 +732,9 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "21.2.15",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.15.tgz",
-      "integrity": "sha512-swGUHgbBrPNvODPR9qBP6+vT2EHiyW361iEgS3HpTmvDhF/kD4l8NE0vh3P5N0DnEtGh4umOCKfQ1w6hPJ7lqA==",
+      "version": "21.2.16",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.16.tgz",
+      "integrity": "sha512-2djTJmTpg/MkQ2kdCI9k0LT4RL9/Hg03fDUNN2eN5c04FIk99D3yHXUJYLwiaErLuLQNkU8HaijluKHdH93cWQ==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -744,22 +744,22 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "21.2.15",
-        "@angular/core": "21.2.15",
-        "@angular/platform-browser": "21.2.15",
+        "@angular/common": "21.2.16",
+        "@angular/core": "21.2.16",
+        "@angular/platform-browser": "21.2.16",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/material": {
-      "version": "21.2.13",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-21.2.13.tgz",
-      "integrity": "sha512-6gWFb9LNh4cRIvkdocktej6MUVuGa9HQvap+j9gbZOtiveD7ER+FByUPlLlypreRebF29G2MRZeshKSdmv4NbA==",
+      "version": "21.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-21.2.14.tgz",
+      "integrity": "sha512-fMQca8VRtei93JRRG9qQ+u08DCb0nga59Esoakq5yx3+A1NfdpFeUS1tBns56U04o8KAaIAwZK3NBqXz8ZKNqg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/cdk": "21.2.13",
+        "@angular/cdk": "21.2.14",
         "@angular/common": "^21.0.0 || ^22.0.0",
         "@angular/core": "^21.0.0 || ^22.0.0",
         "@angular/forms": "^21.0.0 || ^22.0.0",
@@ -768,9 +768,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "21.2.15",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.15.tgz",
-      "integrity": "sha512-O4ZHVV/rxkK1AuiD9M3UssL/HkoQvBcZy2+U421IMNibclGhwH9aRwc/0ZlQ7zpseS9+KPZ23FebvN4/92IbPg==",
+      "version": "21.2.16",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.16.tgz",
+      "integrity": "sha512-59ToWYDb+O3fS0+Y4ubQqV0zY6sf2esLZ19AT7JKXN7Akqbz7aQ2/3k3PKmfhwKWek5o3lkuNz8YhxKQruNh8Q==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -779,9 +779,9 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "21.2.15",
-        "@angular/common": "21.2.15",
-        "@angular/core": "21.2.15"
+        "@angular/animations": "21.2.16",
+        "@angular/common": "21.2.16",
+        "@angular/core": "21.2.16"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -790,9 +790,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "21.2.15",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-21.2.15.tgz",
-      "integrity": "sha512-3xvlWLZlsWjPyJFGatOOsod/f5AFjmSUDoOXo0zsr2ckHc4TxbDTnkLULhRSWv6m68fKOdQb8Si8rI15gC5yqA==",
+      "version": "21.2.16",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-21.2.16.tgz",
+      "integrity": "sha512-WtTnkJOmKiGccHRQfBdkwODAkpTB4zbPN3IKhcqCjlezKaPqZB5tjrIu72Z5pmi5VIgJz1LmfO1LSVCMC5h7dA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -801,16 +801,16 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "21.2.15",
-        "@angular/compiler": "21.2.15",
-        "@angular/core": "21.2.15",
-        "@angular/platform-browser": "21.2.15"
+        "@angular/common": "21.2.16",
+        "@angular/compiler": "21.2.16",
+        "@angular/core": "21.2.16",
+        "@angular/platform-browser": "21.2.16"
       }
     },
     "node_modules/@angular/router": {
-      "version": "21.2.15",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-21.2.15.tgz",
-      "integrity": "sha512-Cej4hYkmaTB6wXn1xQPlr4O1wHgUD0WLv//Oue1IssKqL8vkzic5f5x/H/bxtxxGlSnc+i6uIUF/lvjdGoWk/A==",
+      "version": "21.2.16",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-21.2.16.tgz",
+      "integrity": "sha512-0+Pyh0uT4vCLabKoGCARYWlwpz4DgZI9AE01n8s9u/nKAZuEMnJtLLnaUtHEMI8nJSqpgnS/5AthuJZdDEfkYw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -819,9 +819,9 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "21.2.15",
-        "@angular/core": "21.2.15",
-        "@angular/platform-browser": "21.2.15",
+        "@angular/common": "21.2.16",
+        "@angular/core": "21.2.16",
+        "@angular/platform-browser": "21.2.16",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -2964,9 +2964,9 @@
       }
     },
     "node_modules/@grafana/faro-core": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-2.7.0.tgz",
-      "integrity": "sha512-fNOfWEouoHhZ4dw+oLO+UGoMBLgiLLQU56dp9+NgO3mGNwCYsFTQuKgKQfOe5DDmAbwpRISEyLbiMkEyY7mIJQ==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-2.7.1.tgz",
+      "integrity": "sha512-qJOp0sPBAEsmUxhs11nVdGx5Dk+VJ4CN/4s9ek99m33FfzybmjQ9nPXLHWhwEeNJNiEwQdDl4HsNUlXBGT5YEw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -2974,12 +2974,12 @@
       }
     },
     "node_modules/@grafana/faro-web-sdk": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-2.7.0.tgz",
-      "integrity": "sha512-NIbFK2g634/KOcq6ej1LseZrbbRejBiIrO8beQpYX6CkyXVGrcdoWRfJdqkQ3Ys60h4aTH+xoAh2Oh0HebhOZg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-2.7.1.tgz",
+      "integrity": "sha512-ZK3MuE6FWBmiT5tTivcMovTVe8fG1tPm1ctc84blVoJkpQXlgODxOX7/fNmDBOjaHZ3EWdoGplZmjoXQ3g0mDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grafana/faro-core": "^2.7.0",
+        "@grafana/faro-core": "^2.7.1",
         "ua-parser-js": "1.0.41",
         "web-vitals": "^5.1.0"
       }
@@ -4474,9 +4474,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "21.2.13",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-21.2.13.tgz",
-      "integrity": "sha512-Y3W1x5+P8mHXRIkeSxGdj10ipQjJkTT6/bc/Sz5BN2qacbNIYIDg0fnk/ikvl9KAvI/49gUwYxfq4QBodS5ktQ==",
+      "version": "21.2.14",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-21.2.14.tgz",
+      "integrity": "sha512-HXt4pYLlWCJphO6TZoTsi2Z9Lyq/PqYpiKlqUmNoo/oIiSuXtoT/8+84Z/SfBdzeZpiVrAFz+/QGTVFoD8RSGg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5909,14 +5909,14 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "21.2.13",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-21.2.13.tgz",
-      "integrity": "sha512-e5guslSLKbb3PJ6gUuVqM+V9xgn68cJkG1IyBohho34shbpOeoWW2eYdWQQjxvn0KUdgEhYSRBluBamCHngaUA==",
+      "version": "21.2.14",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-21.2.14.tgz",
+      "integrity": "sha512-rIEdtNTdCCTwuo7B4tMoq5qmbLXdBgmW6Ays1hyno//4OE+HFtvlWZd+hl6KceEyN00IcZ2HRaPnfd71E1JnoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "21.2.13",
-        "@angular-devkit/schematics": "21.2.13",
+        "@angular-devkit/core": "21.2.14",
+        "@angular-devkit/schematics": "21.2.14",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
@@ -6543,18 +6543,18 @@
       }
     },
     "node_modules/ag-charts-types": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/ag-charts-types/-/ag-charts-types-13.3.0.tgz",
-      "integrity": "sha512-UMoAn908LC4ZIJSNfUckSBEFa79Mi1vFRA8qIRx+NusEuuFgXDioCZx4MxM7O3rDXlxTWH9DvQmcDjh7vyd89w==",
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/ag-charts-types/-/ag-charts-types-13.3.1.tgz",
+      "integrity": "sha512-m37eUe4g//swvGh8PWMlYQH3gknjSsPeW4sQwBhM3/auGAHmN0wvxEWlrdAn98pBPg4HoKbtOy+yf7gPCYsnvQ==",
       "license": "MIT"
     },
     "node_modules/ag-grid-angular": {
-      "version": "35.3.0",
-      "resolved": "https://registry.npmjs.org/ag-grid-angular/-/ag-grid-angular-35.3.0.tgz",
-      "integrity": "sha512-xZ5kUHtYOvExCwl8Y7DdwYOHXlWaMScQf6L9/08SToYCVsIY29WtgaGfG1j9QaXaikkp0ppAHPZ/6EG/mW/Pvw==",
+      "version": "35.3.1",
+      "resolved": "https://registry.npmjs.org/ag-grid-angular/-/ag-grid-angular-35.3.1.tgz",
+      "integrity": "sha512-oTM1Na5jI16nOyVfuFBiN/xDDoYRpjKTHxqgP4TGfFBM34Z8en/ZS9liE9AEg8LnfaXGXvYDkPXPnBYoWtX3wA==",
       "license": "MIT",
       "dependencies": {
-        "ag-grid-community": "35.3.0",
+        "ag-grid-community": "35.3.1",
         "tslib": "^2.8.1"
       },
       "peerDependencies": {
@@ -6563,12 +6563,12 @@
       }
     },
     "node_modules/ag-grid-community": {
-      "version": "35.3.0",
-      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-35.3.0.tgz",
-      "integrity": "sha512-c9WQWB88J965IjBC/GPUX30aAZix10o6oYT86DWipcxgLZTIQlLSilJJEr1bno/245rPEAIMjhoU1gp9VIfURg==",
+      "version": "35.3.1",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-35.3.1.tgz",
+      "integrity": "sha512-Wmkd/xYTCbAApcZZO74nBggZCnd/oX753NY3MJ4zYARVpfBHRWWhIBJ2sFTFKbDWwHZOWsx3YT9+kkyeuyLKlw==",
       "license": "MIT",
       "dependencies": {
-        "ag-charts-types": "13.3.0"
+        "ag-charts-types": "13.3.1"
       }
     },
     "node_modules/agent-base": {

--- a/client/package.json
+++ b/client/package.json
@@ -9,16 +9,16 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "21.2.15",
-    "@angular/cdk": "21.2.13",
-    "@angular/common": "21.2.15",
-    "@angular/compiler": "21.2.15",
-    "@angular/core": "21.2.15",
-    "@angular/forms": "21.2.15",
-    "@angular/material": "21.2.13",
-    "@angular/platform-browser": "21.2.15",
-    "@angular/platform-browser-dynamic": "21.2.15",
-    "@angular/router": "21.2.15",
+    "@angular/animations": "21.2.16",
+    "@angular/cdk": "21.2.14",
+    "@angular/common": "21.2.16",
+    "@angular/compiler": "21.2.16",
+    "@angular/core": "21.2.16",
+    "@angular/forms": "21.2.16",
+    "@angular/material": "21.2.14",
+    "@angular/platform-browser": "21.2.16",
+    "@angular/platform-browser-dynamic": "21.2.16",
+    "@angular/router": "21.2.16",
     "@grafana/faro-web-sdk": "^2.7.0",
     "@mucsi96/angular-material-theme": "^1.8.0",
     "ag-grid-angular": "^35.0.1",
@@ -30,11 +30,11 @@
     "zone.js": "0.16.2"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "21.2.13",
-    "@angular-devkit/core": "21.2.13",
-    "@angular/build": "21.2.13",
-    "@angular/cli": "21.2.13",
-    "@angular/compiler-cli": "21.2.15",
+    "@angular-devkit/build-angular": "21.2.14",
+    "@angular-devkit/core": "21.2.14",
+    "@angular/build": "21.2.14",
+    "@angular/cli": "21.2.14",
+    "@angular/compiler-cli": "21.2.16",
     "typescript": "5.9.3"
   }
 }

--- a/client/src/app/environment/environment.config.ts
+++ b/client/src/app/environment/environment.config.ts
@@ -11,6 +11,7 @@ export interface ImageModel {
   id: string;
   displayName: string;
   imageCount: number;
+  describedImageCount: number;
 }
 
 export interface AudioModel {

--- a/client/src/app/image-model-settings/image-model-settings.component.html
+++ b/client/src/app/image-model-settings/image-model-settings.component.html
@@ -23,7 +23,8 @@
             <thead>
               <tr>
                 <th class="model-header">Model</th>
-                <th class="count-header">Images per card</th>
+                <th class="count-header">Direct images per card</th>
+                <th class="count-header">Described images per card</th>
               </tr>
             </thead>
             <tbody>
@@ -38,7 +39,19 @@
                         [value]="model.imageCount"
                         (change)="onImageCountChange(model.id, $event)"
                         min="0"
-                        [attr.aria-label]="'Image count for ' + model.displayName"
+                        [attr.aria-label]="'Direct image count for ' + model.displayName"
+                      />
+                    </mat-form-field>
+                  </td>
+                  <td class="count-cell">
+                    <mat-form-field class="count-field">
+                      <input
+                        matInput
+                        type="number"
+                        [value]="model.describedImageCount"
+                        (change)="onDescribedImageCountChange(model.id, $event)"
+                        min="0"
+                        [attr.aria-label]="'Described image count for ' + model.displayName"
                       />
                     </mat-form-field>
                   </td>

--- a/client/src/app/image-model-settings/image-model-settings.component.ts
+++ b/client/src/app/image-model-settings/image-model-settings.component.ts
@@ -65,11 +65,23 @@ export class ImageModelSettingsComponent {
   }
 
   onImageCountChange(modelId: string, event: Event): void {
-    const input = event.target as HTMLInputElement;
-    const value = parseInt(input.value, 10);
-    if (!isNaN(value) && value >= 0) {
+    const value = this.parseCount(event);
+    if (value !== undefined) {
       this.service.updateImageCount(modelId, value);
     }
+  }
+
+  onDescribedImageCountChange(modelId: string, event: Event): void {
+    const value = this.parseCount(event);
+    if (value !== undefined) {
+      this.service.updateDescribedImageCount(modelId, value);
+    }
+  }
+
+  private parseCount(event: Event): number | undefined {
+    const input = event.target as HTMLInputElement;
+    const value = parseInt(input.value, 10);
+    return !isNaN(value) && value >= 0 ? value : undefined;
   }
 
   toggleUseEnglishForImageGeneration(): void {

--- a/client/src/app/image-model-settings/image-model-settings.service.ts
+++ b/client/src/app/image-model-settings/image-model-settings.service.ts
@@ -44,7 +44,9 @@ export class ImageModelSettingsService {
 
   private persistCounts(modelId: string): void {
     const model = this.imageModels().find((m) => m.id === modelId);
-    if (!model) return;
+    if (!model) {
+      throw new Error(`Image model not found: ${modelId}`);
+    }
 
     fetchJson<ImageModel>(this.http, '/api/image-model-settings', {
       method: 'PUT',

--- a/client/src/app/image-model-settings/image-model-settings.service.ts
+++ b/client/src/app/image-model-settings/image-model-settings.service.ts
@@ -9,6 +9,7 @@ import {
 export interface ImageModelSettingRequest {
   modelName: string;
   imageCount: number;
+  describedImageCount: number;
 }
 
 @Injectable({
@@ -29,12 +30,28 @@ export class ImageModelSettingsService {
     this.imageModels.update((models) =>
       models.map((m) => (m.id === modelId ? { ...m, imageCount } : m))
     );
+    this.persistCounts(modelId);
+  }
+
+  updateDescribedImageCount(modelId: string, describedImageCount: number): void {
+    this.imageModels.update((models) =>
+      models.map((m) =>
+        m.id === modelId ? { ...m, describedImageCount } : m
+      )
+    );
+    this.persistCounts(modelId);
+  }
+
+  private persistCounts(modelId: string): void {
+    const model = this.imageModels().find((m) => m.id === modelId);
+    if (!model) return;
 
     fetchJson<ImageModel>(this.http, '/api/image-model-settings', {
       method: 'PUT',
       body: {
         modelName: modelId,
-        imageCount,
+        imageCount: model.imageCount,
+        describedImageCount: model.describedImageCount,
       } satisfies ImageModelSettingRequest,
     });
   }

--- a/client/src/app/shared/image-resource.service.ts
+++ b/client/src/app/shared/image-resource.service.ts
@@ -38,51 +38,56 @@ export class ImageResourceService {
     placeholders: GridImageResource[];
     done: Promise<void>;
   } {
-    const imageModels = this.imageModelSettingsService.imageModels().filter(
-      (m) => m.imageCount > 0
-    );
+    const subtasks = this.imageModelSettingsService
+      .imageModels()
+      .filter((m) => m.imageCount > 0 || m.describedImageCount > 0)
+      .flatMap((model) => [
+        ...Array.from({ length: model.imageCount }, () => ({
+          model,
+          describe: false,
+        })),
+        ...Array.from({ length: model.describedImageCount }, () => ({
+          model,
+          describe: true,
+        })),
+      ]);
 
-    const allPending = imageModels.flatMap((model) =>
-      Array.from({ length: model.imageCount }, () =>
-        this.createPendingResource(model.displayName)
-      )
+    const pending = subtasks.map(({ model }) =>
+      this.createPendingResource(model.displayName)
     );
 
     const { imagePool } = this.rateLimitTokenService;
-    let pendingIdx = 0;
     const done = Promise.all(
-      imageModels.flatMap((model) =>
-        Array.from({ length: model.imageCount }, () => {
-          const idx = pendingIdx++;
-          return (async () => {
-            await imagePool.acquire();
-            try {
-              const response = await fetchJson<ImageResponse>(
-                this.http,
-                `/api/image`,
-                {
-                  body: {
-                    input,
-                    model: model.id,
-                    ...(context ? { context } : {}),
-                  } satisfies ImageSourceRequest,
-                  method: 'POST',
-                }
-              );
-              await allPending[idx].resolve({
-                id: response.id,
-                model: response.model,
-              });
-            } finally {
-              imagePool.release();
-            }
-          })();
-        })
+      subtasks.map(({ model, describe }, idx) =>
+        (async () => {
+          await imagePool.acquire();
+          try {
+            const response = await fetchJson<ImageResponse>(
+              this.http,
+              `/api/image`,
+              {
+                body: {
+                  input,
+                  model: model.id,
+                  describe,
+                  ...(context ? { context } : {}),
+                } satisfies ImageSourceRequest,
+                method: 'POST',
+              }
+            );
+            await pending[idx].resolve({
+              id: response.id,
+              model: response.model,
+            });
+          } finally {
+            imagePool.release();
+          }
+        })()
       )
     ).then(() => undefined);
 
     return {
-      placeholders: allPending.map((p) => p.gridResource),
+      placeholders: pending.map((p) => p.gridResource),
       done,
     };
   }

--- a/client/src/app/shared/image-resource.service.ts
+++ b/client/src/app/shared/image-resource.service.ts
@@ -5,6 +5,7 @@ import { ExampleImage } from '../parser/types';
 import { fetchAsset } from '../utils/fetchAsset';
 import { fetchJson } from '../utils/fetchJson';
 import { ImageResponse, ImageSourceRequest } from './types/image-generation.types';
+import { waitForImageReady } from '../utils/wait-for-image-ready';
 import { GridImageResource, GridImageValue } from './image-grid/image-grid.component';
 import { ImageModelSettingsService } from '../image-model-settings/image-model-settings.service';
 import { RateLimitTokenService } from '../rate-limit-token.service';
@@ -75,6 +76,7 @@ export class ImageResourceService {
                 method: 'POST',
               }
             );
+            await waitForImageReady(this.http, response.id);
             await pending[idx].resolve({
               id: response.id,
               model: response.model,

--- a/client/src/app/shared/types/image-generation.types.ts
+++ b/client/src/app/shared/types/image-generation.types.ts
@@ -2,6 +2,7 @@ export interface ImageSourceRequest {
   input: string;
   model: string;
   context?: string;
+  describe?: boolean;
 }
 
 export interface ImageResponse {

--- a/client/src/app/shared/types/image-generation.types.ts
+++ b/client/src/app/shared/types/image-generation.types.ts
@@ -2,7 +2,7 @@ export interface ImageSourceRequest {
   input: string;
   model: string;
   context?: string;
-  describe?: boolean;
+  describe: boolean;
 }
 
 export interface ImageResponse {

--- a/client/src/app/shared/types/image-generation.types.ts
+++ b/client/src/app/shared/types/image-generation.types.ts
@@ -5,7 +5,15 @@ export interface ImageSourceRequest {
   describe: boolean;
 }
 
+export type ImageJobStatus = 'pending' | 'completed' | 'failed';
+
 export interface ImageResponse {
   id: string;
   model: string;
+  status: ImageJobStatus;
+}
+
+export interface ImageJobStatusResponse {
+  status: ImageJobStatus;
+  error?: string;
 }

--- a/client/src/app/utils/image-generation.util.ts
+++ b/client/src/app/utils/image-generation.util.ts
@@ -13,31 +13,43 @@ export type ImagesByIndex = Map<number, ExampleImage[]>;
 
 export const generateExampleImages = async (
   http: HttpClient,
-  imageModels: ReadonlyArray<{ id: string; imageCount: number }>,
+  imageModels: ReadonlyArray<{
+    id: string;
+    imageCount: number;
+    describedImageCount: number;
+  }>,
   inputs: ReadonlyArray<ImageGenerationInput>,
   imageTokenPool: ToolPool,
   onToolsRequested?: () => void
 ): Promise<ImagesByIndex> => {
-  const activeModels = imageModels.filter((model) => model.imageCount > 0);
+  const activeModels = imageModels.filter(
+    (model) => model.imageCount > 0 || model.describedImageCount > 0
+  );
   if (inputs.length === 0 || activeModels.length === 0) {
     onToolsRequested?.();
     return new Map();
   }
 
   const subtasks = inputs.flatMap((input) =>
-    activeModels.flatMap((model) =>
-      Array.from({ length: model.imageCount }, () => ({
+    activeModels.flatMap((model) => [
+      ...Array.from({ length: model.imageCount }, () => ({
         input,
         model,
-      }))
-    )
+        describe: false,
+      })),
+      ...Array.from({ length: model.describedImageCount }, () => ({
+        input,
+        model,
+        describe: true,
+      })),
+    ])
   );
 
   const acquirePromises = subtasks.map(() => imageTokenPool.acquire());
   onToolsRequested?.();
 
   const results = await Promise.all(
-    subtasks.map(async ({ input, model }, i) => {
+    subtasks.map(async ({ input, model, describe }, i) => {
       await acquirePromises[i];
       try {
         const response = await fetchJson<ImageResponse>(
@@ -47,6 +59,7 @@ export const generateExampleImages = async (
             body: {
               input: input.input,
               model: model.id,
+              describe,
             } satisfies ImageSourceRequest,
             method: 'POST',
           }

--- a/client/src/app/utils/image-generation.util.ts
+++ b/client/src/app/utils/image-generation.util.ts
@@ -3,6 +3,7 @@ import { ExampleImage } from '../parser/types';
 import { ImageResponse, ImageSourceRequest } from '../shared/types/image-generation.types';
 import { fetchJson } from './fetchJson';
 import { ToolPool } from './tool-pool';
+import { waitForImageReady } from './wait-for-image-ready';
 
 export type ImageGenerationInput = {
   exampleIndex: number;
@@ -64,6 +65,7 @@ export const generateExampleImages = async (
             method: 'POST',
           }
         );
+        await waitForImageReady(http, response.id);
         return {
           exampleIndex: input.exampleIndex,
           image: { id: response.id, model: response.model } as ExampleImage,

--- a/client/src/app/utils/wait-for-image-ready.ts
+++ b/client/src/app/utils/wait-for-image-ready.ts
@@ -1,0 +1,38 @@
+import { HttpClient } from '@angular/common/http';
+import { ImageJobStatusResponse } from '../shared/types/image-generation.types';
+import { fetchJson } from './fetchJson';
+
+const POLL_INTERVAL_MS = 1000;
+const MAX_ATTEMPTS = 600;
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+export const waitForImageReady = async (
+  http: HttpClient,
+  id: string
+): Promise<void> => {
+  const poll = async (attempt: number): Promise<void> => {
+    const { status, error } = await fetchJson<ImageJobStatusResponse>(
+      http,
+      `/api/image/${id}/status`
+    );
+
+    if (status === 'completed') {
+      return;
+    }
+
+    if (status === 'failed') {
+      throw new Error(error ?? 'Image generation failed');
+    }
+
+    if (attempt >= MAX_ATTEMPTS) {
+      throw new Error('Image generation timed out');
+    }
+
+    await delay(POLL_INTERVAL_MS);
+    return poll(attempt + 1);
+  };
+
+  return poll(0);
+};

--- a/mock_anthropic_server/package-lock.json
+++ b/mock_anthropic_server/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@tsconfig/node-ts": "23.6.4",
         "@types/express": "5.0.6",
-        "@types/node": "25.9.1",
+        "@types/node": "25.9.2",
         "ts-node": "10.9.2",
         "typescript": "5.9.3"
       }
@@ -150,9 +150,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/mock_anthropic_server/package.json
+++ b/mock_anthropic_server/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@tsconfig/node-ts": "23.6.4",
     "@types/express": "5.0.6",
-    "@types/node": "25.9.1",
+    "@types/node": "25.9.2",
     "ts-node": "10.9.2",
     "typescript": "5.9.3"
   },

--- a/mock_elevenlabs_server/package-lock.json
+++ b/mock_elevenlabs_server/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@types/express": "5.0.6",
-        "@types/node": "25.9.1",
+        "@types/node": "25.9.2",
         "ts-node": "10.9.2",
         "typescript": "5.9.3"
       }
@@ -140,9 +140,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/mock_elevenlabs_server/package.json
+++ b/mock_elevenlabs_server/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@types/express": "5.0.6",
-    "@types/node": "25.9.1",
+    "@types/node": "25.9.2",
     "ts-node": "10.9.2",
     "typescript": "5.9.3"
   }

--- a/mock_google_ai_server/package-lock.json
+++ b/mock_google_ai_server/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@tsconfig/node-ts": "23.6.4",
         "@types/express": "5.0.6",
-        "@types/node": "25.9.1",
+        "@types/node": "25.9.2",
         "ts-node": "10.9.2",
         "typescript": "5.9.3"
       }
@@ -150,9 +150,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/mock_google_ai_server/package.json
+++ b/mock_google_ai_server/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@tsconfig/node-ts": "23.6.4",
     "@types/express": "5.0.6",
-    "@types/node": "25.9.1",
+    "@types/node": "25.9.2",
     "ts-node": "10.9.2",
     "typescript": "5.9.3"
   },

--- a/mock_google_ai_server/src/index.ts
+++ b/mock_google_ai_server/src/index.ts
@@ -68,27 +68,6 @@ app.post(
 );
 
 app.post(
-  '/v1beta/models/imagen-4.0-ultra-generate-001:predict',
-  (req, res) => {
-    try {
-      const prompt = req.body.instances[0].prompt;
-      console.log({ prompt });
-      const images = imageHandler.generateImages(prompt);
-      res.status(200).json({
-        predictions: images.map(imageBytes => ({
-          mimeType: 'image/png',
-          bytesBase64Encoded: imageBytes,
-        })),
-      });
-      console.log({ imageCount: images.length });
-    } catch (error) {
-      console.error('Imagen generation error:', error);
-      res.status(500).json({ error: { message: 'Image generation failed' } });
-    }
-  }
-);
-
-app.post(
   '/v1beta/models/gemini-3.1-flash-tts-preview:generateContent',
   (req, res) => {
     try {

--- a/mock_openai_server/package-lock.json
+++ b/mock_openai_server/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@tsconfig/node-ts": "23.6.4",
         "@types/express": "5.0.6",
-        "@types/node": "25.9.1",
+        "@types/node": "25.9.2",
         "ts-node": "10.9.2",
         "typescript": "5.9.3"
       }
@@ -150,9 +150,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/mock_openai_server/package.json
+++ b/mock_openai_server/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@tsconfig/node-ts": "23.6.4",
     "@types/express": "5.0.6",
-    "@types/node": "25.9.1",
+    "@types/node": "25.9.2",
     "ts-node": "10.9.2",
     "typescript": "5.9.3"
   },

--- a/mock_openai_server/src/index.ts
+++ b/mock_openai_server/src/index.ts
@@ -57,7 +57,7 @@ app.post('/chat/completions', async (req, res) => {
     res.status(200).json(result);
   } catch (error) {
     console.error('Chat completion error:', error);
-    res.status(400).json({ error: { message: error.message || 'Invalid request format' } });
+    res.status(400).json({ error: { message: error instanceof Error ? error.message : 'Invalid request format' } });
   }
 });
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>io.hypersistence</groupId>
       <artifactId>hypersistence-utils-hibernate-71</artifactId>
-      <version>3.15.2</version>
+      <version>3.15.3</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -150,7 +150,7 @@
       <dependency>
         <groupId>org.springframework.ai</groupId>
         <artifactId>spring-ai-bom</artifactId>
-        <version>2.0.0-M8</version>
+        <version>2.0.0-RC1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -142,6 +142,11 @@
       <groupId>org.springframework.ai</groupId>
       <artifactId>spring-ai-starter-model-google-genai</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.github.victools</groupId>
+      <artifactId>jsonschema-module-jackson</artifactId>
+      <version>5.0.0</version>
+    </dependency>
   </dependencies>
   <dependencyManagement>
     <dependencies>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -122,6 +122,11 @@
       <artifactId>spring-ai-starter-model-openai</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.openai</groupId>
+      <artifactId>openai-java-client-okhttp</artifactId>
+      <version>4.38.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.ai</groupId>
       <artifactId>spring-ai-starter-model-elevenlabs</artifactId>
     </dependency>

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/config/AsyncConfiguration.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/config/AsyncConfiguration.java
@@ -1,0 +1,22 @@
+package io.github.mucsi96.learnlanguage.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class AsyncConfiguration {
+
+  @Bean
+  Executor imageGenerationExecutor() {
+    final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(4);
+    executor.setMaxPoolSize(8);
+    executor.setQueueCapacity(100);
+    executor.setThreadNamePrefix("image-gen-");
+    executor.initialize();
+    return executor;
+  }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/config/ModelPricingConfig.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/config/ModelPricingConfig.java
@@ -43,8 +43,7 @@ public class ModelPricingConfig {
         "gpt-image-1.5", new ImageModelPricing(new BigDecimal("0.133")),
         "gpt-image-2", new ImageModelPricing(new BigDecimal("0.211")),
         // Gemini Developer API: 1,290 output tokens per 1024x1024 image at $30/M tokens
-        "gemini-3-pro-image-preview", new ImageModelPricing(new BigDecimal("0.134")),
-        "imagen-4.0-ultra-generate-001", new ImageModelPricing(new BigDecimal("0.06"))
+        "gemini-3-pro-image-preview", new ImageModelPricing(new BigDecimal("0.134"))
     );
 
     private static final Map<String, AudioModelPricing> AUDIO_MODEL_PRICING = Map.of(

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ImageController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ImageController.java
@@ -14,13 +14,15 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
-import io.github.mucsi96.learnlanguage.model.ExampleImageData;
+import io.github.mucsi96.learnlanguage.model.ImageGenerationJobStatus;
+import io.github.mucsi96.learnlanguage.model.ImageGenerationResponse;
+import io.github.mucsi96.learnlanguage.model.ImageJobStatusResponse;
 import io.github.mucsi96.learnlanguage.model.ImageSourceRequest;
 import io.github.mucsi96.learnlanguage.model.ModelType;
 import io.github.mucsi96.learnlanguage.repository.ModelUsageLogRepository;
-import io.github.mucsi96.learnlanguage.service.FfmpegService;
+import io.github.mucsi96.learnlanguage.service.AsyncImageGenerationService;
 import io.github.mucsi96.learnlanguage.service.FileStorageService;
-import io.github.mucsi96.learnlanguage.service.ImageService;
+import io.github.mucsi96.learnlanguage.service.ImageGenerationJobService;
 import io.github.mucsi96.learnlanguage.service.RateLimitSettingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -31,18 +33,17 @@ import org.springframework.http.ResponseEntity;
 public class ImageController {
 
   private final FileStorageService fileStorageService;
-  private final ImageService imageService;
-  private final FfmpegService ffmpegService;
+  private final AsyncImageGenerationService asyncImageGenerationService;
+  private final ImageGenerationJobService imageGenerationJobService;
   private final RateLimitSettingService rateLimitSettingService;
   private final ModelUsageLogRepository modelUsageLogRepository;
 
-  private static final int MAX_IMAGE_DIMENSION = 1200;
   private static final String IMAGE_WEBP_VALUE = "image/webp";
   private static final MediaType IMAGE_WEBP = MediaType.parseMediaType(IMAGE_WEBP_VALUE);
 
   @PostMapping("/image")
   @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
-  public ExampleImageData createImage(@Valid @RequestBody ImageSourceRequest imageSource) {
+  public ImageGenerationResponse createImage(@Valid @RequestBody ImageSourceRequest imageSource) {
     final int dailyLimit = rateLimitSettingService.getImageDailyLimit();
     if (dailyLimit > 0) {
       final long todayUsage = modelUsageLogRepository.countByModelTypeSince(
@@ -53,19 +54,24 @@ public class ImageController {
       }
     }
     final String displayName = imageSource.getModel().getDisplayName();
-    final byte[] data = imageService.generateImage(
-        imageSource.getInput(), imageSource.getContext(), imageSource.getModel(), imageSource.isDescribe());
-    final String uuid = UUID.randomUUID().toString();
-    final String filePath = "images/%s.webp".formatted(uuid);
-    try {
-      ffmpegService.resizeImage(
-          data, MAX_IMAGE_DIMENSION, MAX_IMAGE_DIMENSION, fileStorageService.resolveFilePath(filePath));
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to compress image: " + e.getMessage(), e);
-    }
-    return ExampleImageData.builder()
-        .id(uuid)
+    final UUID id = UUID.randomUUID();
+    imageGenerationJobService.createPending(id, displayName);
+    asyncImageGenerationService.generate(
+        id, imageSource.getInput(), imageSource.getContext(), imageSource.getModel(), imageSource.isDescribe());
+    return ImageGenerationResponse.builder()
+        .id(id.toString())
         .model(displayName)
+        .status(ImageGenerationJobStatus.PENDING.name().toLowerCase())
+        .build();
+  }
+
+  @GetMapping("/image/{id}/status")
+  @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
+  public ImageJobStatusResponse getImageStatus(@PathVariable String id) {
+    final var job = imageGenerationJobService.getJob(UUID.fromString(id));
+    return ImageJobStatusResponse.builder()
+        .status(job.getStatus().name().toLowerCase())
+        .error(job.getError())
         .build();
   }
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ImageController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ImageController.java
@@ -54,7 +54,7 @@ public class ImageController {
     }
     final String displayName = imageSource.getModel().getDisplayName();
     final byte[] data = imageService.generateImage(
-        imageSource.getInput(), imageSource.getContext(), imageSource.getModel());
+        imageSource.getInput(), imageSource.getContext(), imageSource.getModel(), imageSource.isDescribe());
     final String uuid = UUID.randomUUID().toString();
     final String filePath = "images/%s.webp".formatted(uuid);
     try {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ImageController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ImageController.java
@@ -5,6 +5,7 @@ import java.time.ZoneOffset;
 import java.util.UUID;
 
 import jakarta.validation.Valid;
+import org.springframework.core.task.TaskRejectedException;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -56,23 +57,37 @@ public class ImageController {
     final String displayName = imageSource.getModel().getDisplayName();
     final UUID id = UUID.randomUUID();
     imageGenerationJobService.createPending(id, displayName);
-    asyncImageGenerationService.generate(
-        id, imageSource.getInput(), imageSource.getContext(), imageSource.getModel(), imageSource.isDescribe());
+    try {
+      asyncImageGenerationService.generate(
+          id, imageSource.getInput(), imageSource.getContext(), imageSource.getModel(), imageSource.isDescribe());
+    } catch (TaskRejectedException e) {
+      imageGenerationJobService.markFailed(id, "Image generation queue is full");
+      throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
+          "Image generation is busy, please retry");
+    }
     return ImageGenerationResponse.builder()
         .id(id.toString())
         .model(displayName)
-        .status(ImageGenerationJobStatus.PENDING.name().toLowerCase())
+        .status(ImageGenerationJobStatus.PENDING)
         .build();
   }
 
   @GetMapping("/image/{id}/status")
   @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
   public ImageJobStatusResponse getImageStatus(@PathVariable String id) {
-    final var job = imageGenerationJobService.getJob(UUID.fromString(id));
+    final var job = imageGenerationJobService.getJob(parseId(id));
     return ImageJobStatusResponse.builder()
-        .status(job.getStatus().name().toLowerCase())
+        .status(job.getStatus())
         .error(job.getError())
         .build();
+  }
+
+  private UUID parseId(String id) {
+    try {
+      return UUID.fromString(id);
+    } catch (IllegalArgumentException e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid image id");
+    }
   }
 
   @GetMapping(value = "/image/{id}", produces = IMAGE_WEBP_VALUE)

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/entity/ImageGenerationJob.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/entity/ImageGenerationJob.java
@@ -1,0 +1,41 @@
+package io.github.mucsi96.learnlanguage.entity;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import io.github.mucsi96.learnlanguage.model.ImageGenerationJobStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "image_generation_jobs", schema = "learn_language")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageGenerationJob {
+
+  @Id
+  private UUID id;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private ImageGenerationJobStatus status;
+
+  @Column(nullable = false)
+  private String model;
+
+  @Column(columnDefinition = "text")
+  private String error;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/entity/ImageModelSetting.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/entity/ImageModelSetting.java
@@ -28,4 +28,7 @@ public class ImageModelSetting {
 
     @Column(name = "image_count", nullable = false)
     private Integer imageCount;
+
+    @Column(name = "described_image_count", nullable = false)
+    private Integer describedImageCount;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationJobStatus.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationJobStatus.java
@@ -1,0 +1,7 @@
+package io.github.mucsi96.learnlanguage.model;
+
+public enum ImageGenerationJobStatus {
+  PENDING,
+  COMPLETED,
+  FAILED
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationJobStatus.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationJobStatus.java
@@ -1,7 +1,14 @@
 package io.github.mucsi96.learnlanguage.model;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum ImageGenerationJobStatus {
   PENDING,
   COMPLETED,
-  FAILED
+  FAILED;
+
+  @JsonValue
+  public String toJson() {
+    return name().toLowerCase();
+  }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationModel.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationModel.java
@@ -12,9 +12,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ImageGenerationModel {
     GPT_IMAGE_1_5("gpt-image-1.5", "GPT Image 1.5"),
-    GEMINI_3_PRO_IMAGE_PREVIEW("gemini-3-pro-image-preview", "Gemini 3 Pro"),
     GPT_IMAGE_2("gpt-image-2", "GPT Image 2"),
-    IMAGEN_4_ULTRA("imagen-4.0-ultra-generate-001", "Imagen 4 Ultra");
+    GEMINI_3_PRO_IMAGE_PREVIEW("gemini-3-pro-image-preview", "Gemini 3 Pro");
 
     private final String modelName;
     private final String displayName;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationResponse.java
@@ -1,0 +1,12 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ImageGenerationResponse {
+  private String id;
+  private String model;
+  private String status;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationResponse.java
@@ -8,5 +8,5 @@ import lombok.Data;
 public class ImageGenerationResponse {
   private String id;
   private String model;
-  private String status;
+  private ImageGenerationJobStatus status;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageJobStatusResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageJobStatusResponse.java
@@ -1,0 +1,16 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ImageJobStatusResponse {
+  private String status;
+
+  @JsonInclude(Include.NON_NULL)
+  private String error;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageJobStatusResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageJobStatusResponse.java
@@ -9,7 +9,7 @@ import lombok.Data;
 @Data
 @Builder
 public class ImageJobStatusResponse {
-  private String status;
+  private ImageGenerationJobStatus status;
 
   @JsonInclude(Include.NON_NULL)
   private String error;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageModelResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageModelResponse.java
@@ -13,4 +13,5 @@ public class ImageModelResponse {
     private String id;
     private String displayName;
     private int imageCount;
+    private int describedImageCount;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageModelSettingRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageModelSettingRequest.java
@@ -19,4 +19,8 @@ public class ImageModelSettingRequest {
     @NotNull
     @Min(0)
     private Integer imageCount;
+
+    @NotNull
+    @Min(0)
+    private Integer describedImageCount;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageSourceRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageSourceRequest.java
@@ -20,4 +20,6 @@ public class ImageSourceRequest {
 
   @Size(max = 500)
   private String context;
+
+  private boolean describe;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/OperationType.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/OperationType.java
@@ -16,7 +16,7 @@ public enum OperationType {
     CLASSIFICATION("classification", "Classification", true),
     DUPLICATE_DETECTION("duplicate_detection", "Duplicate Detection", true),
     IMAGE_GENERATION("image_generation", "Image Generation", false),
-    IMAGE_DESCRIPTION("image_description", "Image Description", false),
+    IMAGE_DESCRIPTION("image_description", "Image Description", true),
     AUDIO_GENERATION("audio_generation", "Audio Generation", false),
     EXPLANATION("explanation", "Explanation", true),
     TRANSCRIPTION("transcription", "Transcription", false);

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/ImageGenerationJobRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/ImageGenerationJobRepository.java
@@ -1,0 +1,26 @@
+package io.github.mucsi96.learnlanguage.repository;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import io.github.mucsi96.learnlanguage.entity.ImageGenerationJob;
+import io.github.mucsi96.learnlanguage.model.ImageGenerationJobStatus;
+
+@Repository
+public interface ImageGenerationJobRepository extends JpaRepository<ImageGenerationJob, UUID> {
+
+  @Modifying
+  @Query("UPDATE ImageGenerationJob j SET j.status = :status, j.error = :error WHERE j.id = :id")
+  void updateStatus(
+      @Param("id") UUID id,
+      @Param("status") ImageGenerationJobStatus status,
+      @Param("error") String error);
+
+  int deleteByCreatedAtBefore(Instant cutoff);
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/AsyncImageGenerationService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/AsyncImageGenerationService.java
@@ -31,7 +31,7 @@ public class AsyncImageGenerationService {
       imageGenerationJobService.markCompleted(id);
     } catch (Exception e) {
       log.error("Image generation job {} failed", id, e);
-      imageGenerationJobService.markFailed(id, e.getMessage());
+      imageGenerationJobService.markFailed(id, "Image generation failed");
     }
   }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/AsyncImageGenerationService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/AsyncImageGenerationService.java
@@ -1,0 +1,37 @@
+package io.github.mucsi96.learnlanguage.service;
+
+import java.util.UUID;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import io.github.mucsi96.learnlanguage.model.ImageGenerationModel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AsyncImageGenerationService {
+
+  private static final int MAX_IMAGE_DIMENSION = 1200;
+
+  private final ImageService imageService;
+  private final FfmpegService ffmpegService;
+  private final FileStorageService fileStorageService;
+  private final ImageGenerationJobService imageGenerationJobService;
+
+  @Async("imageGenerationExecutor")
+  public void generate(UUID id, String input, String context, ImageGenerationModel model, boolean describe) {
+    try {
+      final byte[] data = imageService.generateImage(input, context, model, describe);
+      final String filePath = "images/%s.webp".formatted(id);
+      ffmpegService.resizeImage(
+          data, MAX_IMAGE_DIMENSION, MAX_IMAGE_DIMENSION, fileStorageService.resolveFilePath(filePath));
+      imageGenerationJobService.markCompleted(id);
+    } catch (Exception e) {
+      log.error("Image generation job {} failed", id, e);
+      imageGenerationJobService.markFailed(id, e.getMessage());
+    }
+  }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/GoogleImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/GoogleImageService.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Service;
 
 import com.google.genai.Client;
 import com.google.genai.types.GenerateContentConfig;
-import com.google.genai.types.GenerateImagesConfig;
 import com.google.genai.types.ImageConfig;
 
 import io.github.mucsi96.learnlanguage.model.OperationType;
@@ -40,24 +39,6 @@ public class GoogleImageService {
               .flatMap(java.util.List::stream))
           .flatMap(part -> part.inlineData().stream())
           .flatMap(data -> data.data().stream())
-          .findFirst()
-          .orElseThrow(() -> new RuntimeException("No image found in " + modelName + " response"));
-    });
-  }
-
-  public byte[] generateImagenImage(String input, String context, String modelName) {
-    return generateWithUsageLogging(modelName, () -> {
-      final GenerateImagesConfig config = GenerateImagesConfig.builder()
-          .numberOfImages(1)
-          .aspectRatio("1:1")
-          .build();
-
-      final String fullPrompt = ImagePromptBuilder.build(input, context);
-
-      return googleAiClient.models.generateImages(modelName, fullPrompt, config)
-          .generatedImages().orElseThrow(() -> new RuntimeException("No images in Imagen response")).stream()
-          .flatMap(generatedImage -> generatedImage.image().stream())
-          .flatMap(img -> img.imageBytes().stream())
           .findFirst()
           .orElseThrow(() -> new RuntimeException("No image found in " + modelName + " response"));
     });

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageGenerationJobService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageGenerationJobService.java
@@ -1,0 +1,62 @@
+package io.github.mucsi96.learnlanguage.service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import io.github.mucsi96.learnlanguage.entity.ImageGenerationJob;
+import io.github.mucsi96.learnlanguage.model.ImageGenerationJobStatus;
+import io.github.mucsi96.learnlanguage.repository.ImageGenerationJobRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ImageGenerationJobService {
+
+  static final Duration TTL = Duration.ofHours(1);
+
+  private final ImageGenerationJobRepository imageGenerationJobRepository;
+
+  @Transactional
+  public ImageGenerationJob createPending(UUID id, String model) {
+    return imageGenerationJobRepository.save(ImageGenerationJob.builder()
+        .id(id)
+        .status(ImageGenerationJobStatus.PENDING)
+        .model(model)
+        .createdAt(Instant.now())
+        .build());
+  }
+
+  @Transactional
+  public void markCompleted(UUID id) {
+    imageGenerationJobRepository.updateStatus(id, ImageGenerationJobStatus.COMPLETED, null);
+  }
+
+  @Transactional
+  public void markFailed(UUID id, String error) {
+    imageGenerationJobRepository.updateStatus(id, ImageGenerationJobStatus.FAILED, error);
+  }
+
+  @Transactional(readOnly = true)
+  public ImageGenerationJob getJob(UUID id) {
+    return imageGenerationJobRepository.findById(id)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Image generation job not found"));
+  }
+
+  @Scheduled(fixedRate = 3_600_000L)
+  @Transactional
+  public void cleanupOld() {
+    final int removed = imageGenerationJobRepository.deleteByCreatedAtBefore(Instant.now().minus(TTL));
+    if (removed > 0) {
+      log.info("Cleaned up {} old image generation job(s)", removed);
+    }
+  }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageModelSettingService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageModelSettingService.java
@@ -22,24 +22,22 @@ public class ImageModelSettingService {
     private final ImageModelSettingRepository imageModelSettingRepository;
 
     public List<ImageModelResponse> getImageModelsWithSettings() {
-        final Map<String, Integer> overrides = imageModelSettingRepository.findAll().stream()
+        final Map<String, ImageModelSetting> overrides = imageModelSettingRepository.findAll().stream()
                 .collect(Collectors.toMap(
                         ImageModelSetting::getModelName,
-                        ImageModelSetting::getImageCount));
+                        setting -> setting));
 
         return Arrays.stream(ImageGenerationModel.values())
-                .map(model -> ImageModelResponse.builder()
-                        .id(model.getModelName())
-                        .displayName(model.getDisplayName())
-                        .imageCount(overrides.getOrDefault(model.getModelName(), 0))
-                        .build())
+                .map(model -> {
+                    final ImageModelSetting setting = overrides.get(model.getModelName());
+                    return ImageModelResponse.builder()
+                            .id(model.getModelName())
+                            .displayName(model.getDisplayName())
+                            .imageCount(setting == null ? 0 : setting.getImageCount())
+                            .describedImageCount(setting == null ? 0 : setting.getDescribedImageCount())
+                            .build();
+                })
                 .toList();
-    }
-
-    public int getImageCount(ImageGenerationModel model) {
-        return imageModelSettingRepository.findByModelName(model.getModelName())
-                .map(ImageModelSetting::getImageCount)
-                .orElse(0);
     }
 
     @Transactional
@@ -50,10 +48,12 @@ public class ImageModelSettingService {
                 .findByModelName(request.getModelName())
                 .map(existing -> existing.toBuilder()
                         .imageCount(request.getImageCount())
+                        .describedImageCount(request.getDescribedImageCount())
                         .build())
                 .orElseGet(() -> ImageModelSetting.builder()
                         .modelName(request.getModelName())
                         .imageCount(request.getImageCount())
+                        .describedImageCount(request.getDescribedImageCount())
                         .build());
 
         final ImageModelSetting saved = imageModelSettingRepository.save(setting);
@@ -62,6 +62,7 @@ public class ImageModelSettingService {
                 .id(saved.getModelName())
                 .displayName(model.getDisplayName())
                 .imageCount(saved.getImageCount())
+                .describedImageCount(saved.getDescribedImageCount())
                 .build();
     }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageModelSettingService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageModelSettingService.java
@@ -3,6 +3,8 @@ package io.github.mucsi96.learnlanguage.service;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -23,18 +25,17 @@ public class ImageModelSettingService {
 
     public List<ImageModelResponse> getImageModelsWithSettings() {
         final Map<String, ImageModelSetting> overrides = imageModelSettingRepository.findAll().stream()
-                .collect(Collectors.toMap(
-                        ImageModelSetting::getModelName,
-                        setting -> setting));
+                .collect(Collectors.toMap(ImageModelSetting::getModelName, Function.identity()));
 
         return Arrays.stream(ImageGenerationModel.values())
                 .map(model -> {
-                    final ImageModelSetting setting = overrides.get(model.getModelName());
+                    final Optional<ImageModelSetting> setting = Optional
+                            .ofNullable(overrides.get(model.getModelName()));
                     return ImageModelResponse.builder()
                             .id(model.getModelName())
                             .displayName(model.getDisplayName())
-                            .imageCount(setting == null ? 0 : setting.getImageCount())
-                            .describedImageCount(setting == null ? 0 : setting.getDescribedImageCount())
+                            .imageCount(setting.map(ImageModelSetting::getImageCount).orElse(0))
+                            .describedImageCount(setting.map(ImageModelSetting::getDescribedImageCount).orElse(0))
                             .build();
                 })
                 .toList();

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
@@ -31,14 +31,15 @@ public class ImageService {
   private final ChatService chatService;
   private final ChatModelSettingService chatModelSettingService;
 
-  public byte[] generateImage(String input, String context, ImageGenerationModel model) {
+  public byte[] generateImage(String input, String context, ImageGenerationModel model, boolean describe) {
+    final String prompt = describe ? describeScene(input, context) : input;
+    final String imageContext = describe ? null : context;
+
     return switch (model) {
-      case GPT_IMAGE_1_5 -> openAIImageService.generateImage(input, context, model.getModelName());
-      case GEMINI_3_PRO_IMAGE_PREVIEW -> googleImageService.generateGeminiImage(input, context, model.getModelName());
-      case GPT_IMAGE_2 ->
-        openAIImageService.generateImage(describeScene(input, context), null, model.getModelName());
-      case IMAGEN_4_ULTRA ->
-        googleImageService.generateImagenImage(describeScene(input, context), null, model.getModelName());
+      case GPT_IMAGE_1_5, GPT_IMAGE_2 ->
+        openAIImageService.generateImage(prompt, imageContext, model.getModelName());
+      case GEMINI_3_PRO_IMAGE_PREVIEW ->
+        googleImageService.generateGeminiImage(prompt, imageContext, model.getModelName());
     };
   }
 
@@ -57,11 +58,11 @@ public class ImageService {
 
   private ChatModel resolveDescriptionModel() {
     final Map<OperationType, String> primaryModels = chatModelSettingService.getPrimaryModelByOperation();
-    final String modelName = primaryModels.get(OperationType.EXTRACTION);
+    final String modelName = primaryModels.get(OperationType.IMAGE_DESCRIPTION);
 
     if (modelName == null) {
       throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
-          "Image description requires a primary chat model configured for the extraction operation");
+          "Image description requires a primary chat model configured for the image description operation");
     }
 
     return ChatModel.fromString(modelName);

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -18,7 +18,6 @@ spring:
       connection-init-sql: CREATE SCHEMA IF NOT EXISTS learn_language
       maximum-pool-size: 20
       minimum-idle: 5
-      connection-timeout: 30000
       leak-detection-threshold: 30000
   jpa:
     open-in-view: false

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -16,7 +16,12 @@ spring:
     driver-class-name: org.postgresql.Driver
     hikari:
       connection-init-sql: CREATE SCHEMA IF NOT EXISTS learn_language
+      maximum-pool-size: 20
+      minimum-idle: 5
+      connection-timeout: 30000
+      leak-detection-threshold: 30000
   jpa:
+    open-in-view: false
     properties:
       hibernate:
         show-sql: true

--- a/server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -955,3 +955,16 @@ databaseChangeLog:
             referencedTableName: sources
             referencedColumnNames: id
             onDelete: CASCADE
+  - changeSet:
+      id: 29-add-described-image-count
+      author: mucsi96
+      changes:
+        - addColumn:
+            tableName: image_model_settings
+            columns:
+              - column:
+                  name: described_image_count
+                  type: int
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false

--- a/server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -968,3 +968,40 @@ databaseChangeLog:
                   defaultValueNumeric: 0
                   constraints:
                     nullable: false
+  - changeSet:
+      id: 30-create-image-generation-jobs-table
+      author: mucsi96
+      changes:
+        - createTable:
+            tableName: image_generation_jobs
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    primaryKey: true
+                    primaryKeyName: image_generation_jobs_pkey
+              - column:
+                  name: status
+                  type: varchar(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: model
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: error
+                  type: text
+              - column:
+                  name: created_at
+                  type: timestamp(6)
+                  constraints:
+                    nullable: false
+        - createIndex:
+            tableName: image_generation_jobs
+            indexName: image_generation_jobs_created_at_idx
+            columns:
+              - column:
+                  name: created_at

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@playwright/test": "1.60.0",
-        "@types/node": "25.9.1",
+        "@types/node": "25.9.2",
         "@types/pg": "8.20.0",
         "pg": "8.21.0",
         "typescript": "5.9.3"
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/test/package.json
+++ b/test/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@playwright/test": "1.60.0",
-    "@types/node": "25.9.1",
+    "@types/node": "25.9.2",
     "@types/pg": "8.20.0",
     "pg": "8.21.0",
     "typescript": "5.9.3"

--- a/test/tests/chat-model-settings.spec.ts
+++ b/test/tests/chat-model-settings.spec.ts
@@ -19,7 +19,7 @@ test('displays matrix with all chat models and operation types', async ({ page }
   await expect(page.getByText('Translation')).toBeVisible();
   await expect(page.getByText('Extraction')).toBeVisible();
   await expect(page.getByText('Classification')).toBeVisible();
-  await expect(page.getByText('Image Description')).not.toBeAttached();
+  await expect(page.getByText('Image Description')).toBeVisible();
 });
 
 test('can set primary model for operation type', async ({ page }) => {

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -359,9 +359,13 @@ test('favorite toggle on newly generated image', async ({ page }) => {
   });
 });
 
-test('generates image with virtual two-stage model', async ({ page }) => {
+test('generates described image with Gemini model', async ({ page }) => {
   await setupDefaultChatModelSettings();
-  await createImageModelSetting({ modelName: 'imagen-4.0-ultra-generate-001', imageCount: 1 });
+  await createImageModelSetting({
+    modelName: 'gemini-3-pro-image-preview',
+    imageCount: 0,
+    describedImageCount: 1,
+  });
   const image1 = uploadMockImage(blueImage);
   await createCard({
     cardId: 'abfahren-elindulni',
@@ -392,7 +396,7 @@ test('generates image with virtual two-stage model', async ({ page }) => {
   await page.getByRole('button', { name: 'Add example image' }).first().click();
   await expect(page.getByRole('img')).toHaveCount(2);
 
-  await expect(page.getByText('Imagen 4 Ultra')).toHaveCount(1);
+  await expect(page.getByText('Gemini 3 Pro')).toHaveCount(1);
 
   const generatedImageContent = await getImageContent(
     page.getByRole('img', { name: 'Wann fährt der Zug ab?' }).nth(1)
@@ -409,12 +413,12 @@ test('generates image with virtual two-stage model', async ({ page }) => {
   const generationLog = logs.find((log) => log.operationType === 'IMAGE_GENERATION');
   expect(generationLog).toBeDefined();
   expect(generationLog!.modelType).toBe('IMAGE');
-  expect(generationLog!.modelName).toBe('imagen-4.0-ultra-generate-001');
+  expect(generationLog!.modelName).toBe('gemini-3-pro-image-preview');
 });
 
-test('generates image with virtual two-stage model using OpenAI models', async ({ page }) => {
+test('generates described image with OpenAI models', async ({ page }) => {
   await Promise.all(
-    ['TRANSLATION', 'EXTRACTION', 'CLASSIFICATION', 'EXPLANATION'].map((operationType) =>
+    ['TRANSLATION', 'EXTRACTION', 'CLASSIFICATION', 'EXPLANATION', 'IMAGE_DESCRIPTION'].map((operationType) =>
       createChatModelSetting({
         modelName: 'gpt-5.2',
         operationType,
@@ -423,7 +427,11 @@ test('generates image with virtual two-stage model using OpenAI models', async (
       })
     )
   );
-  await createImageModelSetting({ modelName: 'gpt-image-2', imageCount: 1 });
+  await createImageModelSetting({
+    modelName: 'gpt-image-2',
+    imageCount: 0,
+    describedImageCount: 1,
+  });
   const image1 = uploadMockImage(blueImage);
   await createCard({
     cardId: 'abfahren-elindulni',
@@ -835,7 +843,7 @@ test('image model name displayed below image', async ({ page }) => {
           ch: 'Mir fahred am zwöufi ab.',
           images: [
             { id: image1, model: 'GPT Image 1' },
-            { id: image2, model: 'Imagen 4 Ultra' },
+            { id: image2, model: 'Gemini 3 Pro' },
           ],
         },
       ],
@@ -845,7 +853,7 @@ test('image model name displayed below image', async ({ page }) => {
   await navigateToCardEditing(page);
 
   await expect(page.getByText('GPT Image 1')).toBeVisible();
-  await expect(page.getByText('Imagen 4 Ultra')).toBeVisible();
+  await expect(page.getByText('Gemini 3 Pro')).toBeVisible();
 });
 
 test('speech card editing page displays sentence and translations', async ({ page }) => {

--- a/test/tests/image-model-settings.spec.ts
+++ b/test/tests/image-model-settings.spec.ts
@@ -21,39 +21,41 @@ test('displays all image models with default image counts', async ({ page }) => 
   await expect(page.getByText('GPT Image 1.5')).toBeVisible();
   await expect(page.getByText('Gemini 3 Pro')).toBeVisible();
   await expect(page.getByText('GPT Image 2')).toBeVisible();
-  await expect(page.getByText('Imagen 4 Ultra')).toBeVisible();
+  await expect(page.getByText('Imagen 4 Ultra')).toHaveCount(0);
 
-  const gptInput = page.getByRole('spinbutton', { name: 'Image count for GPT Image 1.5' });
-  const geminiInput = page.getByRole('spinbutton', { name: 'Image count for Gemini 3 Pro' });
-  const gptImage2Input = page.getByRole('spinbutton', { name: 'Image count for GPT Image 2' });
-  const imagenUltraInput = page.getByRole('spinbutton', { name: 'Image count for Imagen 4 Ultra' });
+  const gptInput = page.getByRole('spinbutton', { name: 'Direct image count for GPT Image 1.5' });
+  const geminiInput = page.getByRole('spinbutton', { name: 'Direct image count for Gemini 3 Pro' });
+  const gptImage2Input = page.getByRole('spinbutton', { name: 'Direct image count for GPT Image 2' });
+  const gptDescribedInput = page.getByRole('spinbutton', { name: 'Described image count for GPT Image 1.5' });
 
   await expect(gptInput).toHaveValue('0');
   await expect(geminiInput).toHaveValue('0');
   await expect(gptImage2Input).toHaveValue('0');
-  await expect(imagenUltraInput).toHaveValue('0');
+  await expect(gptDescribedInput).toHaveValue('0');
 });
 
 test('displays image counts from database settings', async ({ page }) => {
-  await createImageModelSetting({ modelName: 'gpt-image-1.5', imageCount: 2 });
+  await createImageModelSetting({ modelName: 'gpt-image-1.5', imageCount: 2, describedImageCount: 1 });
   await createImageModelSetting({ modelName: 'gemini-3-pro-image-preview', imageCount: 5 });
   await createImageModelSetting({ modelName: 'gpt-image-2', imageCount: 3 });
 
   await page.goto('/settings/image-models');
 
-  const gptInput = page.getByRole('spinbutton', { name: 'Image count for GPT Image 1.5' });
-  const geminiInput = page.getByRole('spinbutton', { name: 'Image count for Gemini 3 Pro' });
-  const gptImage2Input = page.getByRole('spinbutton', { name: 'Image count for GPT Image 2' });
+  const gptInput = page.getByRole('spinbutton', { name: 'Direct image count for GPT Image 1.5' });
+  const geminiInput = page.getByRole('spinbutton', { name: 'Direct image count for Gemini 3 Pro' });
+  const gptImage2Input = page.getByRole('spinbutton', { name: 'Direct image count for GPT Image 2' });
+  const gptDescribedInput = page.getByRole('spinbutton', { name: 'Described image count for GPT Image 1.5' });
 
   await expect(gptInput).toHaveValue('2');
   await expect(geminiInput).toHaveValue('5');
   await expect(gptImage2Input).toHaveValue('3');
+  await expect(gptDescribedInput).toHaveValue('1');
 });
 
-test('can update image count for a model', async ({ page }) => {
+test('can update direct image count for a model', async ({ page }) => {
   await page.goto('/settings/image-models');
 
-  const gptInput = page.getByRole('spinbutton', { name: 'Image count for GPT Image 1.5' });
+  const gptInput = page.getByRole('spinbutton', { name: 'Direct image count for GPT Image 1.5' });
   await gptInput.fill('4');
   await gptInput.dispatchEvent('change');
 
@@ -65,18 +67,18 @@ test('can update image count for a model', async ({ page }) => {
   }).toPass();
 });
 
-test('can update image count for a virtual model', async ({ page }) => {
+test('can update described image count for a model', async ({ page }) => {
   await page.goto('/settings/image-models');
 
-  const imagenUltraInput = page.getByRole('spinbutton', { name: 'Image count for Imagen 4 Ultra' });
-  await imagenUltraInput.fill('2');
-  await imagenUltraInput.dispatchEvent('change');
+  const describedInput = page.getByRole('spinbutton', { name: 'Described image count for GPT Image 2' });
+  await describedInput.fill('2');
+  await describedInput.dispatchEvent('change');
 
   await expect(async () => {
     const settings = await getImageModelSettings();
-    const imagenUltraSetting = settings.find((s) => s.modelName === 'imagen-4.0-ultra-generate-001');
-    expect(imagenUltraSetting).toBeDefined();
-    expect(imagenUltraSetting!.imageCount).toBe(2);
+    const setting = settings.find((s) => s.modelName === 'gpt-image-2');
+    expect(setting).toBeDefined();
+    expect(setting!.describedImageCount).toBe(2);
   }).toPass();
 });
 

--- a/test/tests/image-model-settings.spec.ts
+++ b/test/tests/image-model-settings.spec.ts
@@ -27,11 +27,15 @@ test('displays all image models with default image counts', async ({ page }) => 
   const geminiInput = page.getByRole('spinbutton', { name: 'Direct image count for Gemini 3 Pro' });
   const gptImage2Input = page.getByRole('spinbutton', { name: 'Direct image count for GPT Image 2' });
   const gptDescribedInput = page.getByRole('spinbutton', { name: 'Described image count for GPT Image 1.5' });
+  const geminiDescribedInput = page.getByRole('spinbutton', { name: 'Described image count for Gemini 3 Pro' });
+  const gptImage2DescribedInput = page.getByRole('spinbutton', { name: 'Described image count for GPT Image 2' });
 
   await expect(gptInput).toHaveValue('0');
   await expect(geminiInput).toHaveValue('0');
   await expect(gptImage2Input).toHaveValue('0');
   await expect(gptDescribedInput).toHaveValue('0');
+  await expect(geminiDescribedInput).toHaveValue('0');
+  await expect(gptImage2DescribedInput).toHaveValue('0');
 });
 
 test('displays image counts from database settings', async ({ page }) => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -851,6 +851,7 @@ const ALL_OPERATION_TYPES = [
   'EXTRACTION',
   'CLASSIFICATION',
   'EXPLANATION',
+  'IMAGE_DESCRIPTION',
 ];
 
 const DEFAULT_CHAT_MODEL = 'gemini-3.1-pro-preview';
@@ -895,16 +896,17 @@ export async function getChatModelSettings(): Promise<
 export async function createImageModelSetting(params: {
   modelName: string;
   imageCount: number;
+  describedImageCount?: number;
 }): Promise<number> {
-  const { modelName, imageCount } = params;
+  const { modelName, imageCount, describedImageCount = 0 } = params;
 
   return await withDbConnection(async (client) => {
     const result = await client.query(
-      `INSERT INTO learn_language.image_model_settings (model_name, image_count)
-       VALUES ($1, $2)
-       ON CONFLICT (model_name) DO UPDATE SET image_count = $2
+      `INSERT INTO learn_language.image_model_settings (model_name, image_count, described_image_count)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (model_name) DO UPDATE SET image_count = $2, described_image_count = $3
        RETURNING id`,
-      [modelName, imageCount]
+      [modelName, imageCount, describedImageCount]
     );
     return result.rows[0].id;
   });
@@ -930,11 +932,13 @@ export async function getImageModelSettings(): Promise<
     id: number;
     modelName: string;
     imageCount: number;
+    describedImageCount: number;
   }>
 > {
   return await withDbConnection(async (client) => {
     const result = await client.query(
-      `SELECT id, model_name as "modelName", image_count as "imageCount"
+      `SELECT id, model_name as "modelName", image_count as "imageCount",
+              described_image_count as "describedImageCount"
        FROM learn_language.image_model_settings
        ORDER BY id`
     );


### PR DESCRIPTION
## Summary
This PR refactors image generation to be asynchronous with job status tracking. Instead of blocking until an image is generated, the API now returns immediately with a job ID, and clients poll for completion status. Additionally, it introduces support for "described images" - a two-stage generation process where text descriptions are generated first, then used as prompts for image generation.

## Key Changes

### Backend
- **Async Image Generation**: Created `AsyncImageGenerationService` to handle image generation in a background thread pool (4-8 threads) instead of blocking the HTTP request
- **Job Tracking**: Added `ImageGenerationJob` entity and `ImageGenerationJobRepository` to track generation status (PENDING, COMPLETED, FAILED)
- **Job Status Endpoint**: Added `/api/image/{id}/status` endpoint to query job completion status and error messages
- **Automatic Cleanup**: Scheduled task to clean up old jobs after 1 hour TTL
- **Described Images**: Modified `ImageService.generateImage()` to accept a `describe` flag; when true, generates a text description first, then uses it as the image prompt
- **Model Configuration**: Added `describedImageCount` field to `ImageModelSetting` to allow configuring how many described images to generate per card
- **Removed Imagen Model**: Removed support for Imagen 4 Ultra model

### Frontend
- **Job Status Polling**: Created `waitForImageReady()` utility that polls the status endpoint with 1-second intervals (max 10 minutes timeout)
- **Described Image Support**: Updated image generation to handle both direct and described image requests based on model settings
- **UI Updates**: Modified image model settings UI to show separate controls for "Direct images per card" and "Described images per card"
- **Request Format**: Added `describe` boolean flag to `ImageSourceRequest`

### Database
- Added `described_image_count` column to `image_model_settings` table
- Created new `image_generation_jobs` table with status tracking and TTL index

### Configuration
- Added `AsyncConfiguration` with thread pool executor bean for image generation tasks
- Updated database connection pool settings (max 20, min 5)
- Updated dependency versions (hypersistence-utils, @types/node)

## Implementation Details
- Image generation now returns immediately with job ID and initial PENDING status
- Clients must poll `/api/image/{id}/status` to wait for completion
- The two-stage described image flow: input → description generation → image generation from description
- Rate limiting still applies at the request level; background jobs don't consume additional tokens
- Failed jobs store error messages for client debugging

https://claude.ai/code/session_01BtMfykVCHJVnK7WgnH7EaJ