### PR TITLE
Add form management UI for vocabulary card editing

### DIFF
--- a/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.css
+++ b/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.css
@@ -18,11 +18,28 @@
   margin-bottom: 1rem;
 }
 
-.word,
-.forms {
+.word {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   column-gap: 1rem;
+}
+
+.forms {
+  display: grid;
+  justify-items: start;
+  gap: 0.5rem;
+}
+
+.form-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.form-row .field {
+  flex: 1;
+  margin-bottom: 0;
 }
 
 .example {

--- a/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.html
+++ b/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.html
@@ -67,10 +67,29 @@
 <h2>Forms</h2>
 <div class="forms">
   @for (form of forms(); track $index) {
-  <mat-form-field class="field">
-    <input matInput type="text" [(ngModel)]="form" aria-label="Form" />
-  </mat-form-field>
+  <div class="form-row">
+    <mat-form-field class="field">
+      <input matInput type="text" [(ngModel)]="form" aria-label="Form" />
+    </mat-form-field>
+    <button
+      mat-icon-button
+      (click)="removeForm($index)"
+      aria-label="Remove form"
+    >
+      <mat-icon>delete</mat-icon>
+    </button>
+    <button
+      mat-icon-button
+      (click)="insertFormAfter($index)"
+      aria-label="Insert form below"
+    >
+      <mat-icon>add</mat-icon>
+    </button>
+  </div>
   }
+  <button mat-stroked-button (click)="addForm()" aria-label="Add form">
+    <mat-icon>add</mat-icon> Add form
+  </button>
 </div>
 <h2>Examples</h2>
 <mat-radio-group [(ngModel)]="selectedExampleIndex">

--- a/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.ts
+++ b/client/src/app/parser/edit-card/edit-vocabulary-card/edit-vocabulary-card.component.ts
@@ -75,6 +75,22 @@ export class EditVocabularyCardComponent {
   readonly forms = linkedSignal(() =>
     this.card()?.data.forms?.map((form: string) => signal(form))
   );
+
+  addForm() {
+    this.forms.update((forms) => [...(forms ?? []), signal('')]);
+  }
+
+  insertFormAfter(index: number) {
+    this.forms.update((forms) => [
+      ...(forms ?? []).slice(0, index + 1),
+      signal(''),
+      ...(forms ?? []).slice(index + 1),
+    ]);
+  }
+
+  removeForm(index: number) {
+    this.forms.update((forms) => (forms ?? []).filter((_, i) => i !== index));
+  }
   readonly examples = linkedSignal(() =>
     this.card()?.data.examples?.map((example) => signal(example['de']))
   );

--- a/test/tests/edit-card-page.spec.ts
+++ b/test/tests/edit-card-page.spec.ts
@@ -123,6 +123,65 @@ test('card editing page', async ({ page }) => {
   expect(await getImageColor(page, imageContent2)).toBe('red');
 });
 
+test('forms list editing - add, insert and remove', async ({ page }) => {
+  await setupDefaultChatModelSettings();
+  await createCard({
+    cardId: 'abfahren-elindulni',
+    sourceId: 'goethe-a1',
+    sourcePageNumber: 9,
+    data: {
+      word: 'abfahren',
+      type: 'VERB',
+      forms: ['fährt ab', 'fuhr ab', 'abgefahren'],
+      translation: {
+        en: 'to leave',
+        hu: 'elindulni, elhagyni',
+        ch: 'abfahra, verlah',
+      },
+      examples: [
+        {
+          de: 'Wir fahren um zwölf Uhr ab.',
+          hu: 'Tizenkét órakor indulunk.',
+          en: "We leave at twelve o'clock.",
+          ch: 'Mir fahred am zwöufi ab.',
+          isSelected: true,
+        },
+      ],
+    },
+  });
+  await navigateToCardEditing(page);
+
+  const formInputs = page.getByLabel('Form', { exact: true });
+  await expect(formInputs).toHaveCount(3);
+
+  // Add a form at the end
+  await page.getByRole('button', { name: 'Add form' }).click();
+  await expect(formInputs).toHaveCount(4);
+  await formInputs.nth(3).fill('partizip');
+
+  // Insert a form between the first and second existing forms
+  await page.getByRole('button', { name: 'Insert form below' }).nth(0).click();
+  await expect(formInputs).toHaveCount(5);
+  await expect(formInputs.nth(0)).toHaveValue('fährt ab');
+  await expect(formInputs.nth(1)).toHaveValue('');
+  await expect(formInputs.nth(2)).toHaveValue('fuhr ab');
+  await formInputs.nth(1).fill('inserted');
+
+  // Remove the 'abgefahren' form (now at index 3)
+  await page.getByRole('button', { name: 'Remove form' }).nth(3).click();
+  await expect(formInputs).toHaveCount(4);
+
+  await page.getByRole('button', { name: 'Update' }).click();
+  await expect(page.getByText('Card updated successfully')).toBeVisible();
+
+  await withDbConnection(async (client) => {
+    const result = await client.query("SELECT data FROM learn_language.cards WHERE id = 'abfahren-elindulni'");
+    expect(result.rows.length).toBe(1);
+    const cardData = result.rows[0].data;
+    expect(cardData.forms).toEqual(['fährt ab', 'inserted', 'fuhr ab', 'partizip']);
+  });
+});
+
 test('card editing in db', async ({ page }) => {
   await setupDefaultChatModelSettings();
   await setupDefaultImageModelSettings();


### PR DESCRIPTION
## Summary
Added comprehensive form management functionality to the vocabulary card editing interface, allowing users to add, insert, and remove word forms with a more intuitive UI.

## Key Changes
- **Component Template**: Restructured forms section with individual action buttons for each form
  - Added "Remove form" button (delete icon) for each form entry
  - Added "Insert form below" button (add icon) for each form entry
  - Added "Add form" button at the end of the forms list
  
- **Component Logic**: Implemented three new methods in `EditVocabularyCardComponent`
  - `addForm()`: Appends a new empty form to the end of the list
  - `insertFormAfter(index)`: Inserts a new empty form after the specified index
  - `removeForm(index)`: Removes the form at the specified index

- **Styling**: Updated CSS layout for forms section
  - Changed forms container from 3-column grid to flexible layout with proper spacing
  - Added `.form-row` class for horizontal alignment of form input and action buttons
  - Adjusted margins and gaps for better visual hierarchy

- **Tests**: Added comprehensive test coverage for form management operations
  - Tests adding a form at the end
  - Tests inserting a form between existing forms
  - Tests removing a form
  - Verifies final form order persists correctly in the database

## Implementation Details
The forms are managed using Angular signals with a `linkedSignal` pattern, allowing reactive updates to the UI when the underlying form array changes. Each form action immediately updates the signal, triggering template re-renders and proper index tracking.

https://claude.ai/code/session_01Bn4JcKDYeMcutvVhu8MEje