### PR TITLE
Drop direct image generation method

### DIFF
--- a/client/src/app/environment/environment.config.ts
+++ b/client/src/app/environment/environment.config.ts
@@ -11,7 +11,6 @@ export interface ImageModel {
   id: string;
   displayName: string;
   imageCount: number;
-  describedImageCount: number;
 }
 
 export interface AudioModel {

--- a/client/src/app/image-model-settings/image-model-settings.component.html
+++ b/client/src/app/image-model-settings/image-model-settings.component.html
@@ -14,8 +14,7 @@
             <thead>
               <tr>
                 <th class="model-header">Model</th>
-                <th class="count-header">Direct images per card</th>
-                <th class="count-header">Described images per card</th>
+                <th class="count-header">Images per card</th>
               </tr>
             </thead>
             <tbody>
@@ -30,19 +29,7 @@
                         [value]="model.imageCount"
                         (change)="onImageCountChange(model.id, $event)"
                         min="0"
-                        [attr.aria-label]="'Direct image count for ' + model.displayName"
-                      />
-                    </mat-form-field>
-                  </td>
-                  <td class="count-cell">
-                    <mat-form-field class="count-field">
-                      <input
-                        matInput
-                        type="number"
-                        [value]="model.describedImageCount"
-                        (change)="onDescribedImageCountChange(model.id, $event)"
-                        min="0"
-                        [attr.aria-label]="'Described image count for ' + model.displayName"
+                        [attr.aria-label]="'Image count for ' + model.displayName"
                       />
                     </mat-form-field>
                   </td>

--- a/client/src/app/image-model-settings/image-model-settings.component.ts
+++ b/client/src/app/image-model-settings/image-model-settings.component.ts
@@ -68,13 +68,6 @@ export class ImageModelSettingsComponent {
     }
   }
 
