### PR TITLE
Add configurable image resolution for Ideogram models

### DIFF
--- a/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationModel.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/model/ImageGenerationModel.java
@@ -11,13 +11,13 @@ import lombok.RequiredArgsConstructor;
 //          https://ai.google.dev/gemini-api/docs/pricing
 @RequiredArgsConstructor
 public enum ImageGenerationModel {
-    GPT_IMAGE_2_LOW("gpt-image-2-low", "gpt-image-2", "GPT Image 2 (Low)", ImageQuality.LOW),
-    GPT_IMAGE_2_MEDIUM("gpt-image-2-medium", "gpt-image-2", "GPT Image 2 (Medium)", ImageQuality.MEDIUM),
-    GPT_IMAGE_2_HIGH("gpt-image-2-high", "gpt-image-2", "GPT Image 2 (High)", ImageQuality.HIGH),
-    IDEOGRAM_4_TURBO("ideogram-4-turbo", "ideogram-v4", "Ideogram 4 (Turbo)", ImageQuality.LOW),
-    IDEOGRAM_4_DEFAULT("ideogram-4-default", "ideogram-v4", "Ideogram 4 (Default)", ImageQuality.MEDIUM),
-    IDEOGRAM_4_QUALITY("ideogram-4-quality", "ideogram-v4", "Ideogram 4 (Quality)", ImageQuality.HIGH),
-    GEMINI_3_PRO_IMAGE_PREVIEW("gemini-3-pro-image-preview", "gemini-3-pro-image-preview", "Gemini 3 Pro", null);
+    GPT_IMAGE_2_LOW("gpt-image-2-low", "gpt-image-2", "GPT Image 2 (Low)", ImageQuality.LOW, null),
+    GPT_IMAGE_2_MEDIUM("gpt-image-2-medium", "gpt-image-2", "GPT Image 2 (Medium)", ImageQuality.MEDIUM, null),
+    GPT_IMAGE_2_HIGH("gpt-image-2-high", "gpt-image-2", "GPT Image 2 (High)", ImageQuality.HIGH, null),
+    IDEOGRAM_4_TURBO("ideogram-4-turbo", "ideogram-v4", "Ideogram 4 (Turbo)", ImageQuality.LOW, "2048x2048"),
+    IDEOGRAM_4_DEFAULT("ideogram-4-default", "ideogram-v4", "Ideogram 4 (Default)", ImageQuality.MEDIUM, "2048x2048"),
+    IDEOGRAM_4_QUALITY("ideogram-4-quality", "ideogram-v4", "Ideogram 4 (Quality)", ImageQuality.HIGH, "2048x2048"),
+    GEMINI_3_PRO_IMAGE_PREVIEW("gemini-3-pro-image-preview", "gemini-3-pro-image-preview", "Gemini 3 Pro", null, null);
 
     public enum ImageQuality {
         LOW, MEDIUM, HIGH
@@ -27,6 +27,7 @@ public enum ImageGenerationModel {
     private final String apiModelName;
     private final String displayName;
     private final ImageQuality quality;
+    private final String resolution;
 
     @JsonValue
     public String getModelName() {
@@ -43,6 +44,10 @@ public enum ImageGenerationModel {
 
     public ImageQuality getQuality() {
         return quality;
+    }
+
+    public String getResolution() {
+        return resolution;
     }
 
     @JsonCreator

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/IdeogramImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/IdeogramImageService.java
@@ -39,7 +39,7 @@ public class IdeogramImageService {
             final MultiValueMap<String, Object> form = new LinkedMultiValueMap<>();
             form.add("text_prompt", ImagePromptBuilder.build(input));
             form.add("rendering_speed", toRenderingSpeed(model.getQuality()));
-            form.add("resolution", "2048x2048");
+            form.add("resolution", model.getResolution());
             form.add("num_images", "1");
 
             final IdeogramResponse response = ideogramRestClient.post()

--- a/server/src/main/java/io/github/mucsi96/learnlanguage/service/IdeogramImageService.java
+++ b/server/src/main/java/io/github/mucsi96/learnlanguage/service/IdeogramImageService.java
@@ -39,7 +39,7 @@ public class IdeogramImageService {
             final MultiValueMap<String, Object> form = new LinkedMultiValueMap<>();
             form.add("text_prompt", ImagePromptBuilder.build(input));
             form.add("rendering_speed", toRenderingSpeed(model.getQuality()));
-            form.add("resolution", "1024x1024");
+            form.add("resolution", "2048x2048");
             form.add("num_images", "1");
 
             final IdeogramResponse response = ideogramRestClient.post()


### PR DESCRIPTION
## Summary
This change adds support for configurable image resolution across different image generation models by introducing a new `resolution` field to the `ImageGenerationModel` enum.

## Key Changes
- Added `resolution` field to `ImageGenerationModel` enum to store model-specific resolution values
- Set resolution to `null` for GPT Image 2 models (no resolution constraint)
- Set resolution to `"2048x2048"` for all Ideogram 4 variants (Turbo, Default, Quality)
- Set resolution to `null` for Gemini 3 Pro Image Preview
- Added `getResolution()` getter method to `ImageGenerationModel`
- Updated `IdeogramImageService` to use `model.getResolution()` instead of hardcoded `"1024x1024"` value

## Implementation Details
The resolution is now model-specific rather than hardcoded, allowing different image generation providers to specify their optimal or supported resolutions. This provides better flexibility for future model additions and maintains consistency with the existing quality-based configuration pattern.

https://claude.ai/code/session_01VVoU3tcGE9xwM3BFHspiEz