### PR TITLE
Hide generation method badge while loading image data

### DIFF
--- a/client/src/app/shared/image-carousel/image-carousel.component.html
+++ b/client/src/app/shared/image-carousel/image-carousel.component.html
@@ -31,7 +31,7 @@
     <app-image-model-badge
       [model]="imageResource?.value()?.model"
       [description]="imageResource?.value()?.description"
-      [loading]="imageResource?.isLoading()"
+      [loading]="imageResource?.isLoading() ?? false"
     />
     <div class="carousel-controls">
       <button

--- a/client/src/app/shared/image-carousel/image-carousel.component.html
+++ b/client/src/app/shared/image-carousel/image-carousel.component.html
@@ -31,6 +31,7 @@
     <app-image-model-badge
       [model]="imageResource?.value()?.model"
       [description]="imageResource?.value()?.description"
+      [loading]="imageResource?.isLoading()"
     />
     <div class="carousel-controls">
       <button

--- a/client/src/app/shared/image-grid/image-grid.component.html
+++ b/client/src/app/shared/image-grid/image-grid.component.html
@@ -27,6 +27,7 @@
     <app-image-model-badge
       [model]="imageResource.value()?.model"
       [description]="imageResource.value()?.description"
+      [loading]="imageResource.isLoading()"
     />
   </div>
 }

--- a/client/src/app/shared/image-model-badge/image-model-badge.component.html
+++ b/client/src/app/shared/image-model-badge/image-model-badge.component.html
@@ -1,12 +1,14 @@
 @if (model()) {
   <span class="model-name">
     {{ model() }}
-    <span
-      class="generation-method"
-      [class.has-tooltip]="description()"
-      [matTooltip]="description() ?? ''"
-      [matTooltipDisabled]="!description()"
-      >{{ description() ? "described" : "direct" }}</span
-    >
+    @if (!loading()) {
+      <span
+        class="generation-method"
+        [class.has-tooltip]="description()"
+        [matTooltip]="description() ?? ''"
+        [matTooltipDisabled]="!description()"
+        >{{ description() ? "described" : "direct" }}</span
+      >
+    }
   </span>
 }

--- a/client/src/app/shared/image-model-badge/image-model-badge.component.ts
+++ b/client/src/app/shared/image-model-badge/image-model-badge.component.ts
@@ -10,5 +10,5 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 export class ImageModelBadgeComponent {
   model = input<string>();
   description = input<string>();
-  loading = input<boolean>();
+  loading = input<boolean>(false);
 }

--- a/client/src/app/shared/image-model-badge/image-model-badge.component.ts
+++ b/client/src/app/shared/image-model-badge/image-model-badge.component.ts
@@ -10,4 +10,5 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 export class ImageModelBadgeComponent {
   model = input<string>();
   description = input<string>();
+  loading = input<boolean>();
 }


### PR DESCRIPTION
## Summary
Add loading state handling to the image model badge component to hide the generation method indicator while image data is being loaded.

## Changes
- Added `loading` input property to `ImageModelBadgeComponent` to track loading state
- Wrapped the generation method badge (`described`/`direct` indicator) in a conditional block that only renders when not loading
- Updated `image-carousel.component.html` to pass the `isLoading()` state to the badge component
- Updated `image-grid.component.html` to pass the `isLoading()` state to the badge component

## Implementation Details
The generation method badge is now hidden during the loading phase, preventing the display of potentially stale or incomplete information. The model name remains visible while loading, but the generation method indicator is only shown once the image data has fully loaded.

https://claude.ai/code/session_01NmKArxtsLcoPEe8k3pBiDv