### PR TITLE
Change AI-generated cards default readiness from IN_REVIEW to READY

### DIFF
--- a/client/src/app/prompt-source.service.ts
+++ b/client/src/app/prompt-source.service.ts
@@ -64,7 +64,7 @@ export class PromptSourceService {
           ...(suggestion.topic ? { topic: suggestion.topic } : {}),
         },
         ...this.fsrsGradingService.convertFromFSRSCard(emptyCard),
-        readiness: 'IN_REVIEW',
+        readiness: 'READY',
       } satisfies CardCreatePayload;
 
       await fetchJson(this.http, `/api/card`, {

--- a/test/tests/ai-prompt-source.spec.ts
+++ b/test/tests/ai-prompt-source.spec.ts
@@ -83,7 +83,7 @@ test('create AI prompt source, generate, preview and create simple cards', async
       expect(row.data.frontText).toBeTruthy();
       expect(row.data.backText).toBeTruthy();
       expect(row.data.topic).toBe('Pods');
-      expect(row.readiness).toBe('IN_REVIEW');
+      expect(row.readiness).toBe('READY');
     }
   });
 


### PR DESCRIPTION
## Summary
Updated the default readiness status for AI-generated cards from `IN_REVIEW` to `READY`, allowing them to be immediately available for study without requiring manual review.

## Changes
- Modified `PromptSourceService` to set newly created AI-generated cards with `readiness: 'READY'` instead of `'IN_REVIEW'`
- Updated corresponding test expectations to verify the new default readiness status

## Details
This change streamlines the workflow for AI-generated cards by removing the intermediate review step. Cards created from AI prompt sources will now be ready for immediate use in the spaced repetition system.

https://claude.ai/code/session_01YUuULquxb2a8q5eTgp12gN