### PR TITLE
Use context directly for image descriptions instead of appending to German text

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
@@ -52,15 +52,13 @@ public class ImageService {
   }
 
   private String describeScene(String input, String context) {
-    final String contextSegment = context == null || context.isBlank()
-        ? ""
-        : " Additional context: " + context + ".";
+    final String descriptionInput = context == null || context.isBlank() ? input : context;
     final String description = chatService.callForTextWithLogging(
         resolveDescriptionModel(),
         OperationType.IMAGE_DESCRIPTION,
         DESCRIPTION_SYSTEM_PROMPT,
-        input + contextSegment);
-    log.info("Generated image description for input \"{}\": {}", input, description);
+        descriptionInput);
+    log.info("Generated image description for input \"{}\": {}", descriptionInput, description);
     return description;
   }
 

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -571,6 +571,69 @@ test('add image with context dialog', async ({ page }) => {
   await expect(page.getByRole('img')).toHaveCount(5);
 });
 
+test('described image uses context instead of German sentence', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await createImageModelSetting({
+    modelName: 'gemini-3-pro-image-preview',
+    imageCount: 0,
+    describedImageCount: 1,
+  });
+  const image1 = uploadMockImage(blueImage);
+  await createCard({
+    cardId: 'abfahren-elindulni',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'abfahren',
+      type: 'VERB',
+      forms: ['fährt ab', 'fuhr ab', 'abgefahren'],
+      translation: {
+        en: 'to leave',
+        hu: 'elindulni, elhagyni',
+        ch: 'abfahra, verlah',
+      },
+      examples: [
+        {
+          de: 'Wann fährt der Zug ab?',
+          hu: 'Mikor indul a vonat?',
+          en: 'When does the train leave?',
+          ch: 'Wänn fahrt dr Zug ab?',
+          images: [{ id: image1 }],
+          isSelected: true,
+        },
+      ],
+    },
+  });
+  await navigateToCardEditing(page);
+  await expect(page.getByRole('img')).toHaveCount(1);
+
+  await page.getByRole('button', { name: 'Add image with context' }).first().click();
+  await page
+    .getByRole('textbox', { name: 'Image generation context' })
+    .fill('A vintage steam train at sunset');
+  await page.getByRole('button', { name: 'Generate' }).click();
+  await expect(page.getByRole('dialog', { name: 'Image generation context' })).toBeHidden();
+  await expect(page.getByRole('img')).toHaveCount(2);
+
+  await expect(page.getByText('described', { exact: true })).toHaveCount(1);
+  await expect(page.getByText('Card updated successfully')).toBeVisible();
+
+  await withDbConnection(async (client) => {
+    const result = await client.query(
+      "SELECT data FROM learn_language.cards WHERE id = 'abfahren-elindulni'"
+    );
+    const cardData = result.rows[0].data;
+    expect(cardData.examples[0].images[1].description).toContain('A vintage steam train at sunset');
+    expect(cardData.examples[0].images[1].description).not.toContain('Wann fährt der Zug ab?');
+  });
+
+  const logs = await getModelUsageLogs();
+  const descriptionLog = logs.find((log) => log.operationType === 'IMAGE_DESCRIPTION');
+  expect(descriptionLog).toBeDefined();
+  expect(descriptionLog!.responseContent).toContain('A vintage steam train at sunset');
+  expect(descriptionLog!.responseContent).not.toContain('Wann fährt der Zug ab?');
+});
+
 test('image generation sends German example by default', async ({ page }) => {
   await setupDefaultChatModelSettings();
   await setupDefaultImageModelSettings();


### PR DESCRIPTION
## Summary
Changed the image description generation logic to use the provided context directly as the input to the description model, rather than appending it as additional context to the original German sentence. This ensures that when a user provides a custom context for image generation, that context becomes the primary source for the image description instead of being supplementary to the German example text.

## Key Changes
- **ImageService.describeScene()**: Modified to use `context` as the primary input when available, falling back to the original `input` only when context is null or blank
  - Removed the "Additional context:" prefix approach that was appending context to the German sentence
  - Simplified the logic to be a straightforward conditional: use context if provided, otherwise use input
- **Test coverage**: Added comprehensive test `'described image uses context instead of German sentence'` that verifies:
  - When generating an image with custom context, the description contains the context text
  - The description does not contain the original German sentence
  - Database records the correct description
  - Model usage logs capture the context-based description, not the German text

## Implementation Details
This change prioritizes user-provided context over the original input text when describing generated images, giving users more control over how their images are described in the learning system.

https://claude.ai/code/session_0159U5AF9mDyzTZm6rNuiFow