### PR TITLE
Add rate limit retry interceptor for API requests

### DIFF
--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -21,6 +21,7 @@ import { provideOidcAuth } from './auth.config';
 import { AuthService } from './auth.service';
 import { authRetryInterceptor } from './utils/auth-retry.interceptor';
 import { errorInterceptor } from './utils/error.interceptor';
+import { rateLimitRetryInterceptor } from './utils/rate-limit-retry.interceptor';
 import { timezoneInterceptor } from './utils/timezone.interceptor';
 import { tokenInterceptor } from './utils/token.interceptor';
 import {
@@ -41,6 +42,7 @@ export function getAppConfig(environment: EnvironmentConfig): ApplicationConfig 
         withInterceptors([
           errorInterceptor,
           authRetryInterceptor,
+          rateLimitRetryInterceptor,
           tokenInterceptor,
           timezoneInterceptor,
         ])

--- a/client/src/app/utils/auth-retry.interceptor.ts
+++ b/client/src/app/utils/auth-retry.interceptor.ts
@@ -2,8 +2,7 @@ import { HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { catchError, from, switchMap, tap, throwError } from 'rxjs';
 import { AuthService } from '../auth.service';
-
-const isApiRequest = (url: string): boolean => /\/api(\/|$)/.test(url);
+import { isApiRequest } from './http.util';
 
 /**
  * Recovers from an expired access token without forcing a full re-login.

--- a/client/src/app/utils/http.util.ts
+++ b/client/src/app/utils/http.util.ts
@@ -1,0 +1,1 @@
+export const isApiRequest = (url: string): boolean => /\/api(\/|$)/.test(url);

--- a/client/src/app/utils/rate-limit-retry.interceptor.ts
+++ b/client/src/app/utils/rate-limit-retry.interceptor.ts
@@ -1,7 +1,6 @@
 import { HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
 import { retry, throwError, timer } from 'rxjs';
-
-const isApiRequest = (url: string): boolean => /\/api(\/|$)/.test(url);
+import { isApiRequest } from './http.util';
 
 const MAX_RETRIES = 6;
 const BASE_DELAY_MS = 1000;

--- a/client/src/app/utils/rate-limit-retry.interceptor.ts
+++ b/client/src/app/utils/rate-limit-retry.interceptor.ts
@@ -55,15 +55,15 @@ export const rateLimitRetryInterceptor: HttpInterceptorFn = (req, next) =>
     retry({
       count: MAX_RETRIES,
       delay: (error: unknown, retryCount: number) => {
-        const is429 =
-          error instanceof HttpErrorResponse && error.status === 429;
-
-        if (!is429 || !isApiRequest(req.url)) {
+        if (
+          !(error instanceof HttpErrorResponse) ||
+          error.status !== 429 ||
+          !isApiRequest(req.url)
+        ) {
           return throwError(() => error);
         }
 
-        const waitMs =
-          retryAfterMs(error as HttpErrorResponse) ?? backoffDelayMs(retryCount);
+        const waitMs = retryAfterMs(error) ?? backoffDelayMs(retryCount);
         console.warn(
           '[rate-limit] API request returned 429 - backing off and retrying',
           JSON.stringify({ url: req.url, retryCount, waitMs: Math.round(waitMs) })

--- a/client/src/app/utils/rate-limit-retry.interceptor.ts
+++ b/client/src/app/utils/rate-limit-retry.interceptor.ts
@@ -1,0 +1,52 @@
+import { HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
+import { retry, throwError, timer } from 'rxjs';
+
+const isApiRequest = (url: string): boolean => /\/api(\/|$)/.test(url);
+
+const MAX_RETRIES = 6;
+const BASE_DELAY_MS = 1000;
+const MAX_DELAY_MS = 30_000;
+
+const backoffDelayMs = (retryCount: number): number => {
+  const exponential = Math.min(
+    BASE_DELAY_MS * 2 ** (retryCount - 1),
+    MAX_DELAY_MS
+  );
+  return exponential / 2 + Math.random() * (exponential / 2);
+};
+
+/**
+ * Survives upstream rate limiting (Cloudflare returns 429 and blocks the
+ * client IP for a fixed window) without corrupting in-flight work.
+ *
+ * During bulk operations the app fans out many concurrent polls and fetches.
+ * A burst can trip the rate limiter, after which every request comes back 429
+ * for the duration of the block. Treat that as "keep waiting": retry the
+ * request with exponential backoff and equal jitter so a transient block never
+ * surfaces as a failed image job or card fetch, and so parallel callers
+ * de-synchronize instead of hammering the limiter in lockstep.
+ *
+ * Sits inside the error interceptor so a successful retry never raises a
+ * spurious error notification; only an exhausted retry budget propagates.
+ */
+export const rateLimitRetryInterceptor: HttpInterceptorFn = (req, next) =>
+  next(req).pipe(
+    retry({
+      count: MAX_RETRIES,
+      delay: (error: unknown, retryCount: number) => {
+        const is429 =
+          error instanceof HttpErrorResponse && error.status === 429;
+
+        if (!is429 || !isApiRequest(req.url)) {
+          return throwError(() => error);
+        }
+
+        const waitMs = backoffDelayMs(retryCount);
+        console.warn(
+          '[rate-limit] API request returned 429 - backing off and retrying',
+          JSON.stringify({ url: req.url, retryCount, waitMs: Math.round(waitMs) })
+        );
+        return timer(waitMs);
+      },
+    })
+  );

--- a/client/src/app/utils/rate-limit-retry.interceptor.ts
+++ b/client/src/app/utils/rate-limit-retry.interceptor.ts
@@ -15,6 +15,25 @@ const backoffDelayMs = (retryCount: number): number => {
   return exponential / 2 + Math.random() * (exponential / 2);
 };
 
+const retryAfterMs = (error: HttpErrorResponse): number | undefined => {
+  const header = error.headers.get('Retry-After');
+  if (!header) {
+    return undefined;
+  }
+
+  const seconds = Number(header);
+  if (Number.isFinite(seconds)) {
+    return Math.min(Math.max(seconds, 0) * 1000, MAX_DELAY_MS);
+  }
+
+  const dateMs = Date.parse(header);
+  if (Number.isFinite(dateMs)) {
+    return Math.min(Math.max(dateMs - Date.now(), 0), MAX_DELAY_MS);
+  }
+
+  return undefined;
+};
+
 /**
  * Survives upstream rate limiting (Cloudflare returns 429 and blocks the
  * client IP for a fixed window) without corrupting in-flight work.
@@ -24,7 +43,9 @@ const backoffDelayMs = (retryCount: number): number => {
  * for the duration of the block. Treat that as "keep waiting": retry the
  * request with exponential backoff and equal jitter so a transient block never
  * surfaces as a failed image job or card fetch, and so parallel callers
- * de-synchronize instead of hammering the limiter in lockstep.
+ * de-synchronize instead of hammering the limiter in lockstep. When the 429
+ * carries a Retry-After header it is honored (capped) in preference to the
+ * computed backoff.
  *
  * Sits inside the error interceptor so a successful retry never raises a
  * spurious error notification; only an exhausted retry budget propagates.
@@ -41,7 +62,8 @@ export const rateLimitRetryInterceptor: HttpInterceptorFn = (req, next) =>
           return throwError(() => error);
         }
 
-        const waitMs = backoffDelayMs(retryCount);
+        const waitMs =
+          retryAfterMs(error as HttpErrorResponse) ?? backoffDelayMs(retryCount);
         console.warn(
           '[rate-limit] API request returned 429 - backing off and retrying',
           JSON.stringify({ url: req.url, retryCount, waitMs: Math.round(waitMs) })


### PR DESCRIPTION
## Summary
Adds an HTTP interceptor that automatically retries API requests that receive 429 (Too Many Requests) responses from upstream rate limiters like Cloudflare, using exponential backoff with jitter to prevent thundering herd issues.

## Changes
- **New file**: `client/src/app/utils/rate-limit-retry.interceptor.ts`
  - Implements `rateLimitRetryInterceptor` that catches 429 responses on API requests
  - Retries up to 6 times with exponential backoff (1s to 30s) and equal jitter
  - Only retries API requests (matching `/api/` path pattern); other errors propagate immediately
  - Logs retry attempts with URL, retry count, and wait duration for observability
  - Prevents transient rate limit blocks from surfacing as failed operations during bulk concurrent requests

- **Modified**: `client/src/app/app.config.ts`
  - Registers the new interceptor in the HTTP interceptor chain (after error and auth retry interceptors)

## Implementation Details
- Uses RxJS `retry` operator with custom delay logic to implement exponential backoff with jitter
- Jitter formula: `exponential / 2 + Math.random() * (exponential / 2)` prevents synchronized retry storms
- Only targets API endpoints to avoid retrying non-API requests unnecessarily
- Positioned in the interceptor chain to allow successful retries to bypass error notifications

https://claude.ai/code/session_018eQg24ZF2xzNmfE6DWe7aK