### PR TITLE
Track operation IDs for lesson description and card generation

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/config/OperationIdContext.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/config/OperationIdContext.java
@@ -1,7 +1,5 @@
 package io.github.mucsi96.learnlanguage.config;
 
-import java.util.UUID;
-
 public class OperationIdContext {
 
     private static final ThreadLocal<String> OPERATION_ID = new ThreadLocal<>();
@@ -19,9 +17,8 @@ public class OperationIdContext {
     }
 
     public static String subOperationId(String baseOperationId, String suffix) {
-        final String base = baseOperationId != null && !baseOperationId.isBlank()
-                ? baseOperationId
-                : UUID.randomUUID().toString();
-        return base + ":" + suffix;
+        return baseOperationId != null && !baseOperationId.isBlank()
+                ? baseOperationId + ":" + suffix
+                : null;
     }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/config/OperationIdContext.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/config/OperationIdContext.java
@@ -1,5 +1,7 @@
 package io.github.mucsi96.learnlanguage.config;
 
+import java.util.UUID;
+
 public class OperationIdContext {
 
     private static final ThreadLocal<String> OPERATION_ID = new ThreadLocal<>();
@@ -14,5 +16,12 @@ public class OperationIdContext {
 
     public static void clear() {
         OPERATION_ID.remove();
+    }
+
+    public static String subOperationId(String baseOperationId, String suffix) {
+        final String base = baseOperationId != null && !baseOperationId.isBlank()
+                ? baseOperationId
+                : UUID.randomUUID().toString();
+        return base + ":" + suffix;
     }
 }

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.server.ResponseStatusException;
 
+import io.github.mucsi96.learnlanguage.config.OperationIdContext;
 import io.github.mucsi96.learnlanguage.entity.Document;
 import io.github.mucsi96.learnlanguage.entity.ExtractionRegion;
 import io.github.mucsi96.learnlanguage.entity.LearningPartner;
@@ -622,9 +623,13 @@ public class SourceController {
     final List<PreparedPage> pages = photoPreprocessingService.prepare(
         photo.getImageData(), photo.getContentType());
 
+    final String baseOperationId = OperationIdContext.get();
+
+    OperationIdContext.set(OperationIdContext.subOperationId(baseOperationId, "lesson-description"));
     final LessonDescription lessonDescription = lessonDescriptionService.describe(
         pages, source.getLanguageLevel());
 
+    OperationIdContext.set(OperationIdContext.subOperationId(baseOperationId, "card-generation"));
     final List<SentenceWithHint> sentences = photoGrammarConceptService.generateConceptCards(
         lessonDescription,
         source.getLanguageLevel(),

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
@@ -625,19 +625,23 @@ public class SourceController {
 
     final String baseOperationId = OperationIdContext.get();
 
-    OperationIdContext.set(OperationIdContext.subOperationId(baseOperationId, "lesson-description"));
-    final LessonDescription lessonDescription = lessonDescriptionService.describe(
-        pages, source.getLanguageLevel());
+    try {
+      OperationIdContext.set(OperationIdContext.subOperationId(baseOperationId, "lesson-description"));
+      final LessonDescription lessonDescription = lessonDescriptionService.describe(
+          pages, source.getLanguageLevel());
 
-    OperationIdContext.set(OperationIdContext.subOperationId(baseOperationId, "card-generation"));
-    final List<SentenceWithHint> sentences = photoGrammarConceptService.generateConceptCards(
-        lessonDescription,
-        source.getLanguageLevel(),
-        cardCount);
+      OperationIdContext.set(OperationIdContext.subOperationId(baseOperationId, "card-generation"));
+      final List<SentenceWithHint> sentences = photoGrammarConceptService.generateConceptCards(
+          lessonDescription,
+          source.getLanguageLevel(),
+          cardCount);
 
-    pendingPhotoService.delete(photo);
+      pendingPhotoService.delete(photo);
 
-    return PhotoGrammarSentencesResponse.builder().sentences(sentences).build();
+      return PhotoGrammarSentencesResponse.builder().sentences(sentences).build();
+    } finally {
+      OperationIdContext.set(baseOperationId);
+    }
   }
 
   @PreAuthorize("hasAuthority('APPROLE_DeckCreator') and hasAuthority('SCOPE_createDeck')")

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/controller/SourceController.java
@@ -640,7 +640,11 @@ public class SourceController {
 
       return PhotoGrammarSentencesResponse.builder().sentences(sentences).build();
     } finally {
-      OperationIdContext.set(baseOperationId);
+      if (baseOperationId != null) {
+        OperationIdContext.set(baseOperationId);
+      } else {
+        OperationIdContext.clear();
+      }
     }
   }
 

--- a/test/tests/photo-grammar.spec.ts
+++ b/test/tests/photo-grammar.spec.ts
@@ -149,9 +149,11 @@ test('pending photo banner consumes photo and creates grammar cards', async ({ p
   const cardLog = usageLogs.find(
     (log) => log.operationType === 'CARD_GENERATION'
   );
-  expect(lessonLog?.operationId).toBeTruthy();
-  expect(cardLog?.operationId).toBeTruthy();
-  expect(lessonLog?.operationId).not.toBe(cardLog?.operationId);
+  expect(lessonLog).toBeDefined();
+  expect(cardLog).toBeDefined();
+  expect(lessonLog!.operationId).toMatch(/:lesson-description$/);
+  expect(cardLog!.operationId).toMatch(/:card-generation$/);
+  expect(lessonLog!.operationId).not.toBe(cardLog!.operationId);
 });
 
 test('discarding the pending photo banner removes the photo and no cards are created', async ({ page }) => {

--- a/test/tests/photo-grammar.spec.ts
+++ b/test/tests/photo-grammar.spec.ts
@@ -142,6 +142,16 @@ test('pending photo banner consumes photo and creates grammar cards', async ({ p
   const operationTypes = usageLogs.map((log) => log.operationType);
   expect(operationTypes).toContain('LESSON_DESCRIPTION');
   expect(operationTypes).toContain('CARD_GENERATION');
+
+  const lessonLog = usageLogs.find(
+    (log) => log.operationType === 'LESSON_DESCRIPTION'
+  );
+  const cardLog = usageLogs.find(
+    (log) => log.operationType === 'CARD_GENERATION'
+  );
+  expect(lessonLog?.operationId).toBeTruthy();
+  expect(cardLog?.operationId).toBeTruthy();
+  expect(lessonLog?.operationId).not.toBe(cardLog?.operationId);
 });
 
 test('discarding the pending photo banner removes the photo and no cards are created', async ({ page }) => {

--- a/test/tests/photo-grammar.spec.ts
+++ b/test/tests/photo-grammar.spec.ts
@@ -154,6 +154,10 @@ test('pending photo banner consumes photo and creates grammar cards', async ({ p
   expect(lessonLog!.operationId).toMatch(/:lesson-description$/);
   expect(cardLog!.operationId).toMatch(/:card-generation$/);
   expect(lessonLog!.operationId).not.toBe(cardLog!.operationId);
+
+  const lessonBase = lessonLog!.operationId!.replace(/:lesson-description$/, '');
+  const cardBase = cardLog!.operationId!.replace(/:card-generation$/, '');
+  expect(lessonBase).toBe(cardBase);
 });
 
 test('discarding the pending photo banner removes the photo and no cards are created', async ({ page }) => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -767,6 +767,7 @@ export async function getModelUsageLogs(): Promise<
     modelName: string;
     modelType: string;
     operationType: string;
+    operationId: string | null;
     inputTokens: number | null;
     outputTokens: number | null;
     rating: number | null;
@@ -776,7 +777,8 @@ export async function getModelUsageLogs(): Promise<
   return await withDbConnection(async (client) => {
     const result = await client.query(
       `SELECT id, model_name as "modelName", model_type as "modelType",
-              operation_type as "operationType", input_tokens as "inputTokens",
+              operation_type as "operationType", operation_id as "operationId",
+              input_tokens as "inputTokens",
               output_tokens as "outputTokens", rating,
               response_content as "responseContent"
        FROM learn_language.model_usage_logs


### PR DESCRIPTION
## Summary
This change implements operation ID tracking for sub-operations within the photo grammar consumption flow. Each major operation (lesson description and card generation) now gets a distinct operation ID derived from the parent operation, so the two AI calls are no longer grouped together on the model usage page while remaining traceable to their parent operation.

## Key Changes
- **OperationIdContext**: Added `subOperationId()` to derive a hierarchical operation ID from a base operation ID and a suffix (e.g. `base-id:lesson-description`)
- **SourceController**: `consumePendingPhoto()` sets a distinct operation ID for the lesson description and card generation sub-operations, restoring the original context afterward
- **Test utilities**: `getModelUsageLogs()` now returns the `operationId` field
- **Test coverage**: Asserts the two sub-operations have different operation IDs that share the same base prefix and expected suffixes

## Implementation Details
- Sub-operation IDs follow the format `{baseOperationId}:{suffix}` to maintain traceability
- If no base operation ID exists, `subOperationId()` returns `null` rather than fabricating one — `operationId` is optional infrastructure (the `X-Operation-ID` header is only set by `OperationIdFilter` when present, and the column is nullable), and null-operationId logs already render as separate (ungrouped) entries
- The operation ID is set in the ThreadLocal context before each sub-operation and restored in a `finally` block (clearing it when there was no base id)

https://claude.ai/code/session_0113yX4Lx9HcpNvzdyuaM1Y1