### PR TITLE
Reset FSRS state when moving cards back to draft

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepositoryCustom.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepositoryCustom.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface CardRepositoryCustom {
     void updateReadinessByIds(List<String> ids, CardReadiness readiness);
+
+    void resetFsrsAndMarkDraftByIds(List<String> ids);
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepositoryCustomImpl.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/CardRepositoryCustomImpl.java
@@ -9,10 +9,13 @@ import jakarta.persistence.criteria.CriteriaUpdate;
 import jakarta.persistence.criteria.Root;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RequiredArgsConstructor
 public class CardRepositoryCustomImpl implements CardRepositoryCustom {
+    private static final String NEW_STATE = "NEW";
+
     private final EntityManager entityManager;
 
     @Override
@@ -22,6 +25,28 @@ public class CardRepositoryCustomImpl implements CardRepositoryCustom {
         final Root<Card> root = update.from(Card.class);
 
         update.set(root.get(Card_.readiness), readiness);
+        update.where(root.get(Card_.id).in(ids));
+
+        entityManager.createQuery(update).executeUpdate();
+    }
+
+    @Override
+    public void resetFsrsAndMarkDraftByIds(List<String> ids) {
+        final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        final CriteriaUpdate<Card> update = cb.createCriteriaUpdate(Card.class);
+        final Root<Card> root = update.from(Card.class);
+
+        update.set(root.get(Card_.readiness), CardReadiness.DRAFT);
+        update.set(root.get(Card_.due), LocalDateTime.now());
+        update.set(root.get(Card_.stability), 0f);
+        update.set(root.get(Card_.difficulty), 0f);
+        update.set(root.get(Card_.elapsedDays), 0f);
+        update.set(root.get(Card_.scheduledDays), 0f);
+        update.set(root.get(Card_.learningSteps), 0);
+        update.set(root.get(Card_.reps), 0);
+        update.set(root.get(Card_.lapses), 0);
+        update.set(root.get(Card_.state), NEW_STATE);
+        update.set(root.get(Card_.lastReview), (LocalDateTime) null);
         update.where(root.get(Card_.id).in(ids));
 
         entityManager.createQuery(update).executeUpdate();

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/CardService.java
@@ -202,7 +202,8 @@ public class CardService {
 
   @Transactional
   public void markCardsAsDraft(List<String> cardIds) {
-    cardRepository.updateReadinessByIds(cardIds, CardReadiness.DRAFT);
+    reviewLogRepository.deleteByCardIdIn(cardIds);
+    cardRepository.resetFsrsAndMarkDraftByIds(cardIds);
   }
 
   public List<String> getFilteredCardIds(

--- a/test/tests/cards-table-page.spec.ts
+++ b/test/tests/cards-table-page.spec.ts
@@ -157,13 +157,25 @@ test('marks selected cards as known', async ({ page }) => {
   await expect(page.getByText('1 card(s) marked as known')).toBeVisible();
 });
 
-test('moves selected ready cards back to draft', async ({ page }) => {
+test('moves selected ready cards back to draft and resets FSRS state', async ({ page }) => {
   await createCard({
     cardId: 'move-draft-card',
     sourceId: 'goethe-a1',
     sourcePageNumber: 9,
     data: { word: 'zurück', type: 'ADVERB', translation: { en: 'back' } },
     readiness: 'READY',
+    state: 'REVIEW',
+    stability: 30.5,
+    difficulty: 4.2,
+    reps: 5,
+    lapses: 1,
+    lastReview: new Date(),
+  });
+
+  await createReviewLog({
+    cardId: 'move-draft-card',
+    rating: 3,
+    review: new Date(),
   });
 
   await page.goto('/sources/goethe-a1/cards');
@@ -185,9 +197,21 @@ test('moves selected ready cards back to draft', async ({ page }) => {
 
   await withDbConnection(async (client) => {
     const result = await client.query(
-      `SELECT readiness FROM learn_language.cards WHERE id = 'move-draft-card'`
+      `SELECT readiness, state, reps, lapses, stability, difficulty, last_review
+       FROM learn_language.cards WHERE id = 'move-draft-card'`
     );
     expect(result.rows[0].readiness).toBe('DRAFT');
+    expect(result.rows[0].state).toBe('NEW');
+    expect(result.rows[0].reps).toBe(0);
+    expect(result.rows[0].lapses).toBe(0);
+    expect(result.rows[0].stability).toBe(0);
+    expect(result.rows[0].difficulty).toBe(0);
+    expect(result.rows[0].last_review).toBeNull();
+
+    const logs = await client.query(
+      `SELECT count(*) FROM learn_language.review_logs WHERE card_id = 'move-draft-card'`
+    );
+    expect(Number(logs.rows[0].count)).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary
When moving cards from READY status back to DRAFT, the system now properly resets all FSRS (Free Spaced Repetition Scheduling) state and clears associated review logs, ensuring cards start fresh in the learning process.

## Key Changes
- **CardService**: Updated `markCardsAsDraft()` to delete review logs and reset FSRS state instead of just updating readiness
- **CardRepositoryCustom**: Added new `resetFsrsAndMarkDraftByIds()` method to comprehensively reset card state
- **CardRepositoryCustomImpl**: Implemented `resetFsrsAndMarkDraftByIds()` to reset all FSRS-related fields (stability, difficulty, reps, lapses, state, lastReview, etc.) and set readiness to DRAFT
- **Test**: Enhanced test coverage to verify that moving cards back to draft properly resets FSRS state and clears review logs

## Implementation Details
The new `resetFsrsAndMarkDraftByIds()` method uses JPA Criteria API to perform a single database update that:
- Sets readiness to DRAFT
- Resets FSRS metrics (stability, difficulty, reps, lapses) to 0
- Clears scheduling fields (elapsedDays, scheduledDays, learningSteps)
- Sets card state back to NEW
- Clears lastReview timestamp
- Deletes all associated review logs via `reviewLogRepository.deleteByCardIdIn()`

This ensures cards are in a clean state when returned to draft, allowing users to restart the learning process without residual scheduling data.

https://claude.ai/code/session_01P5xrVFxoAewP6wWAYJutoj