### PR TITLE
Add AI Prompt source type with card generation and coverage analysis

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -22,6 +22,7 @@
         "@mucsi96/angular-material-theme": "^1.8.0",
         "ag-grid-angular": "^35.0.1",
         "ag-grid-community": "^35.0.1",
+        "marked": "^15.0.12",
         "oidc-client-ts": "^3.1.0",
         "rxjs": "7.8.2",
         "ts-fsrs": "5.4.1",
@@ -9902,6 +9903,18 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {

--- a/client/package.json
+++ b/client/package.json
@@ -23,6 +23,7 @@
     "@mucsi96/angular-material-theme": "^1.8.0",
     "ag-grid-angular": "^35.0.1",
     "ag-grid-community": "^35.0.1",
+    "marked": "^15.0.12",
     "oidc-client-ts": "^3.1.0",
     "rxjs": "7.8.2",
     "ts-fsrs": "5.4.1",

--- a/client/src/app/admin/admin.component.ts
+++ b/client/src/app/admin/admin.component.ts
@@ -109,6 +109,10 @@ export class AdminComponent {
   }
 
   navigateToPages(source: Source): void {
+    if (source.sourceType === 'aiPrompt') {
+      this.router.navigate(['/sources', source.id, 'prompt']);
+      return;
+    }
     this.router.navigate(['/sources', source.id, 'page', source.startPage]);
   }
 

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -141,6 +141,29 @@ export const routes: Routes = [
     ],
   },
   {
+    path: 'sources/:sourceId/prompt',
+    canActivate: [authGuard],
+    title: (route) => `Prompt / ${route.params['sourceId']}`,
+    children: [
+      {
+        path: '',
+        outlet: 'source-selector',
+        loadComponent: () =>
+          import('./shared/source-selector/source-selector.component').then(
+            (m) => m.SourceSelectorComponent
+          ),
+        data: { mode: 'admin' },
+      },
+      {
+        path: '',
+        loadComponent: () =>
+          import('./parser/prompt-page/prompt-page.component').then(
+            (m) => m.PromptPageComponent
+          ),
+      },
+    ],
+  },
+  {
     path: 'sources/:sourceId/cards',
     canActivate: [authGuard],
     title: 'Cards',

--- a/client/src/app/cardTypes/card-type.registry.ts
+++ b/client/src/app/cardTypes/card-type.registry.ts
@@ -2,6 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { VocabularyCardType } from './vocabulary-card-type.strategy';
 import { SpeechCardType } from './speech-card-type.strategy';
 import { GrammarCardType } from './grammar-card-type.strategy';
+import { SimpleCardType } from './simple-card-type.strategy';
 import { CardTypeStrategy, CardType } from '../parser/types';
 
 @Injectable({
@@ -11,6 +12,7 @@ export class CardTypeRegistry {
   private readonly vocabularyStrategy = inject(VocabularyCardType);
   private readonly speechStrategy = inject(SpeechCardType);
   private readonly grammarStrategy = inject(GrammarCardType);
+  private readonly simpleStrategy = inject(SimpleCardType);
 
   getStrategy(cardType: CardType | undefined): CardTypeStrategy {
     switch (cardType) {
@@ -20,6 +22,8 @@ export class CardTypeRegistry {
         return this.speechStrategy;
       case 'grammar':
         return this.grammarStrategy;
+      case 'simple':
+        return this.simpleStrategy;
       default:
         throw new Error(`Unknown card type: ${cardType}. Please configure a valid card type.`);
     }

--- a/client/src/app/cardTypes/simple-card-type.strategy.ts
+++ b/client/src/app/cardTypes/simple-card-type.strategy.ts
@@ -1,0 +1,78 @@
+import { Injectable } from '@angular/core';
+import {
+  CardTypeStrategy,
+  CardType,
+  ExtractionRequest,
+  ExtractedItem,
+  AudioGenerationItem,
+  BulkCreationContext,
+  Card,
+  CardData,
+  LanguageTexts,
+} from '../parser/types';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SimpleCardType implements CardTypeStrategy {
+  readonly cardType: CardType = 'simple';
+
+  async extractItems(_request: ExtractionRequest): Promise<ExtractedItem[]> {
+    return [];
+  }
+
+  getItemLabel(item: ExtractedItem & { frontText?: string }): string {
+    return item.frontText ?? item.id;
+  }
+
+  filterItemsBySearchTerm(
+    items: (ExtractedItem & { frontText?: string })[],
+    searchTerm: string
+  ): ExtractedItem[] {
+    const lowerSearchTerm = searchTerm.toLowerCase();
+    return items.filter((item) =>
+      (item.frontText ?? '').toLowerCase().includes(lowerSearchTerm)
+    );
+  }
+
+  createDraftCardData(item: ExtractedItem, _context?: BulkCreationContext): CardData {
+    const simple = item as ExtractedItem & {
+      frontText?: string;
+      backText?: string;
+      topic?: string;
+    };
+    return {
+      frontText: simple.frontText,
+      backText: simple.backText,
+      ...(simple.topic ? { topic: simple.topic } : {}),
+    };
+  }
+
+  async createCardData(cardData: CardData): Promise<CardData> {
+    return cardData;
+  }
+
+  requiredAudioLanguages(): string[] {
+    return [];
+  }
+
+  getCardDisplayLabel(card: Card): string {
+    return card.data.frontText ?? card.id;
+  }
+
+  getCardTypeLabel(_card: Card): string {
+    return 'Simple';
+  }
+
+  getCardAdditionalInfo(card: Card): string | undefined {
+    return card.data.topic;
+  }
+
+  getAudioItems(_card: Card): AudioGenerationItem[] {
+    return [];
+  }
+
+  getLanguageTexts(_card: Card): LanguageTexts[] {
+    return [];
+  }
+}

--- a/client/src/app/coverage-overview/coverage-overview.component.css
+++ b/client/src/app/coverage-overview/coverage-overview.component.css
@@ -1,0 +1,42 @@
+.coverage-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.coverage-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: var(--mat-sys-surface-container, #f5f5f5);
+}
+
+.topic-name {
+  flex: 1;
+}
+
+.topic-count {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.status-none .status-icon {
+  color: var(--mat-sys-error, #b3261e);
+}
+
+.status-low .status-icon {
+  color: #b26a00;
+}
+
+.status-good .status-icon {
+  color: #2e7d32;
+}
+
+.empty {
+  color: var(--mat-sys-on-surface-variant, #666);
+}

--- a/client/src/app/coverage-overview/coverage-overview.component.html
+++ b/client/src/app/coverage-overview/coverage-overview.component.html
@@ -1,0 +1,13 @@
+@if (topics().length === 0) {
+  <p class="empty">No topics analysed yet.</p>
+} @else {
+  <ul class="coverage-list" aria-label="Topic coverage">
+    @for (topic of topics(); track topic.topic) {
+      <li class="coverage-item" [class]="'status-' + topic.status">
+        <mat-icon class="status-icon" [attr.aria-label]="topic.status">{{ iconFor(topic.status) }}</mat-icon>
+        <span class="topic-name">{{ topic.topic }}</span>
+        <span class="topic-count" aria-label="Card count">{{ topic.cardCount }}</span>
+      </li>
+    }
+  </ul>
+}

--- a/client/src/app/coverage-overview/coverage-overview.component.ts
+++ b/client/src/app/coverage-overview/coverage-overview.component.ts
@@ -1,0 +1,25 @@
+import { Component, input } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { TopicCoverage } from '../parser/types';
+
+@Component({
+  selector: 'app-coverage-overview',
+  standalone: true,
+  imports: [MatIconModule],
+  templateUrl: './coverage-overview.component.html',
+  styleUrl: './coverage-overview.component.css',
+})
+export class CoverageOverviewComponent {
+  topics = input<TopicCoverage[]>([]);
+
+  iconFor(status: TopicCoverage['status']): string {
+    switch (status) {
+      case 'good':
+        return 'check_circle';
+      case 'low':
+        return 'error';
+      default:
+        return 'cancel';
+    }
+  }
+}

--- a/client/src/app/parser/prompt-page/prompt-page.component.css
+++ b/client/src/app/parser/prompt-page/prompt-page.component.css
@@ -1,0 +1,125 @@
+.prompt-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.page-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.panel {
+  border: 1px solid var(--mat-sys-outline-variant, #ddd);
+  border-radius: 12px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.panel-title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.generate-controls {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.count-field {
+  width: 100px;
+}
+
+.model-field {
+  min-width: 220px;
+}
+
+.error {
+  color: var(--mat-sys-error, #b3261e);
+}
+
+.preview-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.preview-item {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.preview-card {
+  flex: 1;
+  border: 1px solid var(--mat-sys-outline-variant, #ddd);
+  border-radius: 8px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.topic-chip {
+  align-self: flex-start;
+  padding: 2px 10px;
+  border-radius: 14px;
+  background: var(--mat-sys-secondary-container, #e0e0e0);
+  color: var(--mat-sys-on-secondary-container, #1d1d1d);
+  font-size: 0.8rem;
+}
+
+.divider {
+  width: 100%;
+  border: none;
+  border-top: 1px solid var(--mat-sys-outline-variant, #ddd);
+  margin: 0;
+}
+
+.markdown-body {
+  text-align: left;
+  overflow-wrap: anywhere;
+}
+
+.markdown-body pre {
+  background: var(--mat-sys-surface-container-high, #f0f0f0);
+  padding: 10px;
+  border-radius: 8px;
+  overflow-x: auto;
+}
+
+.markdown-body ul,
+.markdown-body ol {
+  padding-left: 1.5rem;
+}

--- a/client/src/app/parser/prompt-page/prompt-page.component.html
+++ b/client/src/app/parser/prompt-page/prompt-page.component.html
@@ -1,0 +1,140 @@
+<div class="prompt-page">
+  <header class="page-header">
+    <a mat-icon-button routerLink="/sources" aria-label="Back to sources">
+      <mat-icon>arrow_back</mat-icon>
+    </a>
+    <h1>{{ source()?.name ?? sourceId() }}</h1>
+  </header>
+
+  <section class="panel">
+    <h2 class="panel-title">Base prompt</h2>
+    <mat-form-field appearance="fill" class="full-width">
+      <mat-label>Topic description for all cards</mat-label>
+      <textarea
+        matInput
+        rows="3"
+        [ngModel]="basePrompt()"
+        (ngModelChange)="basePrompt.set($event)"
+        aria-label="Base prompt"
+      ></textarea>
+    </mat-form-field>
+    <div class="actions">
+      <button mat-stroked-button (click)="savePrompt()" [disabled]="savingPrompt()">
+        <mat-icon>save</mat-icon>
+        Save prompt
+      </button>
+    </div>
+  </section>
+
+  <section class="panel">
+    <div class="panel-header">
+      <h2 class="panel-title">Coverage overview</h2>
+      <button mat-icon-button (click)="refreshCoverage()" aria-label="Refresh coverage">
+        <mat-icon>refresh</mat-icon>
+      </button>
+    </div>
+    @if (coverage.isLoading()) {
+      <mat-progress-bar mode="indeterminate" aria-label="Loading coverage"></mat-progress-bar>
+    } @else if (coverage.error()) {
+      <p class="error">Could not load coverage.</p>
+    } @else {
+      <app-coverage-overview [topics]="coverage.value()?.topics ?? []"></app-coverage-overview>
+    }
+  </section>
+
+  <section class="panel">
+    <h2 class="panel-title">Generate cards</h2>
+    @if (models.length === 0) {
+      <p class="error">No card-generation models are enabled. Enable one in Settings → Data Model Settings.</p>
+    } @else {
+      <mat-form-field appearance="fill" class="full-width">
+        <mat-label>Generation prompt (optional)</mat-label>
+        <textarea
+          matInput
+          rows="2"
+          [ngModel]="generationPrompt()"
+          (ngModelChange)="generationPrompt.set($event)"
+          placeholder="e.g. focus on multi-container pods and probes"
+          aria-label="Generation prompt"
+        ></textarea>
+      </mat-form-field>
+      <div class="generate-controls">
+        <mat-form-field appearance="fill" class="count-field">
+          <mat-label>Count</mat-label>
+          <input
+            matInput
+            type="number"
+            min="1"
+            max="50"
+            [ngModel]="count()"
+            (ngModelChange)="count.set($event)"
+            aria-label="Card count"
+          />
+        </mat-form-field>
+        <mat-form-field appearance="fill" class="model-field">
+          <mat-label>Model</mat-label>
+          <mat-select
+            [ngModel]="selectedModel()"
+            (ngModelChange)="selectedModel.set($event)"
+            aria-label="Model"
+          >
+            @for (model of models; track model) {
+              <mat-option [value]="model">{{ model }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+        <button
+          mat-flat-button
+          color="primary"
+          (click)="generate()"
+          [disabled]="generating()"
+        >
+          <mat-icon>auto_awesome</mat-icon>
+          Generate
+        </button>
+      </div>
+      @if (generating()) {
+        <mat-progress-bar mode="indeterminate" aria-label="Generating cards"></mat-progress-bar>
+      }
+    }
+  </section>
+
+  @if (suggestions().length > 0) {
+    <section class="panel">
+      <div class="panel-header">
+        <h2 class="panel-title">Preview ({{ selectedCount() }} selected)</h2>
+        <button
+          mat-flat-button
+          color="primary"
+          (click)="createSelected()"
+          [disabled]="creating() || selectedCount() === 0"
+        >
+          <mat-icon>add</mat-icon>
+          Create {{ selectedCount() }} cards
+        </button>
+      </div>
+      @if (creating()) {
+        <mat-progress-bar mode="indeterminate" aria-label="Creating cards"></mat-progress-bar>
+      }
+      <ul class="preview-list">
+        @for (item of suggestions(); track $index) {
+          <li class="preview-item">
+            <mat-checkbox
+              [checked]="item.include"
+              (change)="toggleInclude($index, $event.checked)"
+              [attr.aria-label]="'Include card ' + ($index + 1)"
+            ></mat-checkbox>
+            <div class="preview-card">
+              @if (item.suggestion.topic) {
+                <div class="topic-chip">{{ item.suggestion.topic }}</div>
+              }
+              <div class="preview-front markdown-body" [innerHTML]="item.suggestion.frontText | markdown"></div>
+              <hr class="divider" />
+              <div class="preview-back markdown-body" [innerHTML]="item.suggestion.backText | markdown"></div>
+            </div>
+          </li>
+        }
+      </ul>
+    </section>
+  }
+</div>

--- a/client/src/app/parser/prompt-page/prompt-page.component.ts
+++ b/client/src/app/parser/prompt-page/prompt-page.component.ts
@@ -1,0 +1,161 @@
+import {
+  Component,
+  computed,
+  inject,
+  linkedSignal,
+  resource,
+  signal,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { injectParams } from '../../utils/inject-params';
+import { SourcesService } from '../../sources.service';
+import { PromptSourceService } from '../../prompt-source.service';
+import { MarkdownPipe } from '../../shared/markdown.pipe';
+import { CoverageOverviewComponent } from '../../coverage-overview/coverage-overview.component';
+import { SimpleCardSuggestion } from '../types';
+
+type PreviewItem = {
+  suggestion: SimpleCardSuggestion;
+  include: boolean;
+};
+
+@Component({
+  selector: 'app-prompt-page',
+  standalone: true,
+  imports: [
+    FormsModule,
+    RouterLink,
+    MatButtonModule,
+    MatIconModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatCheckboxModule,
+    MatProgressBarModule,
+    MarkdownPipe,
+    CoverageOverviewComponent,
+  ],
+  templateUrl: './prompt-page.component.html',
+  styleUrl: './prompt-page.component.css',
+})
+export class PromptPageComponent {
+  private readonly routeSourceId = injectParams('sourceId');
+  private readonly sourcesService = inject(SourcesService);
+  private readonly promptSourceService = inject(PromptSourceService);
+
+  readonly sourceId = computed(() => {
+    const id = this.routeSourceId();
+    return id ? String(id) : null;
+  });
+
+  readonly source = computed(() =>
+    (this.sourcesService.sources.value() ?? []).find(
+      (s) => s.id === this.sourceId()
+    )
+  );
+
+  readonly models = this.promptSourceService.enabledModels;
+  readonly primaryModel = this.promptSourceService.primaryModel;
+
+  readonly basePrompt = linkedSignal(() => this.source()?.prompt ?? '');
+  readonly generationPrompt = signal('');
+  readonly count = signal(10);
+  readonly selectedModel = signal(this.primaryModel ?? this.models[0] ?? '');
+
+  readonly savingPrompt = signal(false);
+  readonly generating = signal(false);
+  readonly creating = signal(false);
+
+  readonly suggestions = signal<PreviewItem[]>([]);
+  readonly selectedCount = computed(
+    () => this.suggestions().filter((item) => item.include).length
+  );
+
+  private readonly coverageVersion = signal(0);
+
+  readonly coverage = resource({
+    params: () => {
+      const sourceId = this.sourceId();
+      const model = this.primaryModel;
+      const version = this.coverageVersion();
+      return sourceId && model ? { sourceId, model, version } : undefined;
+    },
+    loader: async ({ params }) =>
+      this.promptSourceService.getCoverage(params.sourceId, params.model),
+  });
+
+  async savePrompt(): Promise<void> {
+    const sourceId = this.sourceId();
+    if (!sourceId) {
+      return;
+    }
+    this.savingPrompt.set(true);
+    try {
+      await this.sourcesService.updateSource(sourceId, {
+        prompt: this.basePrompt(),
+      });
+    } finally {
+      this.savingPrompt.set(false);
+    }
+  }
+
+  async generate(): Promise<void> {
+    const sourceId = this.sourceId();
+    const model = this.selectedModel();
+    if (!sourceId || !model) {
+      return;
+    }
+    this.generating.set(true);
+    try {
+      const cards = await this.promptSourceService.generateCards(
+        sourceId,
+        this.generationPrompt(),
+        this.count(),
+        model
+      );
+      this.suggestions.set(cards.map((suggestion) => ({ suggestion, include: true })));
+    } finally {
+      this.generating.set(false);
+    }
+  }
+
+  toggleInclude(index: number, include: boolean): void {
+    this.suggestions.update((items) =>
+      items.map((item, i) => (i === index ? { ...item, include } : item))
+    );
+  }
+
+  async createSelected(): Promise<void> {
+    const sourceId = this.sourceId();
+    if (!sourceId) {
+      return;
+    }
+    const selected = this.suggestions()
+      .filter((item) => item.include)
+      .map((item) => item.suggestion);
+    if (selected.length === 0) {
+      return;
+    }
+    this.creating.set(true);
+    try {
+      await this.promptSourceService.createCards(sourceId, selected);
+      this.suggestions.set([]);
+      this.coverageVersion.update((v) => v + 1);
+      this.sourcesService.refetchSources();
+    } finally {
+      this.creating.set(false);
+    }
+  }
+
+  refreshCoverage(): void {
+    this.coverageVersion.update((v) => v + 1);
+  }
+}

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -59,6 +59,9 @@ export type CardData = {
   extractionModel?: string;
   grammarTopic?: string;
   hint?: string;
+  frontText?: string;
+  backText?: string;
+  topic?: string;
 };
 
 export type Card = {
@@ -133,7 +136,7 @@ export type Page = {
 };
 
 export type LanguageLevel = 'A1' | 'A2' | 'B1' | 'B2' | 'C1' | 'C2';
-export type CardType = 'vocabulary' | 'speech' | 'grammar';
+export type CardType = 'vocabulary' | 'speech' | 'grammar' | 'simple';
 
 export type ExtractedItem = {
   id: string;
@@ -229,7 +232,27 @@ export type SourceFormatType =
   | 'wordListWithExamples'
   | 'wordListWithFormsAndExamples'
   | 'flowingText';
-export type SourceType = 'pdf' | 'images' | 'ebookDictionary';
+export type SourceType = 'pdf' | 'images' | 'ebookDictionary' | 'aiPrompt';
+
+export type SimpleCardSuggestion = {
+  frontText: string;
+  backText: string;
+  topic?: string;
+};
+
+export type GenerateCardsResponse = {
+  cards: SimpleCardSuggestion[];
+};
+
+export type TopicCoverage = {
+  topic: string;
+  cardCount: number;
+  status: 'none' | 'low' | 'good';
+};
+
+export type CoverageResponse = {
+  topics: TopicCoverage[];
+};
 
 export type Source = {
   id: string;
@@ -251,6 +274,7 @@ export type Source = {
   newCardLimit?: number;
   learningPartnerId?: number | null;
   detectionSourceIds?: string[];
+  prompt?: string;
 };
 
 export type WordList = {

--- a/client/src/app/prompt-source.service.ts
+++ b/client/src/app/prompt-source.service.ts
@@ -1,0 +1,80 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { createEmptyCard } from 'ts-fsrs';
+import { ENVIRONMENT_CONFIG } from './environment/environment.config';
+import { FsrsGradingService } from './fsrs-grading.service';
+import { fetchJson } from './utils/fetchJson';
+import { mapCardDatesToISOStrings } from './utils/date-mapping.util';
+import {
+  CardCreatePayload,
+  CoverageResponse,
+  GenerateCardsResponse,
+  SimpleCardSuggestion,
+} from './parser/types';
+
+const CARD_GENERATION_OPERATION = 'card_generation';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PromptSourceService {
+  private readonly http = inject(HttpClient);
+  private readonly environment = inject(ENVIRONMENT_CONFIG);
+  private readonly fsrsGradingService = inject(FsrsGradingService);
+
+  readonly enabledModels =
+    this.environment.enabledModelsByOperation[CARD_GENERATION_OPERATION] ?? [];
+
+  readonly primaryModel =
+    this.environment.primaryModelByOperation[CARD_GENERATION_OPERATION];
+
+  async generateCards(
+    sourceId: string,
+    prompt: string,
+    count: number,
+    model: string
+  ): Promise<SimpleCardSuggestion[]> {
+    const response = await fetchJson<GenerateCardsResponse>(
+      this.http,
+      `/api/source/${sourceId}/generate-cards`,
+      {
+        method: 'POST',
+        body: { prompt, count, model },
+      }
+    );
+    return response.cards;
+  }
+
+  async getCoverage(sourceId: string, model: string): Promise<CoverageResponse> {
+    return fetchJson<CoverageResponse>(
+      this.http,
+      `/api/source/${sourceId}/coverage?model=${encodeURIComponent(model)}`
+    );
+  }
+
+  async createCards(
+    sourceId: string,
+    suggestions: SimpleCardSuggestion[]
+  ): Promise<void> {
+    for (const suggestion of suggestions) {
+      const emptyCard = createEmptyCard();
+      const cardPayload = {
+        id: `${sourceId}-${crypto.randomUUID()}`,
+        sourceId,
+        sourcePageNumber: 1,
+        data: {
+          frontText: suggestion.frontText,
+          backText: suggestion.backText,
+          ...(suggestion.topic ? { topic: suggestion.topic } : {}),
+        },
+        ...this.fsrsGradingService.convertFromFSRSCard(emptyCard),
+        readiness: 'IN_REVIEW',
+      } satisfies CardCreatePayload;
+
+      await fetchJson(this.http, `/api/card`, {
+        body: mapCardDatesToISOStrings(cardPayload),
+        method: 'POST',
+      });
+    }
+  }
+}

--- a/client/src/app/shared/markdown.pipe.ts
+++ b/client/src/app/shared/markdown.pipe.ts
@@ -1,0 +1,14 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { marked } from 'marked';
+
+@Pipe({
+  name: 'markdown',
+})
+export class MarkdownPipe implements PipeTransform {
+  transform(value: string | undefined | null): string {
+    if (!value) {
+      return '';
+    }
+    return marked.parse(value, { async: false, gfm: true, breaks: true }) as string;
+  }
+}

--- a/client/src/app/shared/source-dialog/source-dialog.component.html
+++ b/client/src/app/shared/source-dialog/source-dialog.component.html
@@ -19,7 +19,7 @@
           <mat-select
             [formField]="sourceForm.cardType"
           >
-            @for (cardType of cardTypes; track cardType.code) {
+            @for (cardType of cardTypes(); track cardType.code) {
             <mat-option [value]="cardType.code">{{ cardType.displayName }}</mat-option>
             }
           </mat-select>
@@ -47,7 +47,7 @@
           </mat-select>
         </mat-form-field>
 
-        @if (formModel().cardType !== 'speech' && formModel().cardType !== 'grammar') {
+        @if (formModel().cardType !== 'speech' && formModel().cardType !== 'grammar' && formModel().cardType !== 'simple') {
         <mat-form-field appearance="fill">
           <mat-label>Format Type</mat-label>
           <mat-select
@@ -64,7 +64,17 @@
 
     <section class="form-section">
       <h3 class="section-title">Content</h3>
-      @if (formModel().sourceType === 'pdf') {
+      @if (isAiPrompt()) {
+      <mat-form-field appearance="fill" class="full-width">
+        <mat-label>Base prompt</mat-label>
+        <textarea
+          matInput
+          rows="4"
+          [formField]="sourceForm.prompt"
+          placeholder="Describe the topic for all cards, e.g. 'Kubernetes Application Developer (CKAD) certification exam preparation'"
+        ></textarea>
+      </mat-form-field>
+      } @else if (formModel().sourceType === 'pdf') {
       <div
         class="dropzone"
         [class.dragging]="isDragging()"

--- a/client/src/app/shared/source-dialog/source-dialog.component.ts
+++ b/client/src/app/shared/source-dialog/source-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, signal } from '@angular/core';
+import { Component, computed, effect, inject, signal } from '@angular/core';
 import { form, FormField, disabled, required, min, validate, requiredError } from '@angular/forms/signals';
 import { HttpClient } from '@angular/common/http';
 import { MatButtonModule } from '@angular/material/button';
@@ -68,11 +68,17 @@ export class SourceDialogComponent {
       (source) => source.id !== this.data.source?.id
     )
   );
-  readonly cardTypes = [
+  private readonly baseCardTypes = [
     { code: 'vocabulary', displayName: 'Vocabulary' },
     { code: 'speech', displayName: 'Speech' },
     { code: 'grammar', displayName: 'Grammar' },
   ];
+
+  readonly isAiPrompt = computed(() => this.formModel().sourceType === 'aiPrompt');
+
+  readonly cardTypes = computed(() =>
+    this.isAiPrompt() ? [{ code: 'simple', displayName: 'Simple' }] : this.baseCardTypes
+  );
 
   readonly formModel = signal<{
     name: string;
@@ -86,6 +92,7 @@ export class SourceDialogComponent {
     newCardLimit: number;
     learningPartnerId: number | null;
     detectionSourceIds: string[];
+    prompt: string;
   }>({
     name: this.data.source?.name || '',
     sourceType: this.data.source?.sourceType ?? '',
@@ -98,6 +105,13 @@ export class SourceDialogComponent {
     newCardLimit: this.data.source?.newCardLimit ?? 50,
     learningPartnerId: this.data.source?.learningPartnerId ?? null,
     detectionSourceIds: this.data.source?.detectionSourceIds ?? [],
+    prompt: this.data.source?.prompt ?? '',
+  });
+
+  private readonly forceSimpleCardType = effect(() => {
+    if (this.isAiPrompt() && this.formModel().cardType !== 'simple') {
+      this.formModel.update((m) => ({ ...m, cardType: 'simple' }));
+    }
   });
   readonly sourceForm = form(this.formModel, (path) => {
     required(path.name);
@@ -109,12 +123,12 @@ export class SourceDialogComponent {
     min(path.newCardLimit, 1);
     validate(path.formatType, (ctx) => {
       const ct = ctx.valueOf(path.cardType);
-      if (ct !== 'speech' && ct !== 'grammar' && !ctx.value()) {
+      if (ct !== 'speech' && ct !== 'grammar' && ct !== 'simple' && !ctx.value()) {
         return requiredError();
       }
       return undefined;
     });
-    disabled(path.cardType, () => this.data.mode === 'edit');
+    disabled(path.cardType, () => this.data.mode === 'edit' || this.isAiPrompt());
     disabled(path.sourceType, () => this.data.mode === 'edit');
   });
 
@@ -126,6 +140,7 @@ export class SourceDialogComponent {
   readonly isValid = computed(() =>
     this.sourceForm().valid() &&
     (this.formModel().sourceType === 'images' ||
+      this.formModel().sourceType === 'aiPrompt' ||
       this.data.mode === 'edit' ||
       this.hasFile())
   );
@@ -156,13 +171,16 @@ export class SourceDialogComponent {
         cardType: result.cardType || undefined,
         formatType: result.cardType === 'speech' || result.cardType === 'grammar'
           ? 'flowingText'
-          : result.formatType || undefined,
+          : result.cardType === 'simple'
+            ? undefined
+            : result.formatType || undefined,
         cardLimit: result.cardLimit,
         newCardLimit: result.newCardLimit,
         learningPartnerId: this.data.mode === 'edit' && result.learningPartnerId === null
           ? 0
           : result.learningPartnerId,
         detectionSourceIds: result.detectionSourceIds,
+        prompt: result.cardType === 'simple' ? result.prompt || undefined : undefined,
       };
       this.dialogRef.close(formData);
     }

--- a/client/src/app/study/learn-card/learn-card.component.html
+++ b/client/src/app/study/learn-card/learn-card.component.html
@@ -83,6 +83,12 @@
           [onPlayAudio]="playAudioForContent.bind(this)">
         </app-learn-grammar-card>
       }
+      @case ('simple') {
+        <app-learn-simple-card
+          [card]="cardResource"
+          [isRevealed]="isRevealed()">
+        </app-learn-simple-card>
+      }
     }
   </div>
 

--- a/client/src/app/study/learn-card/learn-card.component.ts
+++ b/client/src/app/study/learn-card/learn-card.component.ts
@@ -21,6 +21,7 @@ import { CardActionsComponent } from '../../shared/card-actions/card-actions.com
 import { LearnVocabularyCardComponent } from '../learn-vocabulary-card/learn-vocabulary-card.component';
 import { LearnSpeechCardComponent } from '../learn-speech-card/learn-speech-card.component';
 import { LearnGrammarCardComponent } from '../learn-grammar-card/learn-grammar-card.component';
+import { LearnSimpleCardComponent } from '../learn-simple-card/learn-simple-card.component';
 import { LearnCardSkeletonComponent } from '../learn-card-skeleton/learn-card-skeleton.component';
 import { ConfettiComponent } from '../confetti/confetti.component';
 import { AudioPlaybackService } from '../../shared/services/audio-playback.service';
@@ -41,6 +42,7 @@ import { SessionStatsComponent } from '../session-stats/session-stats.component'
     LearnVocabularyCardComponent,
     LearnSpeechCardComponent,
     LearnGrammarCardComponent,
+    LearnSimpleCardComponent,
     LearnCardSkeletonComponent,
     ConfettiComponent,
     SessionStatsComponent,

--- a/client/src/app/study/learn-simple-card/learn-simple-card.component.css
+++ b/client/src/app/study/learn-simple-card/learn-simple-card.component.css
@@ -1,0 +1,55 @@
+.content-section {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.topic-chip {
+  align-self: flex-start;
+  padding: 4px 12px;
+  border-radius: 16px;
+  background: var(--mat-sys-secondary-container, #e0e0e0);
+  color: var(--mat-sys-on-secondary-container, #1d1d1d);
+  font-size: 0.85rem;
+}
+
+.chips-corner {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+}
+
+.divider {
+  width: 100%;
+  border: none;
+  border-top: 1px solid var(--mat-sys-outline-variant, #ccc);
+  margin: 0;
+}
+
+.markdown-body {
+  font-size: 1.1rem;
+  line-height: 1.5;
+  text-align: left;
+  width: 100%;
+  overflow-wrap: anywhere;
+}
+
+.markdown-body pre {
+  background: var(--mat-sys-surface-container-high, #f0f0f0);
+  padding: 12px;
+  border-radius: 8px;
+  overflow-x: auto;
+}
+
+.markdown-body code {
+  font-family: monospace;
+}
+
+.markdown-body ul,
+.markdown-body ol {
+  padding-left: 1.5rem;
+}

--- a/client/src/app/study/learn-simple-card/learn-simple-card.component.html
+++ b/client/src/app/study/learn-simple-card/learn-simple-card.component.html
@@ -1,0 +1,17 @@
+<div class="content-section">
+  @if (topic(); as topic) {
+    <div class="topic-chip" aria-label="Topic">{{ topic }}</div>
+  }
+  <div class="chips-corner">
+    @let state = card()?.value()?.state; @if (state !== undefined) {
+    <app-state [state]="state" />
+    }
+  </div>
+
+  <div class="front-section markdown-body" aria-label="Front" [innerHTML]="frontText() | markdown"></div>
+
+  @if (isRevealed()) {
+    <hr class="divider" />
+    <div class="back-section markdown-body" aria-label="Back" [innerHTML]="backText() | markdown"></div>
+  }
+</div>

--- a/client/src/app/study/learn-simple-card/learn-simple-card.component.ts
+++ b/client/src/app/study/learn-simple-card/learn-simple-card.component.ts
@@ -1,0 +1,21 @@
+import { Component, computed, input } from '@angular/core';
+import { StateComponent } from '../../shared/state/state.component';
+import { CardResourceLike } from '../../shared/types/card-resource.types';
+import { MarkdownPipe } from '../../shared/markdown.pipe';
+
+@Component({
+  selector: 'app-learn-simple-card',
+  standalone: true,
+  imports: [StateComponent, MarkdownPipe],
+  templateUrl: './learn-simple-card.component.html',
+  styleUrl: './learn-simple-card.component.css',
+  host: { role: 'article', 'aria-label': 'Flashcard' },
+})
+export class LearnSimpleCardComponent {
+  card = input<CardResourceLike | null>(null);
+  isRevealed = input<boolean>(false);
+
+  readonly frontText = computed(() => this.card()?.value()?.data.frontText ?? '');
+  readonly backText = computed(() => this.card()?.value()?.data.backText ?? '');
+  readonly topic = computed(() => this.card()?.value()?.data.topic);
+}

--- a/mock_google_ai_server/src/chatHandler.ts
+++ b/mock_google_ai_server/src/chatHandler.ts
@@ -356,10 +356,56 @@ export class ChatHandler {
     );
   }
 
+  handleCardGeneration(request: GeminiRequest): any | null {
+    const systemContent = request.systemInstruction?.parts?.[0]?.text || '';
+
+    if (!systemContent.includes('expert tutor building a spaced-repetition flashcard deck')) {
+      return null;
+    }
+
+    return createGeminiResponse({
+      cards: [
+        {
+          frontText: 'What command creates a pod named `nginx` using the `nginx` image?',
+          backText: '```sh\nkubectl run nginx --image=nginx\n```',
+          topic: 'Pods',
+        },
+        {
+          frontText: 'List the resources a Pod can request.\n\n- CPU\n- Memory',
+          backText: 'A Pod can request **CPU** and **memory** via `resources.requests`.',
+          topic: 'Pods',
+        },
+      ],
+    });
+  }
+
+  handleCoverageAnalysis(request: GeminiRequest): any | null {
+    const systemContent = request.systemInstruction?.parts?.[0]?.text || '';
+
+    if (!systemContent.includes('analysing how well a spaced-repetition flashcard deck covers')) {
+      return null;
+    }
+
+    const hasPods = systemContent.includes('-> Pods');
+
+    return createGeminiResponse({
+      topics: [
+        { topic: 'Services & Networking', cardCount: 0, status: 'none' },
+        { topic: 'Pods', cardCount: hasPods ? 2 : 0, status: hasPods ? 'good' : 'none' },
+      ],
+    });
+  }
+
   async processRequest(request: GeminiRequest): Promise<any> {
     if (!request.contents || !Array.isArray(request.contents)) {
       throw new Error('Invalid request format');
     }
+
+    const cardGenerationResponse = this.handleCardGeneration(request);
+    if (cardGenerationResponse) return cardGenerationResponse;
+
+    const coverageResponse = this.handleCoverageAnalysis(request);
+    if (coverageResponse) return coverageResponse;
 
     const explanationResponse = this.handleExplanation(request);
     if (explanationResponse) return explanationResponse;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/config/ModelPricingConfig.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/config/ModelPricingConfig.java
@@ -30,9 +30,11 @@ public class ModelPricingConfig {
         Map.entry("gpt-5.2", new ChatModelPricing(new BigDecimal("1.75"), new BigDecimal("14.00"))),
         Map.entry("gpt-5-mini", new ChatModelPricing(new BigDecimal("0.25"), new BigDecimal("2.00"))),
         Map.entry("gpt-5-nano", new ChatModelPricing(new BigDecimal("0.05"), new BigDecimal("0.40"))),
+        Map.entry("gpt-5.5", new ChatModelPricing(new BigDecimal("5.00"), new BigDecimal("30.00"))),
         // Anthropic Claude
         Map.entry("claude-sonnet-4-5", new ChatModelPricing(new BigDecimal("3.00"), new BigDecimal("15.00"))),
         Map.entry("claude-haiku-4-5", new ChatModelPricing(new BigDecimal("0.80"), new BigDecimal("4.00"))),
+        Map.entry("claude-opus-4-8", new ChatModelPricing(new BigDecimal("5.00"), new BigDecimal("25.00"))),
         // Google Gemini
         Map.entry("gemini-3.1-pro-preview", new ChatModelPricing(new BigDecimal("2.00"), new BigDecimal("12.00"))),
         Map.entry("gemini-3-flash-preview", new ChatModelPricing(new BigDecimal("0.50"), new BigDecimal("3.00")))

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
@@ -36,7 +36,11 @@ import io.github.mucsi96.learnlanguage.entity.PendingPhoto;
 import io.github.mucsi96.learnlanguage.entity.Source;
 import io.github.mucsi96.learnlanguage.exception.ResourceNotFoundException;
 import io.github.mucsi96.learnlanguage.model.CardType;
+import io.github.mucsi96.learnlanguage.model.ChatModel;
+import io.github.mucsi96.learnlanguage.model.CoverageResponse;
 import io.github.mucsi96.learnlanguage.model.ExtractionRegionCreateRequest;
+import io.github.mucsi96.learnlanguage.model.GenerateCardsRequest;
+import io.github.mucsi96.learnlanguage.model.GenerateCardsResponse;
 import io.github.mucsi96.learnlanguage.model.PageResponse;
 import io.github.mucsi96.learnlanguage.model.PendingPhotoConsumeRequest;
 import io.github.mucsi96.learnlanguage.model.PendingPhotoStatusResponse;
@@ -56,7 +60,9 @@ import io.github.mucsi96.learnlanguage.service.AreaSentenceService;
 import io.github.mucsi96.learnlanguage.service.AreaWordsService;
 import io.github.mucsi96.learnlanguage.service.CardService;
 import io.github.mucsi96.learnlanguage.service.CardService.SourceStats;
+import io.github.mucsi96.learnlanguage.service.CoverageService;
 import io.github.mucsi96.learnlanguage.service.DocumentProcessorService;
+import io.github.mucsi96.learnlanguage.service.PromptCardGenerationService;
 import io.github.mucsi96.learnlanguage.service.FileStorageService;
 import io.github.mucsi96.learnlanguage.service.KnownWordService;
 import io.github.mucsi96.learnlanguage.service.LearningPartnerService;
@@ -88,6 +94,8 @@ public class SourceController {
   private final LearningPartnerService learningPartnerService;
   private final PendingPhotoService pendingPhotoService;
   private final PhotoGrammarConceptService photoGrammarConceptService;
+  private final PromptCardGenerationService promptCardGenerationService;
+  private final CoverageService coverageService;
 
   @PreAuthorize("hasAuthority('APPROLE_DeckReader') and hasAuthority('SCOPE_readDecks')")
   @GetMapping("/sources")
@@ -128,6 +136,7 @@ public class SourceController {
           .newCardLimit(source.getNewCardLimit())
           .learningPartnerId(source.getLearningPartner() != null ? source.getLearningPartner().getId() : null)
           .detectionSourceIds(source.getDetectionSources().stream().map(Source::getId).sorted().toList())
+          .prompt(source.getPrompt())
           .build();
     }).collect(Collectors.toList());
   }
@@ -270,6 +279,35 @@ public class SourceController {
   }
 
   @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
+  @PostMapping("/source/{sourceId}/generate-cards")
+  public GenerateCardsResponse generateCards(
+      @PathVariable String sourceId,
+      @RequestBody GenerateCardsRequest request) {
+    if (request.getModel() == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "model is required");
+    }
+    final int count = request.getCount() != null ? request.getCount() : 0;
+    if (count < 1 || count > 50) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "count must be between 1 and 50");
+    }
+
+    final Source source = requireAiPromptSource(sourceId);
+
+    return GenerateCardsResponse.builder()
+        .cards(promptCardGenerationService.generateCards(source, request.getPrompt(), count, request.getModel()))
+        .build();
+  }
+
+  @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
+  @GetMapping("/source/{sourceId}/coverage")
+  public CoverageResponse getCoverage(
+      @PathVariable String sourceId,
+      @RequestParam ChatModel model) {
+    final Source source = requireAiPromptSource(sourceId);
+    return coverageService.analyzeCoverage(source, model);
+  }
+
+  @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")
   @PostMapping("/source/{sourceId}/extraction-regions")
   public ResponseEntity<Map<String, String>> saveExtractionRegions(
       @PathVariable String sourceId,
@@ -319,6 +357,7 @@ public class SourceController {
             ? learningPartnerService.getLearningPartnerById(request.getLearningPartnerId())
             : null)
         .detectionSources(resolveDetectionSources(request.getDetectionSourceIds(), request.getId()))
+        .prompt(request.getPrompt())
         .build();
 
     sourceService.saveSource(source);
@@ -356,6 +395,7 @@ public class SourceController {
         .detectionSources(request.getDetectionSourceIds() != null
             ? resolveDetectionSources(request.getDetectionSourceIds(), sourceId)
             : existingSource.getDetectionSources())
+        .prompt(request.getPrompt() != null ? request.getPrompt() : existingSource.getPrompt())
         .build();
 
     sourceService.saveSource(updatedSource);
@@ -607,6 +647,17 @@ public class SourceController {
   public ResponseEntity<Map<String, String>> handleUploadTooLarge(MaxUploadSizeExceededException ex) {
     return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE)
         .body(Map.of("error", "Uploaded file exceeds the maximum allowed size"));
+  }
+
+  private Source requireAiPromptSource(String sourceId) {
+    final Source source = sourceService.getSourceById(sourceId)
+        .orElseThrow(() -> new ResourceNotFoundException("Source not found with id: " + sourceId));
+
+    if (source.getSourceType() != SourceType.AI_PROMPT) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+          "Card generation is only supported on AI prompt sources");
+    }
+    return source;
   }
 
   private Source requirePhotoGrammarSource(String sourceId) {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/entity/Source.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/entity/Source.java
@@ -59,6 +59,9 @@ public class Source {
   @Column(name = "new_card_limit")
   private Integer newCardLimit;
 
+  @Column(name = "prompt", columnDefinition = "text")
+  private String prompt;
+
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "learning_partner_id")
   @ToString.Exclude

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardData.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardData.java
@@ -42,4 +42,13 @@ public class CardData implements Serializable {
 
     @JsonInclude(Include.NON_NULL)
     private String hint;
+
+    @JsonInclude(Include.NON_NULL)
+    private String frontText;
+
+    @JsonInclude(Include.NON_NULL)
+    private String backText;
+
+    @JsonInclude(Include.NON_NULL)
+    private String topic;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardType.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/CardType.java
@@ -11,7 +11,8 @@ import lombok.RequiredArgsConstructor;
 public enum CardType {
     VOCABULARY("vocabulary"),
     SPEECH("speech"),
-    GRAMMAR("grammar");
+    GRAMMAR("grammar"),
+    SIMPLE("simple");
 
     private final String typeName;
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ChatModel.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ChatModel.java
@@ -18,8 +18,10 @@ public enum ChatModel {
   GPT_5_2("gpt-5.2", ModelProvider.OPENAI),
   GPT_5_MINI("gpt-5-mini", ModelProvider.OPENAI),
   GPT_5_NANO("gpt-5-nano", ModelProvider.OPENAI),
+  GPT_5_5("gpt-5.5", ModelProvider.OPENAI),
   CLAUDE_SONNET_4_5("claude-sonnet-4-5", ModelProvider.ANTHROPIC),
   CLAUDE_HAIKU_4_5("claude-haiku-4-5", ModelProvider.ANTHROPIC),
+  CLAUDE_OPUS_4_8("claude-opus-4-8", ModelProvider.ANTHROPIC),
   GEMINI_3_1_PRO_PREVIEW("gemini-3.1-pro-preview", ModelProvider.GOOGLE),
   GEMINI_3_FLASH_PREVIEW("gemini-3-flash-preview", ModelProvider.GOOGLE);
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/CoverageResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/CoverageResponse.java
@@ -1,0 +1,12 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class CoverageResponse {
+    private List<TopicCoverage> topics;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/GenerateCardsRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/GenerateCardsRequest.java
@@ -1,0 +1,16 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GenerateCardsRequest {
+    private String prompt;
+    private Integer count;
+    private ChatModel model;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/GenerateCardsResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/GenerateCardsResponse.java
@@ -1,0 +1,12 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class GenerateCardsResponse {
+    private List<SimpleCardSuggestion> cards;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/OperationType.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/OperationType.java
@@ -19,7 +19,8 @@ public enum OperationType {
     IMAGE_DESCRIPTION("image_description", "Image Description", true),
     AUDIO_GENERATION("audio_generation", "Audio Generation", false),
     EXPLANATION("explanation", "Explanation", true),
-    TRANSCRIPTION("transcription", "Transcription", false);
+    TRANSCRIPTION("transcription", "Transcription", false),
+    CARD_GENERATION("card_generation", "Card Generation", true);
 
     private final String code;
     private final String displayName;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/SimpleCardSuggestion.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/SimpleCardSuggestion.java
@@ -1,0 +1,16 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SimpleCardSuggestion {
+    private String frontText;
+    private String backText;
+    private String topic;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceRequest.java
@@ -24,4 +24,5 @@ public class SourceRequest {
     private Integer newCardLimit;
     private Integer learningPartnerId;
     private List<String> detectionSourceIds;
+    private String prompt;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceResponse.java
@@ -28,4 +28,5 @@ public class SourceResponse {
     private Integer newCardLimit;
     private Integer learningPartnerId;
     private List<String> detectionSourceIds;
+    private String prompt;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceType.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/SourceType.java
@@ -11,7 +11,8 @@ import lombok.RequiredArgsConstructor;
 public enum SourceType {
     PDF("pdf", "PDF Document"),
     IMAGES("images", "Image Collection"),
-    EBOOK_DICTIONARY("ebookDictionary", "Ebook Dictionary");
+    EBOOK_DICTIONARY("ebookDictionary", "Ebook Dictionary"),
+    AI_PROMPT("aiPrompt", "AI Prompt");
 
     private final String code;
     private final String displayName;

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/TopicCoverage.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/TopicCoverage.java
@@ -1,0 +1,16 @@
+package io.github.mucsi96.learnlanguage.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TopicCoverage {
+    private String topic;
+    private Integer cardCount;
+    private String status;
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ChatClientService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ChatClientService.java
@@ -49,11 +49,17 @@ public class ChatClientService {
       case GPT_5_NANO -> ChatClient.builder(openAiChatModel)
           .defaultOptions(OpenAiChatOptions.builder().model(com.openai.models.ChatModel.GPT_5_NANO.toString()))
           .build();
+      case GPT_5_5 -> ChatClient.builder(openAiChatModel)
+          .defaultOptions(OpenAiChatOptions.builder().model("gpt-5.5"))
+          .build();
       case CLAUDE_SONNET_4_5 -> ChatClient.builder(anthropicChatModel)
           .defaultOptions(AnthropicChatOptions.builder().model(com.anthropic.models.messages.Model.CLAUDE_SONNET_4_5))
           .build();
       case CLAUDE_HAIKU_4_5 -> ChatClient.builder(anthropicChatModel)
           .defaultOptions(AnthropicChatOptions.builder().model(com.anthropic.models.messages.Model.CLAUDE_HAIKU_4_5))
+          .build();
+      case CLAUDE_OPUS_4_8 -> ChatClient.builder(anthropicChatModel)
+          .defaultOptions(AnthropicChatOptions.builder().model(com.anthropic.models.messages.Model.of("claude-opus-4-8")))
           .build();
       case GEMINI_3_1_PRO_PREVIEW -> ChatClient.builder(googleGenAiChatModel)
           .defaultOptions(GoogleGenAiChatOptions.builder().model("gemini-3.1-pro-preview"))

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CoverageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CoverageService.java
@@ -1,0 +1,98 @@
+package io.github.mucsi96.learnlanguage.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import io.github.mucsi96.learnlanguage.entity.Card;
+import io.github.mucsi96.learnlanguage.entity.Source;
+import io.github.mucsi96.learnlanguage.model.CardData;
+import io.github.mucsi96.learnlanguage.model.ChatModel;
+import io.github.mucsi96.learnlanguage.model.CoverageResponse;
+import io.github.mucsi96.learnlanguage.model.OperationType;
+import io.github.mucsi96.learnlanguage.model.TopicCoverage;
+import io.github.mucsi96.learnlanguage.repository.CardRepository;
+import lombok.RequiredArgsConstructor;
+import tools.jackson.databind.json.JsonMapper;
+
+@Service
+@RequiredArgsConstructor
+public class CoverageService {
+
+  record CoverageTopic(String topic, int cardCount, String status) {
+  }
+
+  record Coverage(List<CoverageTopic> topics) {
+  }
+
+  private final JsonMapper jsonMapper;
+  private final ChatService chatService;
+  private final CardRepository cardRepository;
+
+  public CoverageResponse analyzeCoverage(Source source, ChatModel model) {
+    final List<Card> existingCards = cardRepository.findBySource_IdIn(List.of(source.getId()));
+
+    final Coverage result = chatService.callWithLogging(
+        model,
+        OperationType.CARD_GENERATION,
+        buildSystemPrompt(source, existingCards),
+        "Produce the coverage report for this deck.",
+        Coverage.class);
+
+    final List<TopicCoverage> topics = result.topics().stream()
+        .map(topic -> TopicCoverage.builder()
+            .topic(topic.topic())
+            .cardCount(topic.cardCount())
+            .status(topic.status())
+            .build())
+        .toList();
+
+    return CoverageResponse.builder().topics(topics).build();
+  }
+
+  private String buildSystemPrompt(Source source, List<Card> existingCards) {
+    final String existingSummary = existingCards.isEmpty()
+        ? "There are no existing cards yet."
+        : existingCards.stream()
+            .map(Card::getData)
+            .filter(data -> data != null && data.getFrontText() != null)
+            .map(this::describeExistingCard)
+            .collect(Collectors.joining("\n"));
+
+    final String basePrompt = """
+        You are an expert tutor analysing how well a spaced-repetition flashcard deck covers its subject.
+
+        Deck topic (base prompt):
+        %s
+
+        Your task:
+        1. Infer the full curriculum of topics implied by the deck topic above (the areas an exam or
+           exercise on this subject would cover). Keep the list focused - typically 5 to 15 areas.
+        2. For each curriculum topic, count how many of the existing cards below belong to it (match on
+           meaning, not only on the literal topic label) and assign a coverage status:
+           - "none": no cards cover this topic
+           - "low": some cards but the topic is under-covered
+           - "good": the topic is well covered
+        3. Order topics from least to best covered so gaps appear first.
+
+        Respond ONLY with JSON of the form {"topics": [...]} matching the example shape below.
+
+        Existing cards (frontText -> topic):
+        %s
+        """.formatted(
+        source.getPrompt() != null ? source.getPrompt() : "",
+        existingSummary);
+
+    final Coverage example = new Coverage(List.of(
+        new CoverageTopic("Services & Networking", 0, "none"),
+        new CoverageTopic("Pods", 3, "good")));
+
+    return basePrompt + "\nExample JSON response shape:\n" + jsonMapper.writeValueAsString(example);
+  }
+
+  private String describeExistingCard(CardData data) {
+    final String topic = data.getTopic() != null ? data.getTopic() : "(untagged)";
+    return "- " + data.getFrontText().replaceAll("\\s+", " ").trim() + " -> " + topic;
+  }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/PromptCardGenerationService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/PromptCardGenerationService.java
@@ -1,0 +1,124 @@
+package io.github.mucsi96.learnlanguage.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import io.github.mucsi96.learnlanguage.entity.Card;
+import io.github.mucsi96.learnlanguage.entity.Source;
+import io.github.mucsi96.learnlanguage.model.CardData;
+import io.github.mucsi96.learnlanguage.model.ChatModel;
+import io.github.mucsi96.learnlanguage.model.OperationType;
+import io.github.mucsi96.learnlanguage.model.SimpleCardSuggestion;
+import io.github.mucsi96.learnlanguage.repository.CardRepository;
+import lombok.RequiredArgsConstructor;
+import tools.jackson.databind.json.JsonMapper;
+
+@Service
+@RequiredArgsConstructor
+public class PromptCardGenerationService {
+
+  record GeneratedCard(String frontText, String backText, String topic) {
+  }
+
+  record GeneratedCards(List<GeneratedCard> cards) {
+  }
+
+  private final JsonMapper jsonMapper;
+  private final ChatService chatService;
+  private final CardRepository cardRepository;
+
+  public List<SimpleCardSuggestion> generateCards(
+      Source source,
+      String generationPrompt,
+      int count,
+      ChatModel model) {
+
+    final List<Card> existingCards = cardRepository.findBySource_IdIn(List.of(source.getId()));
+
+    final GeneratedCards result = chatService.callWithLogging(
+        model,
+        OperationType.CARD_GENERATION,
+        buildSystemPrompt(source, existingCards, count),
+        buildUserMessage(generationPrompt, count),
+        GeneratedCards.class);
+
+    return result.cards().stream()
+        .map(card -> SimpleCardSuggestion.builder()
+            .frontText(card.frontText())
+            .backText(card.backText())
+            .topic(normalize(card.topic()))
+            .build())
+        .toList();
+  }
+
+  private String buildSystemPrompt(Source source, List<Card> existingCards, int count) {
+    final String existingSummary = existingCards.isEmpty()
+        ? "There are no existing cards yet."
+        : existingCards.stream()
+            .map(Card::getData)
+            .filter(data -> data != null && data.getFrontText() != null)
+            .map(this::describeExistingCard)
+            .collect(Collectors.joining("\n"));
+
+    final String basePrompt = """
+        You are an expert tutor building a spaced-repetition flashcard deck for a learner.
+
+        Deck topic (base prompt):
+        %s
+
+        Your task:
+        1. Infer the full curriculum of topics implied by the deck topic above (the areas an exam or
+           exercise on this subject would cover).
+        2. Generate exactly %d new, high-quality flashcards that best advance coverage of that curriculum.
+           Prioritise topics that are NOT yet covered or are under-covered by the existing cards listed
+           below. Do NOT duplicate existing cards.
+
+        Card format:
+        - "frontText": the question/prompt side, in GitHub-flavoured Markdown. Bullet lists are allowed.
+        - "backText": the answer/explanation side, in GitHub-flavoured Markdown. Bullet lists are allowed.
+        - "topic": a short topic label (a few words) naming the curriculum area this card belongs to.
+          Reuse the exact same label for cards in the same area so coverage can be tracked.
+
+        Rules:
+        - Keep each card focused on a single fact, concept or skill.
+        - Keep cards self-contained and unambiguous.
+        - Respond ONLY with JSON of the form {"cards": [...]} matching the example shape below.
+
+        Existing cards (frontText -> topic):
+        %s
+        """.formatted(
+        source.getPrompt() != null ? source.getPrompt() : "",
+        count,
+        existingSummary);
+
+    final GeneratedCards example = new GeneratedCards(List.of(
+        new GeneratedCard(
+            "What command creates a pod named `nginx` using the `nginx` image?",
+            "```sh\nkubectl run nginx --image=nginx\n```",
+            "Pods")));
+
+    return basePrompt + "\nExample JSON response shape:\n" + jsonMapper.writeValueAsString(example);
+  }
+
+  private String describeExistingCard(CardData data) {
+    final String topic = data.getTopic() != null ? data.getTopic() : "(untagged)";
+    return "- " + data.getFrontText().replaceAll("\\s+", " ").trim() + " -> " + topic;
+  }
+
+  private String buildUserMessage(String generationPrompt, int count) {
+    final String extra = generationPrompt != null && !generationPrompt.isBlank()
+        ? "\nAdditional instructions for this batch: " + generationPrompt.trim()
+        : "";
+    return "Generate exactly %d new cards that improve coverage of the deck topic.%s".formatted(count, extra);
+  }
+
+  private String normalize(String value) {
+    if (value == null) {
+      return null;
+    }
+    final String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+}

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/cardtype/CardTypeStrategyFactory.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/cardtype/CardTypeStrategyFactory.java
@@ -11,6 +11,7 @@ public class CardTypeStrategyFactory {
     private final VocabularyCardTypeStrategy vocabularyCardTypeStrategy;
     private final SpeechCardTypeStrategy speechCardTypeStrategy;
     private final GrammarCardTypeStrategy grammarCardTypeStrategy;
+    private final SimpleCardTypeStrategy simpleCardTypeStrategy;
 
     public CardTypeStrategy getStrategy(CardType cardType) {
         if (cardType == null) {
@@ -21,6 +22,7 @@ public class CardTypeStrategyFactory {
             case VOCABULARY -> vocabularyCardTypeStrategy;
             case SPEECH -> speechCardTypeStrategy;
             case GRAMMAR -> grammarCardTypeStrategy;
+            case SIMPLE -> simpleCardTypeStrategy;
         };
     }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/cardtype/SimpleCardTypeStrategy.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/cardtype/SimpleCardTypeStrategy.java
@@ -1,0 +1,21 @@
+package io.github.mucsi96.learnlanguage.service.cardtype;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import io.github.mucsi96.learnlanguage.model.CardData;
+
+@Component
+public class SimpleCardTypeStrategy implements CardTypeStrategy {
+
+    @Override
+    public String getPrimaryText(CardData cardData) {
+        return cardData.getFrontText();
+    }
+
+    @Override
+    public List<AudioTextItem> getRequiredAudioTexts(CardData cardData) {
+        return List.of();
+    }
+}

--- a/server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -755,12 +755,13 @@ databaseChangeLog:
                   rs.review_score,
                   cs.correct_streak,
                   CASE WHEN c.readiness IN ('READY', 'REVIEWED', 'KNOWN') AND (
-                      (s.card_type <> 'GRAMMAR' AND (c.data->'translation'->>'en' IS NULL OR TRIM(c.data->'translation'->>'en') = '')) OR
-                      (s.card_type <> 'GRAMMAR' AND (c.data->'translation'->>'hu' IS NULL OR TRIM(c.data->'translation'->>'hu') = '')) OR
-                      (s.card_type <> 'GRAMMAR' AND (c.data->'translation'->>'ch' IS NULL OR TRIM(c.data->'translation'->>'ch') = '')) OR
+                      (s.card_type NOT IN ('GRAMMAR', 'SIMPLE') AND (c.data->'translation'->>'en' IS NULL OR TRIM(c.data->'translation'->>'en') = '')) OR
+                      (s.card_type NOT IN ('GRAMMAR', 'SIMPLE') AND (c.data->'translation'->>'hu' IS NULL OR TRIM(c.data->'translation'->>'hu') = '')) OR
+                      (s.card_type NOT IN ('GRAMMAR', 'SIMPLE') AND (c.data->'translation'->>'ch' IS NULL OR TRIM(c.data->'translation'->>'ch') = '')) OR
                       (s.card_type = 'VOCABULARY' AND c.data->>'type' = 'NOUN' AND (c.data->>'gender' IS NULL OR TRIM(c.data->>'gender') = '')) OR
                       (s.card_type = 'VOCABULARY' AND (c.data->>'type' IS NULL OR TRIM(c.data->>'type') = '')) OR
-                      (s.card_type = 'GRAMMAR' AND (c.data->'examples'->0->>'hu' IS NULL OR TRIM(c.data->'examples'->0->>'hu') = ''))
+                      (s.card_type = 'GRAMMAR' AND (c.data->'examples'->0->>'hu' IS NULL OR TRIM(c.data->'examples'->0->>'hu') = '')) OR
+                      (s.card_type = 'SIMPLE' AND (c.data->>'frontText' IS NULL OR TRIM(c.data->>'frontText') = '' OR c.data->>'backText' IS NULL OR TRIM(c.data->>'backText') = ''))
                   ) THEN true ELSE false END AS is_unhealthy,
                   CASE WHEN c.readiness = 'READY'
                       AND c.state = 'REVIEW'
@@ -1015,3 +1016,47 @@ databaseChangeLog:
               - column:
                   name: description
                   type: text
+  - changeSet:
+      id: 32-add-prompt-to-sources
+      author: mucsi96
+      changes:
+        - addColumn:
+            tableName: sources
+            columns:
+              - column:
+                  name: prompt
+                  type: text
+  - changeSet:
+      id: 33-seed-card-generation-model-settings
+      author: mucsi96
+      changes:
+        - insert:
+            tableName: chat_model_settings
+            columns:
+              - column:
+                  name: model_name
+                  value: claude-opus-4-8
+              - column:
+                  name: operation_type
+                  value: CARD_GENERATION
+              - column:
+                  name: is_enabled
+                  valueBoolean: true
+              - column:
+                  name: is_primary
+                  valueBoolean: true
+        - insert:
+            tableName: chat_model_settings
+            columns:
+              - column:
+                  name: model_name
+                  value: gpt-5.5
+              - column:
+                  name: operation_type
+                  value: CARD_GENERATION
+              - column:
+                  name: is_enabled
+                  valueBoolean: true
+              - column:
+                  name: is_primary
+                  valueBoolean: false

--- a/test/tests/ai-prompt-source.spec.ts
+++ b/test/tests/ai-prompt-source.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect } from '../fixtures';
+import { Page } from '@playwright/test';
+import {
+  createCard,
+  createChatModelSetting,
+  createSource,
+  getSource,
+  setupDefaultChatModelSettings,
+  withDbConnection,
+} from '../utils';
+
+async function pressRemoteKey(page: Page, key: string) {
+  await page.evaluate(
+    (k) =>
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: k, bubbles: true })
+      ),
+    key
+  );
+}
+
+async function enableCardGenerationModel() {
+  await setupDefaultChatModelSettings();
+  await createChatModelSetting({
+    modelName: 'gemini-3.1-pro-preview',
+    operationType: 'CARD_GENERATION',
+    isEnabled: true,
+    isPrimary: true,
+  });
+}
+
+test('create AI prompt source, generate, preview and create simple cards', async ({ page }) => {
+  await enableCardGenerationModel();
+
+  await page.goto('/sources');
+  await page.getByRole('button', { name: 'Add Source' }).click();
+
+  await page.getByRole('textbox', { name: 'Name', exact: true }).fill('CKAD Prep');
+  await page.getByLabel('Source Type').click();
+  await page.getByRole('option', { name: 'AI Prompt' }).click();
+  await page.getByLabel('Language Level').click();
+  await page.getByRole('option', { name: 'A1' }).click();
+  await page
+    .getByLabel('Base prompt')
+    .fill('Kubernetes Application Developer (CKAD) certification exam preparation');
+
+  await page.getByRole('button', { name: 'Create' }).click();
+
+  await expect(page.getByText('CKAD Prep')).toBeVisible();
+
+  const source = await getSource('ckad-prep');
+  expect(source?.sourceType).toBe('AI_PROMPT');
+  expect(source?.cardType).toBe('SIMPLE');
+
+  await withDbConnection(async (client) => {
+    const result = await client.query(
+      `SELECT prompt FROM learn_language.sources WHERE id = $1`,
+      ['ckad-prep']
+    );
+    expect(result.rows[0].prompt).toContain('CKAD');
+  });
+
+  await page.getByRole('button', { name: 'Actions for CKAD Prep' }).click();
+  await page.getByRole('menuitem', { name: 'Pages' }).click();
+
+  await expect(page).toHaveURL(/\/sources\/ckad-prep\/prompt/);
+
+  const coverageList = page.getByRole('list', { name: 'Topic coverage' });
+  await expect(coverageList.getByText('Services & Networking')).toBeVisible();
+  await expect(coverageList.getByText('Pods')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Generate' }).click();
+
+  await expect(page.getByText(/What command creates a pod named/)).toBeVisible();
+
+  await page.getByRole('button', { name: /Create 2 cards/ }).click();
+
+  await expect.poll(async () =>
+    withDbConnection(async (client) => {
+      const result = await client.query(
+        `SELECT data FROM learn_language.cards WHERE source_id = $1`,
+        ['ckad-prep']
+      );
+      return result.rows.length;
+    })
+  ).toBe(2);
+
+  await withDbConnection(async (client) => {
+    const result = await client.query(
+      `SELECT data, readiness FROM learn_language.cards WHERE source_id = $1`,
+      ['ckad-prep']
+    );
+    for (const row of result.rows) {
+      expect(row.data.frontText).toBeTruthy();
+      expect(row.data.backText).toBeTruthy();
+      expect(row.data.topic).toBe('Pods');
+      expect(row.readiness).toBe('IN_REVIEW');
+    }
+  });
+
+  const podsRow = coverageList.getByRole('listitem').filter({ hasText: 'Pods' });
+  await expect(podsRow).toContainText('2');
+});
+
+test('study mode renders a simple card front and back as markdown', async ({ page }) => {
+  await createSource({
+    id: 'ckad-study',
+    name: 'CKAD Study',
+    startPage: 1,
+    languageLevel: 'A1',
+    cardType: 'SIMPLE',
+    formatType: 'FLOWING_TEXT',
+    sourceType: 'AI_PROMPT',
+  });
+
+  await createCard({
+    cardId: 'ckad-pods-1',
+    sourceId: 'ckad-study',
+    sourcePageNumber: 1,
+    data: {
+      frontText: 'What is a **Pod**?',
+      backText: 'A Pod is the smallest deployable unit.\n\n- holds containers\n- shares network',
+      topic: 'Pods',
+    },
+  });
+
+  await page.goto('/sources/ckad-study/study');
+  await page.getByRole('button', { name: 'Start study session' }).click();
+
+  const flashcard = page.getByRole('article', { name: 'Flashcard' });
+  await expect(flashcard.getByText(/What is a/)).toBeVisible();
+  await expect(flashcard.getByText('holds containers')).not.toBeVisible();
+
+  await pressRemoteKey(page, 'Enter');
+
+  await expect(flashcard.getByText('holds containers')).toBeVisible();
+  await expect(flashcard.getByText('shares network')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
Introduces a new "AI Prompt" source type that enables users to generate flashcards using AI models. This feature includes card generation from prompts, coverage analysis of existing cards, and a dedicated UI for managing prompt-based sources.

## Key Changes

### Backend
- **New source type**: Added `AI_PROMPT` to `SourceType` enum with support for storing base prompts in the `Source` entity
- **Card generation service**: `PromptCardGenerationService` generates flashcard suggestions using configured chat models, with intelligent curriculum inference and duplicate avoidance
- **Coverage analysis service**: `CoverageService` analyzes how well existing cards cover the inferred curriculum topics
- **New card type**: `SimpleCardTypeStrategy` for simple question-answer cards with optional topic labels
- **API endpoints**: Added `/api/source/{sourceId}/generate-cards` and `/api/source/{sourceId}/coverage` endpoints in `SourceController`
- **Model support**: Added `CARD_GENERATION` operation type and pricing configuration for supported chat models

### Frontend
- **Prompt page component**: New dedicated UI (`PromptPageComponent`) for managing AI prompt sources with sections for:
  - Base prompt editing and saving
  - Coverage overview visualization
  - Card generation with customizable prompts and model selection
  - Preview and selection of generated cards before creation
- **Coverage overview component**: Displays topic coverage status with visual indicators
- **Simple card study component**: `LearnSimpleCardComponent` renders simple cards with markdown support for front/back text
- **Card type strategy**: `SimpleCardType` implements extraction and display logic for simple cards
- **Type definitions**: Extended `CardData`, `CardType`, and `SourceType` to support simple cards
- **Markdown rendering**: Added `MarkdownPipe` for rendering markdown content in cards and previews
- **Routing**: Added route `/sources/:sourceId/prompt` for the prompt management page
- **Source dialog**: Updated to show "Simple" card type option only for AI Prompt sources

### Database
- Added `prompt` column to `sources` table for storing base prompts
- Updated card readiness query to exclude `SIMPLE` card type from translation validation requirements

### Testing
- Added comprehensive E2E test covering the full workflow: source creation, card generation, preview, and creation

## Implementation Details
- Card generation uses system prompts that include existing card summaries to avoid duplication and prioritize curriculum coverage gaps
- Coverage analysis infers the full curriculum from the base prompt and evaluates how many cards address each topic
- Generated cards are created with `IN_REVIEW` readiness status for quality control
- The UI uses Angular signals for reactive state management and Material Design components for consistency

https://claude.ai/code/session_01RHWTiLxjyAidyMPjoYxzMo