### PR TITLE
Fix stretched Ideogram images: generate exact 1024x1024 square

### DIFF
--- a/mock_ideogram_server/src/index.ts
+++ b/mock_ideogram_server/src/index.ts
@@ -26,7 +26,8 @@ app.post('/v1/:model/generate', upload.none(), (req, res) => {
       return;
     }
     const renderingSpeed: string = req.body.rendering_speed ?? 'DEFAULT';
-    console.log('Received image generation request', { prompt, renderingSpeed });
+    const resolution: string = req.body.resolution ?? '1024x1024';
+    console.log('Received image generation request', { prompt, renderingSpeed, resolution });
 
     const color = imageHandler.resolveColor(prompt);
     const url = `${req.protocol}://${req.get('host')}/images/${color}.png`;
@@ -37,7 +38,7 @@ app.post('/v1/:model/generate', upload.none(), (req, res) => {
         {
           url,
           prompt,
-          resolution: '1024x1024',
+          resolution,
           is_image_safe: true,
           seed: 0,
           style_type: 'GENERAL',

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/IdeogramImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/IdeogramImageService.java
@@ -39,7 +39,7 @@ public class IdeogramImageService {
             final MultiValueMap<String, Object> form = new LinkedMultiValueMap<>();
             form.add("text_prompt", ImagePromptBuilder.build(input));
             form.add("rendering_speed", toRenderingSpeed(model.getQuality()));
-            form.add("aspect_ratio", "1x1");
+            form.add("resolution", "1024x1024");
             form.add("num_images", "1");
 
             final IdeogramResponse response = ideogramRestClient.post()


### PR DESCRIPTION
## Summary
Ideogram images were rendering stretched (non-square) because the Java service passed `aspect_ratio: 1x1`, which lets the Ideogram API choose its own output resolution rather than guaranteeing a square 1024x1024. This switches to an explicit `resolution` parameter so Ideogram produces exact 1024x1024 1:1 images, matching the other models (e.g. OpenAI's `1024x1024`).

## Changes
- **Java service** (`IdeogramImageService`): Send `resolution: 1024x1024` instead of `aspect_ratio: 1x1` so the output is an exact square at the same resolution as the other image models.
- **Mock server**: Read the `resolution` form field from the request (defaulting to `1024x1024`) and echo it in the response and request log, keeping the mock faithful to the real request shape.

## Notes
- The resolution is currently fixed at `1024x1024` (not user-configurable); this matches the fixed sizes used by the other image models.

https://claude.ai/code/session_01BWf8WfuX2ne8U8HHg8SdVW