### PR TITLE
Fix Ideogram API parameter name from prompt to text_prompt

### DIFF
--- a/mock_ideogram_server/src/index.ts
+++ b/mock_ideogram_server/src/index.ts
@@ -20,7 +20,11 @@ app.post('/reset', (req, res) => {
 
 app.post('/v1/:model/generate', upload.none(), (req, res) => {
   try {
-    const prompt: string = req.body.text_prompt ?? '';
+    const prompt: string | undefined = req.body.text_prompt;
+    if (!prompt) {
+      res.status(400).json({ error: 'Supply one of `text_prompt` or `json_prompt`.' });
+      return;
+    }
     const renderingSpeed: string = req.body.rendering_speed ?? 'DEFAULT';
     console.log('Received image generation request', { prompt, renderingSpeed });
 

--- a/mock_ideogram_server/src/index.ts
+++ b/mock_ideogram_server/src/index.ts
@@ -20,7 +20,7 @@ app.post('/reset', (req, res) => {
 
 app.post('/v1/:model/generate', upload.none(), (req, res) => {
   try {
-    const prompt: string = req.body.prompt ?? '';
+    const prompt: string = req.body.text_prompt ?? '';
     const renderingSpeed: string = req.body.rendering_speed ?? 'DEFAULT';
     console.log('Received image generation request', { prompt, renderingSpeed });
 

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/IdeogramImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/IdeogramImageService.java
@@ -37,7 +37,7 @@ public class IdeogramImageService {
         final long startTime = System.currentTimeMillis();
         try {
             final MultiValueMap<String, Object> form = new LinkedMultiValueMap<>();
-            form.add("prompt", ImagePromptBuilder.build(input));
+            form.add("text_prompt", ImagePromptBuilder.build(input));
             form.add("rendering_speed", toRenderingSpeed(model.getQuality()));
             form.add("aspect_ratio", "1x1");
             form.add("num_images", "1");


### PR DESCRIPTION
## Summary
Updated the Ideogram API integration to use the correct parameter name `text_prompt` instead of `prompt` for image generation requests.

## Changes
- **Mock server** (`mock_ideogram_server/src/index.ts`): Updated the request body parameter from `req.body.prompt` to `req.body.text_prompt`
- **Java service** (`IdeogramImageService.java`): Updated the form parameter from `"prompt"` to `"text_prompt"` when building the image generation request

## Details
The Ideogram API expects the image prompt to be passed as `text_prompt` in the request payload. This change aligns both the mock server and the actual service implementation with the correct API specification, ensuring proper parameter handling for image generation requests.

https://claude.ai/code/session_01WMMJXuydnRguynfQEa1J9N