-  onDescribedImageCountChange(modelId: string, event: Event): void {
-    const value = this.parseCount(event);
-    if (value !== undefined) {
-      this.service.updateDescribedImageCount(modelId, value);
-    }
-  }
-
   private parseCount(event: Event): number | undefined {
     const input = event.target as HTMLInputElement;
     const value = parseInt(input.value, 10);

--- a/client/src/app/image-model-settings/image-model-settings.service.ts
+++ b/client/src/app/image-model-settings/image-model-settings.service.ts
@@ -9,7 +9,6 @@ import {
 export interface ImageModelSettingRequest {
   modelName: string;
   imageCount: number;
-  describedImageCount: number;
 }
 
 @Injectable({
@@ -30,15 +29,6 @@ export class ImageModelSettingsService {
     this.persistCounts(modelId);
   }
 
-  updateDescribedImageCount(modelId: string, describedImageCount: number): void {
-    this.imageModels.update((models) =>
-      models.map((m) =>
-        m.id === modelId ? { ...m, describedImageCount } : m
-      )
-    );
-    this.persistCounts(modelId);
-  }
-
   private persistCounts(modelId: string): void {
     const model = this.imageModels().find((m) => m.id === modelId);
     if (!model) {
@@ -50,7 +40,6 @@ export class ImageModelSettingsService {
       body: {
         modelName: modelId,
         imageCount: model.imageCount,
-        describedImageCount: model.describedImageCount,
       } satisfies ImageModelSettingRequest,
     });
   }

--- a/client/src/app/parser/types.ts
+++ b/client/src/app/parser/types.ts
@@ -33,7 +33,6 @@ export type ExampleImage = {
   id: string;
   isFavorite?: boolean;
   model?: string;
-  description?: string;
 };
 
 export type Example = {

--- a/client/src/app/shared/image-grid/image-grid.component.html
+++ b/client/src/app/shared/image-grid/image-grid.component.html
@@ -24,10 +24,6 @@
     } @else {
       <mat-icon class="no-image-icon">image_not_supported</mat-icon>
     }
-    <app-image-model-badge
-      [model]="imageResource.value()?.model"
-      [description]="imageResource.value()?.description"
-      [loading]="imageResource.isLoading()"
-    />
+    <app-image-model-badge [model]="imageResource.value()?.model" />
   </div>
 }

--- a/client/src/app/shared/image-grid/image-grid.component.ts
+++ b/client/src/app/shared/image-grid/image-grid.component.ts
@@ -8,7 +8,6 @@ export type GridImageValue = {
   url: string;
   model?: string;
   isFavorite?: boolean;
-  description?: string;
 };
 
 export type GridImageResource = {

--- a/client/src/app/shared/image-model-badge/image-model-badge.component.css
+++ b/client/src/app/shared/image-model-badge/image-model-badge.component.css
@@ -5,12 +5,3 @@
   color: rgba(255, 255, 255, 0.7);
   margin-top: 4px;
 }
-
-.generation-method {
-  font-style: italic;
-  opacity: 0.8;
-}
-
-.generation-method.has-tooltip {
-  cursor: help;
-}

--- a/client/src/app/shared/image-model-badge/image-model-badge.component.html
+++ b/client/src/app/shared/image-model-badge/image-model-badge.component.html
@@ -1,14 +1,3 @@
 @if (model()) {
-  <span class="model-name">
-    {{ model() }}
-    @if (!loading()) {
-      <span
-        class="generation-method"
-        [class.has-tooltip]="description()"
-        [matTooltip]="description() ?? ''"
-        [matTooltipDisabled]="!description()"
-        >{{ description() ? "described" : "direct" }}</span
-      >
-    }
-  </span>
+  <span class="model-name">{{ model() }}</span>
 }

--- a/client/src/app/shared/image-model-badge/image-model-badge.component.ts
+++ b/client/src/app/shared/image-model-badge/image-model-badge.component.ts
@@ -1,14 +1,10 @@
 import { Component, input } from '@angular/core';
-import { MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
   selector: 'app-image-model-badge',
-  imports: [MatTooltipModule],
   templateUrl: './image-model-badge.component.html',
   styleUrl: './image-model-badge.component.css',
 })
 export class ImageModelBadgeComponent {
   model = input<string>();
-  description = input<string>();
-  loading = input<boolean>(false);
 }

--- a/client/src/app/shared/image-resource.service.ts
+++ b/client/src/app/shared/image-resource.service.ts
@@ -41,17 +41,10 @@ export class ImageResourceService {
   } {
     const subtasks = this.imageModelSettingsService
       .imageModels()
-      .filter((m) => m.imageCount > 0 || m.describedImageCount > 0)
-      .flatMap((model) => [
-        ...Array.from({ length: model.imageCount }, () => ({
-          model,
-          describe: false,
-        })),
-        ...Array.from({ length: model.describedImageCount }, () => ({
-          model,
-          describe: true,
-        })),
-      ]);
+      .filter((m) => m.imageCount > 0)
+      .flatMap((model) =>
+        Array.from({ length: model.imageCount }, () => ({ model }))
+      );
 
     const pending = subtasks.map(({ model }) =>
       this.createPendingResource(model.displayName)
@@ -59,7 +52,7 @@ export class ImageResourceService {
 
     const { imagePool } = this.rateLimitTokenService;
     const done = Promise.all(
-      subtasks.map(({ model, describe }, idx) =>
+      subtasks.map(({ model }, idx) =>
         (async () => {
           await imagePool.acquire();
           try {
@@ -70,17 +63,15 @@ export class ImageResourceService {
                 body: {
                   input,
                   model: model.id,
-                  describe,
                   ...(context ? { context } : {}),
                 } satisfies ImageSourceRequest,
                 method: 'POST',
               }
             );
-            const { description } = await waitForImageReady(this.http, response.id);
+            await waitForImageReady(this.http, response.id);
             await pending[idx].resolve({
               id: response.id,
               model: response.model,
-              description,
             });
           } finally {
             imagePool.release();
@@ -107,7 +98,6 @@ export class ImageResourceService {
             id: v.id,
             model: v.model,
             isFavorite: v.isFavorite,
-            description: v.description,
           }) satisfies ExampleImage
       );
   }

--- a/client/src/app/shared/types/image-generation.types.ts
+++ b/client/src/app/shared/types/image-generation.types.ts
@@ -2,7 +2,6 @@ export interface ImageSourceRequest {
   input: string;
   model: string;
   context?: string;
-  describe: boolean;
 }
 
 export type ImageJobStatus = 'pending' | 'completed' | 'failed';
@@ -16,5 +15,4 @@ export interface ImageResponse {
 export interface ImageJobStatusResponse {
   status: ImageJobStatus;
   error?: string;
-  description?: string;
 }

--- a/client/src/app/utils/image-generation.util.ts
+++ b/client/src/app/utils/image-generation.util.ts
@@ -17,40 +17,28 @@ export const generateExampleImages = async (
   imageModels: ReadonlyArray<{
     id: string;
     imageCount: number;
-    describedImageCount: number;
   }>,
   inputs: ReadonlyArray<ImageGenerationInput>,
   imageTokenPool: ToolPool,
   onToolsRequested?: () => void
 ): Promise<ImagesByIndex> => {
-  const activeModels = imageModels.filter(
-    (model) => model.imageCount > 0 || model.describedImageCount > 0
-  );
+  const activeModels = imageModels.filter((model) => model.imageCount > 0);
   if (inputs.length === 0 || activeModels.length === 0) {
     onToolsRequested?.();
     return new Map();
   }
 
   const subtasks = inputs.flatMap((input) =>
-    activeModels.flatMap((model) => [
-      ...Array.from({ length: model.imageCount }, () => ({
-        input,
-        model,
-        describe: false,
-      })),
-      ...Array.from({ length: model.describedImageCount }, () => ({
-        input,
-        model,
-        describe: true,
-      })),
-    ])
+    activeModels.flatMap((model) =>
+      Array.from({ length: model.imageCount }, () => ({ input, model }))
+    )
   );
 
   const acquirePromises = subtasks.map(() => imageTokenPool.acquire());
   onToolsRequested?.();
 
   const results = await Promise.all(
-    subtasks.map(async ({ input, model, describe }, i) => {
+    subtasks.map(async ({ input, model }, i) => {
       await acquirePromises[i];
       try {
         const response = await fetchJson<ImageResponse>(
@@ -60,15 +48,14 @@ export const generateExampleImages = async (
             body: {
               input: input.input,
               model: model.id,
-              describe,
             } satisfies ImageSourceRequest,
             method: 'POST',
           }
         );
-        const { description } = await waitForImageReady(http, response.id);
+        await waitForImageReady(http, response.id);
         return {
           exampleIndex: input.exampleIndex,
-          image: { id: response.id, model: response.model, description } as ExampleImage,
+          image: { id: response.id, model: response.model } as ExampleImage,
         };
       } catch {
         return undefined;

--- a/client/src/app/utils/wait-for-image-ready.ts
+++ b/client/src/app/utils/wait-for-image-ready.ts
@@ -11,15 +11,15 @@ const delay = (ms: number): Promise<void> =>
 export const waitForImageReady = async (
   http: HttpClient,
   id: string
-): Promise<{ description?: string }> => {
-  const poll = async (attempt: number): Promise<{ description?: string }> => {
-    const { status, error, description } = await fetchJson<ImageJobStatusResponse>(
+): Promise<void> => {
+  const poll = async (attempt: number): Promise<void> => {
+    const { status, error } = await fetchJson<ImageJobStatusResponse>(
       http,
       `/api/image/${id}/status`
     );
 
     if (status === 'completed') {
-      return { description };
+      return;
     }
 
     if (status === 'failed') {

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ImageController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/ImageController.java
@@ -59,7 +59,7 @@ public class ImageController {
     imageGenerationJobService.createPending(id, displayName);
     try {
       asyncImageGenerationService.generate(
-          id, imageSource.getInput(), imageSource.getContext(), imageSource.getModel(), imageSource.isDescribe());
+          id, imageSource.getInput(), imageSource.getContext(), imageSource.getModel());
     } catch (TaskRejectedException e) {
       imageGenerationJobService.markFailed(id, "Image generation queue is full");
       throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
@@ -79,7 +79,6 @@ public class ImageController {
     return ImageJobStatusResponse.builder()
         .status(job.getStatus())
         .error(job.getError())
-        .description(job.getDescription())
         .build();
   }
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/entity/ImageGenerationJob.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/entity/ImageGenerationJob.java
@@ -36,9 +36,6 @@ public class ImageGenerationJob {
   @Column(columnDefinition = "text")
   private String error;
 
-  @Column(columnDefinition = "text")
-  private String description;
-
   @Column(name = "created_at", nullable = false)
   private Instant createdAt;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/entity/ImageModelSetting.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/entity/ImageModelSetting.java
@@ -28,7 +28,4 @@ public class ImageModelSetting {
 
     @Column(name = "image_count", nullable = false)
     private Integer imageCount;
-
-    @Column(name = "described_image_count", nullable = false)
-    private Integer describedImageCount;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/GeneratedImage.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/GeneratedImage.java
@@ -7,5 +7,4 @@ import lombok.Value;
 @Builder
 public class GeneratedImage {
   byte[] data;
-  String description;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageJobStatusResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageJobStatusResponse.java
@@ -13,7 +13,4 @@ public class ImageJobStatusResponse {
 
   @JsonInclude(Include.NON_NULL)
   private String error;
-
-  @JsonInclude(Include.NON_NULL)
-  private String description;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageModelResponse.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageModelResponse.java
@@ -13,5 +13,4 @@ public class ImageModelResponse {
     private String id;
     private String displayName;
     private int imageCount;
-    private int describedImageCount;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageModelSettingRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageModelSettingRequest.java
@@ -19,8 +19,4 @@ public class ImageModelSettingRequest {
     @NotNull
     @Min(0)
     private Integer imageCount;
-
-    @NotNull
-    @Min(0)
-    private Integer describedImageCount;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageSourceRequest.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageSourceRequest.java
@@ -20,6 +20,4 @@ public class ImageSourceRequest {
 
   @Size(max = 500)
   private String context;
-
-  private boolean describe;
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/repository/ImageGenerationJobRepository.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/repository/ImageGenerationJobRepository.java
@@ -16,12 +16,11 @@ import io.github.mucsi96.learnlanguage.model.ImageGenerationJobStatus;
 public interface ImageGenerationJobRepository extends JpaRepository<ImageGenerationJob, UUID> {
 
   @Modifying
-  @Query("UPDATE ImageGenerationJob j SET j.status = :status, j.error = :error, j.description = :description WHERE j.id = :id")
+  @Query("UPDATE ImageGenerationJob j SET j.status = :status, j.error = :error WHERE j.id = :id")
   void updateStatus(
       @Param("id") UUID id,
       @Param("status") ImageGenerationJobStatus status,
-      @Param("error") String error,
-      @Param("description") String description);
+      @Param("error") String error);
 
   int deleteByCreatedAtBefore(Instant cutoff);
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/AsyncImageGenerationService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/AsyncImageGenerationService.java
@@ -23,14 +23,14 @@ public class AsyncImageGenerationService {
   private final ImageGenerationJobService imageGenerationJobService;
 
   @Async("imageGenerationExecutor")
-  public void generate(UUID id, String input, String context, ImageGenerationModel model, boolean describe) {
+  public void generate(UUID id, String input, String context, ImageGenerationModel model) {
     try {
-      final GeneratedImage generatedImage = imageService.generateImage(input, context, model, describe);
+      final GeneratedImage generatedImage = imageService.generateImage(input, context, model);
       final String filePath = "images/%s.webp".formatted(id);
       ffmpegService.resizeImage(
           generatedImage.getData(), MAX_IMAGE_DIMENSION, MAX_IMAGE_DIMENSION,
           fileStorageService.resolveFilePath(filePath));
-      imageGenerationJobService.markCompleted(id, generatedImage.getDescription());
+      imageGenerationJobService.markCompleted(id);
     } catch (Exception e) {
       log.error("Image generation job {} failed", id, e);
       imageGenerationJobService.markFailed(id, "Image generation failed");

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/GoogleImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/GoogleImageService.java
@@ -20,7 +20,7 @@ public class GoogleImageService {
   private final Client googleAiClient;
   private final ModelUsageLoggingService usageLoggingService;
 
-  public byte[] generateGeminiImage(String input, String context, String modelName) {
+  public byte[] generateGeminiImage(String input, String modelName) {
     return generateWithUsageLogging(modelName, () -> {
       final GenerateContentConfig config = GenerateContentConfig.builder()
           .responseModalities("TEXT", "IMAGE")
@@ -30,7 +30,7 @@ public class GoogleImageService {
               .build())
           .build();
 
-      final String fullPrompt = ImagePromptBuilder.build(input, context);
+      final String fullPrompt = ImagePromptBuilder.build(input);
 
       return googleAiClient.models.generateContent(modelName, fullPrompt, config)
           .candidates().orElseThrow(() -> new RuntimeException("No candidates in Gemini response")).stream()

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageGenerationJobService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageGenerationJobService.java
@@ -36,13 +36,13 @@ public class ImageGenerationJobService {
   }
 
   @Transactional
-  public void markCompleted(UUID id, String description) {
-    imageGenerationJobRepository.updateStatus(id, ImageGenerationJobStatus.COMPLETED, null, description);
+  public void markCompleted(UUID id) {
+    imageGenerationJobRepository.updateStatus(id, ImageGenerationJobStatus.COMPLETED, null);
   }
 
   @Transactional
   public void markFailed(UUID id, String error) {
-    imageGenerationJobRepository.updateStatus(id, ImageGenerationJobStatus.FAILED, error, null);
+    imageGenerationJobRepository.updateStatus(id, ImageGenerationJobStatus.FAILED, error);
   }
 
   @Transactional(readOnly = true)

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageModelSettingService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageModelSettingService.java
@@ -35,7 +35,6 @@ public class ImageModelSettingService {
                             .id(model.getModelName())
                             .displayName(model.getDisplayName())
                             .imageCount(setting.map(ImageModelSetting::getImageCount).orElse(0))
-                            .describedImageCount(setting.map(ImageModelSetting::getDescribedImageCount).orElse(0))
                             .build();
                 })
                 .toList();
@@ -49,12 +48,10 @@ public class ImageModelSettingService {
                 .findByModelName(request.getModelName())
                 .map(existing -> existing.toBuilder()
                         .imageCount(request.getImageCount())
-                        .describedImageCount(request.getDescribedImageCount())
                         .build())
                 .orElseGet(() -> ImageModelSetting.builder()
                         .modelName(request.getModelName())
                         .imageCount(request.getImageCount())
-                        .describedImageCount(request.getDescribedImageCount())
                         .build());
 
         final ImageModelSetting saved = imageModelSettingRepository.save(setting);
@@ -63,7 +60,6 @@ public class ImageModelSettingService {
                 .id(saved.getModelName())
                 .displayName(model.getDisplayName())
                 .imageCount(saved.getImageCount())
-                .describedImageCount(saved.getDescribedImageCount())
                 .build();
     }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImagePromptBuilder.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImagePromptBuilder.java
@@ -4,11 +4,7 @@ final class ImagePromptBuilder {
   private ImagePromptBuilder() {
   }
 
-  static String build(String input, String context) {
-    final String contextSegment = context == null || context.isBlank()
-        ? ""
-        : " Additional context: " + context + ".";
-    return "Create a photorealistic image for the following context: " + input + "."
-        + contextSegment + " Avoid using text.";
+  static String build(String input) {
+    return "Create a photorealistic image for the following context: " + input + ". Avoid using text.";
   }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/ImageService.java
@@ -33,21 +33,18 @@ public class ImageService {
   private final ChatService chatService;
   private final ChatModelSettingService chatModelSettingService;
 
-  public GeneratedImage generateImage(String input, String context, ImageGenerationModel model, boolean describe) {
-    final String sceneDescription = describe ? describeScene(input, context) : null;
-    final String prompt = describe ? sceneDescription : input;
-    final String imageContext = describe ? null : context;
+  public GeneratedImage generateImage(String input, String context, ImageGenerationModel model) {
+    final String prompt = describeScene(input, context);
 
     final byte[] data = switch (model) {
       case GPT_IMAGE_1_5, GPT_IMAGE_2 ->
-        openAIImageService.generateImage(prompt, imageContext, model.getModelName());
+        openAIImageService.generateImage(prompt, model.getModelName());
       case GEMINI_3_PRO_IMAGE_PREVIEW ->
-        googleImageService.generateGeminiImage(prompt, imageContext, model.getModelName());
+        googleImageService.generateGeminiImage(prompt, model.getModelName());
     };
 
     return GeneratedImage.builder()
         .data(data)
-        .description(sceneDescription)
         .build();
   }
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/OpenAIImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/OpenAIImageService.java
@@ -19,11 +19,11 @@ public class OpenAIImageService {
     private final OpenAIClient openAIClient;
     private final ModelUsageLoggingService usageLoggingService;
 
-    public byte[] generateImage(String input, String context, String modelName) {
+    public byte[] generateImage(String input, String modelName) {
         final long startTime = System.currentTimeMillis();
         try {
             final ImageGenerateParams imageGenerateParams = ImageGenerateParams.builder()
-                .prompt(ImagePromptBuilder.build(input, context))
+                .prompt(ImagePromptBuilder.build(input))
                 .model(modelName)
                 .size(ImageGenerateParams.Size._1024X1024)
                 .quality(ImageGenerateParams.Quality.HIGH)

--- a/server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1066,3 +1066,17 @@ databaseChangeLog:
       changes:
         - dropTable:
             tableName: image_settings
+  - changeSet:
+      id: 35-drop-direct-image-generation
+      author: mucsi96
+      changes:
+        - dropColumn:
+            tableName: image_model_settings
+            columnName: image_count
+        - renameColumn:
+            tableName: image_model_settings
+            oldColumnName: described_image_count
+            newColumnName: image_count
+        - dropColumn:
+            tableName: image_generation_jobs
+            columnName: description

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -180,10 +180,6 @@ test('card editing in db', async ({ page }) => {
 
   await expect(page.getByText('GPT Image 1.5')).toHaveCount(1);
   await expect(page.getByText('Gemini 3 Pro')).toHaveCount(3);
-  await expect(page.getByText('direct', { exact: true })).toHaveCount(4);
-
-  await page.getByText('direct', { exact: true }).first().hover();
-  await expect(page.getByText('Detailed scene:')).toHaveCount(0);
 
   await page.evaluate(() => {
     window.scrollTo(0, document.body.scrollHeight);
@@ -228,8 +224,6 @@ test('card editing in db', async ({ page }) => {
     expect(cardData.examples[1].images[2].model).toBe('Gemini 3 Pro');
     expect(cardData.examples[1].images[3].model).toBe('Gemini 3 Pro');
     expect(cardData.examples[1].images[4].model).toBe('Gemini 3 Pro');
-    expect(cardData.examples[1].images[1].description).toBeUndefined();
-    expect(cardData.examples[1].images[2].description).toBeUndefined();
   });
 });
 
@@ -364,12 +358,11 @@ test('favorite toggle on newly generated image', async ({ page }) => {
   });
 });
 
-test('generates described image with Gemini model', async ({ page }) => {
+test('generates image with Gemini model', async ({ page }) => {
   await setupDefaultChatModelSettings();
   await createImageModelSetting({
     modelName: 'gemini-3-pro-image-preview',
-    imageCount: 0,
-    describedImageCount: 1,
+    imageCount: 1,
   });
   const image1 = uploadMockImage(blueImage);
   await createCard({
@@ -402,27 +395,12 @@ test('generates described image with Gemini model', async ({ page }) => {
   await expect(page.getByRole('img')).toHaveCount(2);
 
   await expect(page.getByText('Gemini 3 Pro')).toHaveCount(1);
-  await expect(page.getByText('described', { exact: true })).toHaveCount(1);
   await expect(page.getByText('Card updated successfully')).toBeVisible();
-
-  await page.getByText('described', { exact: true }).hover();
-  await expect(
-    page.getByText('Detailed scene: Wann fährt der Zug ab? A train platform with a large clock, no visible text.').first()
-  ).toBeVisible();
 
   const generatedImageContent = await getImageContent(
     page.getByRole('img', { name: 'Wann fährt der Zug ab?' }).nth(1)
   );
   expect(await getImageColor(page, generatedImageContent)).toBe('red');
-
-  await withDbConnection(async (client) => {
-    const result = await client.query(
-      "SELECT data FROM learn_language.cards WHERE id = 'abfahren-elindulni'"
-    );
-    const cardData = result.rows[0].data;
-    expect(cardData.examples[0].images[0].description).toBeUndefined();
-    expect(cardData.examples[0].images[1].description).toContain('Wann fährt der Zug ab?');
-  });
 
   const logs = await getModelUsageLogs();
   const descriptionLog = logs.find((log) => log.operationType === 'IMAGE_DESCRIPTION');
@@ -437,7 +415,7 @@ test('generates described image with Gemini model', async ({ page }) => {
   expect(generationLog!.modelName).toBe('gemini-3-pro-image-preview');
 });
 
-test('generates described image with OpenAI models', async ({ page }) => {
+test('generates image with OpenAI models', async ({ page }) => {
   await Promise.all(
     ['TRANSLATION', 'EXTRACTION', 'CLASSIFICATION', 'EXPLANATION', 'IMAGE_DESCRIPTION'].map((operationType) =>
       createChatModelSetting({
@@ -450,8 +428,7 @@ test('generates described image with OpenAI models', async ({ page }) => {
   );
   await createImageModelSetting({
     modelName: 'gpt-image-2',
-    imageCount: 0,
-    describedImageCount: 1,
+    imageCount: 1,
   });
   const image1 = uploadMockImage(blueImage);
   await createCard({
@@ -484,27 +461,12 @@ test('generates described image with OpenAI models', async ({ page }) => {
   await expect(page.getByRole('img')).toHaveCount(2);
 
   await expect(page.getByText('GPT Image 2')).toHaveCount(1);
-  await expect(page.getByText('described', { exact: true })).toHaveCount(1);
   await expect(page.getByText('Card updated successfully')).toBeVisible();
-
-  await page.getByText('described', { exact: true }).hover();
-  await expect(
-    page.getByText('Detailed scene: Wann fährt der Zug ab? A train platform with a large clock, no visible text.').first()
-  ).toBeVisible();
 
   const generatedImageContent = await getImageContent(
     page.getByRole('img', { name: 'Wann fährt der Zug ab?' }).nth(1)
   );
   expect(await getImageColor(page, generatedImageContent)).toBe('red');
-
-  await withDbConnection(async (client) => {
-    const result = await client.query(
-      "SELECT data FROM learn_language.cards WHERE id = 'abfahren-elindulni'"
-    );
-    const cardData = result.rows[0].data;
-    expect(cardData.examples[0].images[0].description).toBeUndefined();
-    expect(cardData.examples[0].images[1].description).toContain('Wann fährt der Zug ab?');
-  });
 
   const logs = await getModelUsageLogs();
   const descriptionLog = logs.find((log) => log.operationType === 'IMAGE_DESCRIPTION');
@@ -571,12 +533,11 @@ test('add image with context dialog', async ({ page }) => {
   await expect(page.getByRole('img')).toHaveCount(5);
 });
 
-test('described image uses context instead of German sentence', async ({ page }) => {
+test('image generation uses context instead of German sentence', async ({ page }) => {
   await setupDefaultChatModelSettings();
   await createImageModelSetting({
     modelName: 'gemini-3-pro-image-preview',
-    imageCount: 0,
-    describedImageCount: 1,
+    imageCount: 1,
   });
   const image1 = uploadMockImage(blueImage);
   await createCard({
@@ -615,17 +576,7 @@ test('described image uses context instead of German sentence', async ({ page })
   await expect(page.getByRole('dialog', { name: 'Image generation context' })).toBeHidden();
   await expect(page.getByRole('img')).toHaveCount(2);
 
-  await expect(page.getByText('described', { exact: true })).toHaveCount(1);
   await expect(page.getByText('Card updated successfully')).toBeVisible();
-
-  await withDbConnection(async (client) => {
-    const result = await client.query(
-      "SELECT data FROM learn_language.cards WHERE id = 'abfahren-elindulni'"
-    );
-    const cardData = result.rows[0].data;
-    expect(cardData.examples[0].images[1].description).toContain('A vintage steam train at sunset');
-    expect(cardData.examples[0].images[1].description).not.toContain('Wann fährt der Zug ab?');
-  });
 
   const logs = await getModelUsageLogs();
   const descriptionLog = logs.find((log) => log.operationType === 'IMAGE_DESCRIPTION');

--- a/test/tests/image-model-settings.spec.ts
+++ b/test/tests/image-model-settings.spec.ts
@@ -21,43 +21,35 @@ test('displays all image models with default image counts', async ({ page }) => 
   await expect(page.getByText('GPT Image 2')).toBeVisible();
   await expect(page.getByText('Imagen 4 Ultra')).toHaveCount(0);
 
-  const gptInput = page.getByRole('spinbutton', { name: 'Direct image count for GPT Image 1.5' });
-  const geminiInput = page.getByRole('spinbutton', { name: 'Direct image count for Gemini 3 Pro' });
-  const gptImage2Input = page.getByRole('spinbutton', { name: 'Direct image count for GPT Image 2' });
-  const gptDescribedInput = page.getByRole('spinbutton', { name: 'Described image count for GPT Image 1.5' });
-  const geminiDescribedInput = page.getByRole('spinbutton', { name: 'Described image count for Gemini 3 Pro' });
-  const gptImage2DescribedInput = page.getByRole('spinbutton', { name: 'Described image count for GPT Image 2' });
+  const gptInput = page.getByRole('spinbutton', { name: 'Image count for GPT Image 1.5' });
+  const geminiInput = page.getByRole('spinbutton', { name: 'Image count for Gemini 3 Pro' });
+  const gptImage2Input = page.getByRole('spinbutton', { name: 'Image count for GPT Image 2' });
 
   await expect(gptInput).toHaveValue('0');
   await expect(geminiInput).toHaveValue('0');
   await expect(gptImage2Input).toHaveValue('0');
-  await expect(gptDescribedInput).toHaveValue('0');
-  await expect(geminiDescribedInput).toHaveValue('0');
-  await expect(gptImage2DescribedInput).toHaveValue('0');
 });
 
 test('displays image counts from database settings', async ({ page }) => {
-  await createImageModelSetting({ modelName: 'gpt-image-1.5', imageCount: 2, describedImageCount: 1 });
+  await createImageModelSetting({ modelName: 'gpt-image-1.5', imageCount: 2 });
   await createImageModelSetting({ modelName: 'gemini-3-pro-image-preview', imageCount: 5 });
   await createImageModelSetting({ modelName: 'gpt-image-2', imageCount: 3 });
 
   await page.goto('/settings/image-models');
 
-  const gptInput = page.getByRole('spinbutton', { name: 'Direct image count for GPT Image 1.5' });
-  const geminiInput = page.getByRole('spinbutton', { name: 'Direct image count for Gemini 3 Pro' });
-  const gptImage2Input = page.getByRole('spinbutton', { name: 'Direct image count for GPT Image 2' });
-  const gptDescribedInput = page.getByRole('spinbutton', { name: 'Described image count for GPT Image 1.5' });
+  const gptInput = page.getByRole('spinbutton', { name: 'Image count for GPT Image 1.5' });
+  const geminiInput = page.getByRole('spinbutton', { name: 'Image count for Gemini 3 Pro' });
+  const gptImage2Input = page.getByRole('spinbutton', { name: 'Image count for GPT Image 2' });
 
   await expect(gptInput).toHaveValue('2');
   await expect(geminiInput).toHaveValue('5');
   await expect(gptImage2Input).toHaveValue('3');
-  await expect(gptDescribedInput).toHaveValue('1');
 });
 
-test('can update direct image count for a model', async ({ page }) => {
+test('can update image count for a model', async ({ page }) => {
   await page.goto('/settings/image-models');
 
-  const gptInput = page.getByRole('spinbutton', { name: 'Direct image count for GPT Image 1.5' });
+  const gptInput = page.getByRole('spinbutton', { name: 'Image count for GPT Image 1.5' });
   await gptInput.fill('4');
   await gptInput.dispatchEvent('change');
 
@@ -66,21 +58,6 @@ test('can update direct image count for a model', async ({ page }) => {
     const gptSetting = settings.find((s) => s.modelName === 'gpt-image-1.5');
     expect(gptSetting).toBeDefined();
     expect(gptSetting!.imageCount).toBe(4);
-  }).toPass();
-});
-
-test('can update described image count for a model', async ({ page }) => {
-  await page.goto('/settings/image-models');
-
-  const describedInput = page.getByRole('spinbutton', { name: 'Described image count for GPT Image 2' });
-  await describedInput.fill('2');
-  await describedInput.dispatchEvent('change');
-
-  await expect(async () => {
-    const settings = await getImageModelSettings();
-    const setting = settings.find((s) => s.modelName === 'gpt-image-2');
-    expect(setting).toBeDefined();
-    expect(setting!.describedImageCount).toBe(2);
   }).toPass();
 });
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -896,17 +896,16 @@ export async function getChatModelSettings(): Promise<
 export async function createImageModelSetting(params: {
   modelName: string;
   imageCount: number;
-  describedImageCount?: number;
 }): Promise<number> {
-  const { modelName, imageCount, describedImageCount = 0 } = params;
+  const { modelName, imageCount } = params;
 
   return await withDbConnection(async (client) => {
     const result = await client.query(
-      `INSERT INTO learn_language.image_model_settings (model_name, image_count, described_image_count)
-       VALUES ($1, $2, $3)
-       ON CONFLICT (model_name) DO UPDATE SET image_count = $2, described_image_count = $3
+      `INSERT INTO learn_language.image_model_settings (model_name, image_count)
+       VALUES ($1, $2)
+       ON CONFLICT (model_name) DO UPDATE SET image_count = $2
        RETURNING id`,
-      [modelName, imageCount, describedImageCount]
+      [modelName, imageCount]
     );
     return result.rows[0].id;
   });
@@ -932,13 +931,11 @@ export async function getImageModelSettings(): Promise<
     id: number;
     modelName: string;
     imageCount: number;
-    describedImageCount: number;
   }>
 > {
   return await withDbConnection(async (client) => {
     const result = await client.query(
-      `SELECT id, model_name as "modelName", image_count as "imageCount",
-              described_image_count as "describedImageCount"
+      `SELECT id, model_name as "modelName", image_count as "imageCount"
        FROM learn_language.image_model_settings
        ORDER BY id`
     );


### PR DESCRIPTION
## Summary

Production testing showed the description-based image generation method clearly outperforms the direct method, so this removes the **direct** strategy entirely along with all infrastructure that existed only to support it.

Every image is now generated via the described path: a chat model writes a scene description which is used as the image prompt. The description is still generated and used, but is no longer persisted, returned to the client, or shown anywhere.

### Changes
- **Remove the `describe` flag** throughout backend and frontend — `ImageService` always describes.
- **Stop storing the description** — dropped from `GeneratedImage`, `ImageGenerationJob`, the repository update, `ImageJobStatusResponse`, the status endpoint, and the per-image card data.
- **Remove the described/direct badge labels and the description tooltip** — the badge now shows only the model name.
- **Collapse image settings** from two counts (direct + described) to a single **images-per-card** count; the settings UI shows one "Images per card" column.
- **Simplify the image services and `ImagePromptBuilder`** — the image-level context param was always null once direct was gone (user context still feeds description generation).
- **Migration 35** — drops the old `image_count`, renames `described_image_count` → `image_count`, and drops `image_generation_jobs.description`.
- Tests updated accordingly (single count; label/tooltip/stored-description assertions removed; `IMAGE_DESCRIPTION` usage-log assertions kept).

The two image-add buttons (with / without context) are retained — both now feed the described path.

## Verification

- ✅ Client TypeScript type-checks (`tsc --noEmit`); the edited test specs type-check cleanly.
- ⚠️ Not runnable in the build sandbox: backend Maven compile (Azure SDK BOM blocked by network policy — 403), Angular build (`ng` requires Node ≥ 22.22.3; sandbox has 22.22.2), and the Playwright E2E suite (needs the running stack). Please run `./mvnw clean compile`, `npm run build`, and `npm test` with the stack up so Liquibase applies migration 35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoP9VZABFHPb1zs6aaKyyk)_