### PR TITLE
Show Hungarian translation above sentence in grammar cards

### DIFF
--- a/client/src/app/study/learn-grammar-card/learn-grammar-card.component.html
+++ b/client/src/app/study/learn-grammar-card/learn-grammar-card.component.html
@@ -13,13 +13,13 @@
   }
 
   <div class="sentence-section">
+    @if (hungarianTranslation()) {
+      <p class="translation-text" aria-label="Hungarian translation">{{ hungarianTranslation() }}</p>
+    }
     <p class="sentence-text">@for (part of sentenceParts(); track $index) {<span
         [class.gap-word]="part.isGap"
         [class.masked]="part.isGap && !isRevealed()"
         [class.highlighted]="part.isGap && isRevealed()"
       >{{ part.text }}</span>}</p>
-    @if (isRevealed() && hungarianTranslation()) {
-      <p class="translation-text" aria-label="Hungarian translation">{{ hungarianTranslation() }}</p>
-    }
   </div>
 </div>

--- a/test/tests/study-page.spec.ts
+++ b/test/tests/study-page.spec.ts
@@ -1242,13 +1242,49 @@ test('grammar card study shows sentence with gaps on front, full sentence on rev
   const flashcard = page.getByRole('article', { name: 'Flashcard' });
   await expect(flashcard.locator('.gap-word.masked')).toBeVisible();
   await expect(flashcard.locator('.gap-word.masked')).toHaveText('jeden');
-  await expect(flashcard.getByLabel('Hungarian translation')).toHaveCount(0);
+  await expect(flashcard.getByLabel('Hungarian translation')).toHaveText('Minden nap iskolába megyek.');
 
   await flashcard.getByText('Ich gehe').click();
 
   await expect(flashcard.locator('.gap-word.highlighted')).toBeVisible();
   await expect(flashcard.locator('.gap-word.highlighted')).toHaveText('jeden');
   await expect(flashcard.getByLabel('Hungarian translation')).toHaveText('Minden nap iskolába megyek.');
+});
+
+test('grammar card shows Hungarian translation above the sentence on both sides', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await createCard({
+    cardId: 'grammar-translation-order-card',
+    sourceId: 'grammar-a1',
+    sourcePageNumber: 9,
+    data: {
+      examples: [
+        {
+          de: 'Wir [fahren] nach Hause.',
+          hu: 'Hazamegyünk.',
+          isSelected: true,
+        },
+      ],
+      audio: [{ id: 'translation-order-audio', text: 'Wir fahren nach Hause.', language: 'de' }],
+    },
+  });
+
+  await page.goto('/sources/grammar-a1/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
+
+  const flashcard = page.getByRole('article', { name: 'Flashcard' });
+  await expect(flashcard.getByLabel('Hungarian translation')).toHaveText('Hazamegyünk.');
+
+  const frontTranslationBox = await flashcard.getByLabel('Hungarian translation').boundingBox();
+  const frontSentenceBox = await flashcard.locator('.gap-word.masked').boundingBox();
+  expect(frontTranslationBox!.y).toBeLessThan(frontSentenceBox!.y);
+
+  await flashcard.getByText('Wir').click();
+
+  await expect(flashcard.getByLabel('Hungarian translation')).toHaveText('Hazamegyünk.');
+  const backTranslationBox = await flashcard.getByLabel('Hungarian translation').boundingBox();
+  const backSentenceBox = await flashcard.locator('.gap-word.highlighted').boundingBox();
+  expect(backTranslationBox!.y).toBeLessThan(backSentenceBox!.y);
 });
 
 test('grammar card study shows German hint on front when present', async ({ page }) => {


### PR DESCRIPTION
## Summary
Updated the grammar card component to display the Hungarian translation above the sentence on both the front and back sides of the card, rather than only showing it on the back after revealing the answer.

## Changes
- **Component template**: Moved the Hungarian translation display from a conditional that only shows when `isRevealed()` is true to always display above the sentence when available
- **Test updates**: 
  - Updated existing test to expect the Hungarian translation to be visible on the front side
  - Added new test `grammar card shows Hungarian translation above the sentence on both sides` to verify the translation appears above the sentence on both sides and validate the visual ordering using bounding box assertions

## Implementation Details
The Hungarian translation now appears in the DOM immediately, positioned above the sentence text on both the front (masked) and back (revealed) sides of the card. This provides better context to learners from the start of the study session.

https://claude.ai/code/session_017Uim8U7BKwFbe54qcjDmk2