### PR TITLE
Ensure image descriptions are always generated in English

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
@@ -25,6 +25,7 @@ public class ImageService {
       their positions and spatial relationships, the setting, lighting and mood. \
       Use simple, unambiguous language an image model can follow. \
       The scene must not contain any text, letters, numbers, signs with writing or captions. \
+      Always write the description in English, regardless of the language of the input. \
       Respond with the description only.""";
 
   private final OpenAIImageService openAIImageService;


### PR DESCRIPTION
## Summary
Updated the image description prompt to explicitly require English output regardless of the input language. This ensures consistency in generated image descriptions across the application.

## Changes
- Added instruction to the ImageService prompt to always generate descriptions in English, regardless of the language of the input text

## Implementation Details
The change modifies the system prompt used when generating image descriptions via the OpenAI service. By explicitly stating "Always write the description in English, regardless of the language of the input," we ensure that image descriptions are consistently produced in English, which improves consistency and usability across the application regardless of what language users provide as input.

https://claude.ai/code/session_01CbGomTpdfUB4cw63pL153M